### PR TITLE
Replace deprecated bundleOf with platform Bundle class

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -15,7 +15,6 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -428,7 +427,9 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
                 }
                 requireActivity().supportFragmentManager.setFragmentResult(
                     RESULT_JOINED_COURSE,
-                    bundleOf(KEY_JOINED_COURSE_ID to course.id)
+                    Bundle().apply {
+                        putString(KEY_JOINED_COURSE_ID, course.id)
+                    }
                 )
             }
 
@@ -467,10 +468,10 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
                 }
                 requireActivity().supportFragmentManager.setFragmentResult(
                     RESULT_JOINED_COURSE,
-                    bundleOf(
-                        KEY_JOINED_COURSE_ID to course.id,
-                        KEY_LEFT_COURSE to true
-                    )
+                    Bundle().apply {
+                        putString(KEY_JOINED_COURSE_ID, course.id)
+                        putBoolean(KEY_LEFT_COURSE, true)
+                    }
                 )
             }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -22,7 +22,6 @@ import android.widget.Toast
 
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.AppCompatImageView
-import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -921,10 +920,10 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
 
         fun newInstanceForTeam(teamId: String, teamName: String): DashboardVoicesFragment {
             return DashboardVoicesFragment().apply {
-                arguments = bundleOf(
-                    ARG_TEAM_ID to teamId,
-                    ARG_TEAM_NAME to teamName
-                )
+                arguments = Bundle().apply {
+                    putString(ARG_TEAM_ID, teamId)
+                    putString(ARG_TEAM_NAME, teamName)
+                }
             }
         }
     }


### PR DESCRIPTION
The `bundleOf` utility from `androidx.core.os` is deprecated because it does not provide type safety at compile time. This PR refactors the usage of `bundleOf` in `DashboardCoursePageFragment.kt` and `DashboardVoicesFragment.kt` to use the standard platform `Bundle` class directly, using an `apply` block with explicit type-specific setter methods (e.g., `putString`, `putBoolean`). This resolves the related compiler warnings during build.

---
*PR created automatically by Jules for task [16740470048867740107](https://jules.google.com/task/16740470048867740107) started by @PlataformasInformaticas*