### PR TITLE
Remove all Log calls from source and configure ProGuard to strip them in release builds.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,12 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+    public static *** wtf(...);
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -6,8 +6,6 @@
 
 package org.ole.planet.myplanet.lite.dashboard
 
-import android.util.Log
-
 import org.ole.planet.myplanet.lite.BuildConfig
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
@@ -30,10 +28,6 @@ import java.io.IOException
 import java.util.ArrayList
 
 class DashboardCoursesRepository {
-    companion object {
-        private const val TAG = "DashboardCoursesRepo"
-    }
-
     private val client: OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(
             HttpLoggingInterceptor().apply {
@@ -134,22 +128,13 @@ class DashboardCoursesRepository {
                             }.getOrNull()
                             if (reason == "missing") {
                                 val fallbackId = "org.couchdb.user:${credentials.username}"
-                                if (BuildConfig.DEBUG) {
-                                    Log.d(TAG, "fetchShelfDocument missing for $requestUrl, creating fallback shelf.")
-                                }
                                 return@runCatching ShelfDocument(
                                     id = fallbackId,
                                     rev = null
                                 )
                             }
                         }
-                        if (BuildConfig.DEBUG) {
-                            Log.d(TAG, "fetchShelfDocument error ${response.code} for $requestUrl")
-                        }
                         throw IOException("Unexpected response ${response.code}")
-                    }
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "fetchShelfDocument success for $requestUrl")
                     }
                     val document = shelfDocumentAdapter.fromJson(response.body.string())
                         ?: throw IOException("Invalid shelf response")
@@ -202,12 +187,6 @@ class DashboardCoursesRepository {
 
                     client.newCall(request).execute().use { response ->
                         val responseBody = response.body.string()
-                        if (BuildConfig.DEBUG) {
-                            Log.d(
-                                TAG,
-                                "joinCourse update shelf $requestUrl responseCode=${response.code}"
-                            )
-                        }
                         if (response.isSuccessful) {
                             val updatedRev = runCatching {
                                 org.json.JSONObject(responseBody).optString("rev").takeIf { it.isNotBlank() }


### PR DESCRIPTION
- Removed manual Log.d calls and related TAG constant from DashboardCoursesRepository.kt.
- Added '-assumenosideeffects' ProGuard rule to strip all android.util.Log calls.
- Enabled isMinifyEnabled for the release build type in app/build.gradle.kts.
- Verified that no other Log. calls remain in the source code.

Co-authored-by: PlataformasInformaticas <9954269+PlataformasInformaticas@users.noreply.github.com>
