### PR TITLE
Cleanup unused string resources across all localizations

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -518,7 +518,6 @@
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
     <string name="dashboard_share_post_chooser_title">مشاركة الصوت</string>
     <string name="dashboard_share_post_fallback">تمت المشاركة من MyPlanetLite</string>
-    <string name="share_post">مشاركة المنشور</string>
     <string name="dashboard_relative_time_seconds">منذ بضع ثوانٍ</string>
     <string name="dashboard_relative_time_minute">منذ دقيقة واحدة</string>
     <string name="dashboard_relative_time_minutes">منذ %1$d دقيقة</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -535,7 +535,6 @@ Si no está de acuerdo, debe seleccionar "Cancelar" y dejar de usar la aplicaci�
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
     <string name="dashboard_share_post_chooser_title">Compartir voz</string>
     <string name="dashboard_share_post_fallback">Compartido desde MyPlanetLite</string>
-    <string name="share_post">Compartir publicación</string>
     <string name="dashboard_relative_time_seconds">hace unos segundos</string>
     <string name="dashboard_relative_time_minute">hace 1 minuto</string>
     <string name="dashboard_relative_time_minutes">hace %1$d minutos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -514,7 +514,6 @@ Si vous n\'êtes pas d\'accord, vous devez sélectionner « Annuler » et cess
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
     <string name="dashboard_share_post_chooser_title">Partager la voix</string>
     <string name="dashboard_share_post_fallback">Partagé depuis MyPlanetLite</string>
-    <string name="share_post">Partager la publication</string>
     <string name="dashboard_relative_time_seconds">il y a quelques secondes</string>
     <string name="dashboard_relative_time_minute">il y a 1 minute</string>
     <string name="dashboard_relative_time_minutes">il y a %1$d minutes</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -554,7 +554,6 @@ Applications: Planet, myPlanet, और myPlanetLite</string>
     <string name="dashboard_post_delete_error">इस आवाज़ को हटाने में असमर्थ। कृपया पुनः प्रयास करें।</string>
     <string name="dashboard_share_post_title">आवाज़ - Planet - %1$s</string>
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
-    <string name="share_post">पोस्ट साझा करें</string>
     <string name="dashboard_share_post_chooser_title">आवाज़ साझा करें</string>
     <string name="dashboard_share_post_fallback">MyPlanetLite से साझा किया गया</string>
     <string name="dashboard_relative_time_seconds">कुछ सेकंड पहले</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -477,7 +477,6 @@
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
     <string name="dashboard_share_post_chooser_title">भ्वाइस साझा गर्नुहोस्</string>
     <string name="dashboard_share_post_fallback">MyPlanetLite बाट साझेदारी गरिएको</string>
-    <string name="share_post">पोस्ट सेयर गर्नुहोस्</string>
     <string name="dashboard_relative_time_seconds">केही सेकेन्ड अघि</string>
     <string name="dashboard_relative_time_minute">१ मिनेट अघि</string>
     <string name="dashboard_relative_time_minutes">%1$d मिनेट अघि</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -566,7 +566,6 @@ Se você não concordar, deve selecionar "Cancelar" e parar de usar o aplicativo
     <string name="dashboard_post_delete_error">Não foi possível excluir esta voz. Tente novamente.</string>
     <string name="dashboard_share_post_title">Voz - Planet - %1$s</string>
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
-    <string name="share_post">Compartilhar post</string>
     <string name="dashboard_share_post_chooser_title">Compartilhar voz</string>
     <string name="dashboard_share_post_fallback">Compartilhado do MyPlanetLite</string>
     <string name="dashboard_relative_time_seconds">há alguns segundos</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -477,7 +477,6 @@ Haddii aadan oggolayn, waa inaad doorataa "Jooji" oo aad joojisaa isticmaalka ba
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
     <string name="dashboard_share_post_chooser_title">La wadaag codka</string>
     <string name="dashboard_share_post_fallback">Lagaga wadaagay MyPlanetLite</string>
-    <string name="share_post">La wadaag qoraalka</string>
     <string name="dashboard_relative_time_seconds">dhowr ilbiriqsi kahor</string>
     <string name="dashboard_relative_time_minute">hal daqiiqo kahor</string>
     <string name="dashboard_relative_time_minutes">%1$d daqiiqo kahor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,7 +566,6 @@ If you do not agree, you must select "Cancel" and stop using the application.</s
     <string name="dashboard_post_delete_error">Unable to delete this voice. Please try again.</string>
     <string name="dashboard_share_post_title">Voice - Planet - %1$s</string>
     <string name="dashboard_share_post_server_fallback">MyPlanetLite</string>
-    <string name="share_post">Share post</string>
     <string name="dashboard_share_post_chooser_title">Share voice</string>
     <string name="dashboard_share_post_fallback">Shared from MyPlanetLite</string>
     <string name="dashboard_relative_time_seconds">a few seconds ago</string>


### PR DESCRIPTION
This PR identifies and removes unused string resources from the project. Specifically, the `share_post` string, which was present in the base `strings.xml` and its various translations (Arabic, Spanish, French, Hindi, Nepali, Portuguese, and Somali), was found to have no active references in the codebase. All other strings were confirmed to be in use. The build and unit tests were successfully executed to ensure no regressions were introduced. Additionally, all temporary scripts and logs used during the identification process have been removed to keep the repository clean.

---
*PR created automatically by Jules for task [3581759680464657186](https://jules.google.com/task/3581759680464657186) started by @PlataformasInformaticas*