### PR TITLE
🧹 Remove unused import MaterialButton in MyPlanetLite.kt

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -43,7 +43,6 @@ import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.lifecycle.lifecycleScope
 
 import com.blongho.country_data.World
-import com.google.android.material.button.MaterialButton
 import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputEditText


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unused import of `MaterialButton` in `MyPlanetLite.kt`.
💡 **Why:** Removing unused imports improves code maintainability, readability, and overall hygiene by reducing clutter.
✅ **Verification:** The change was confirmed by verifying the absence of the import using `grep`. Build and test runs were attempted but timed out in the environment; however, this is a safe, no-op change.
✨ **Result:** Cleaned up the import block in `MyPlanetLite.kt`.

---
*PR created automatically by Jules for task [13842803254176245883](https://jules.google.com/task/13842803254176245883) started by @dogi*