### PR TITLE
⚡ Optimize redundant column index lookups in Cursor loop

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
@@ -89,18 +89,26 @@ class DashboardSurveyOutboxStore(
             null,
             "$COLUMN_CREATED_AT DESC",
         ).use { cursor ->
+            val idIdx = cursor.getColumnIndexOrThrow(COLUMN_ID)
+            val surveyIdIdx = cursor.getColumnIndexOrThrow(COLUMN_SURVEY_ID)
+            val teamIdIdx = cursor.getColumnIndexOrThrow(COLUMN_TEAM_ID)
+            val teamNameIdx = cursor.getColumnIndexOrThrow(COLUMN_TEAM_NAME)
+            val surveyNameIdx = cursor.getColumnIndexOrThrow(COLUMN_SURVEY_NAME)
+            val createdAtIdx = cursor.getColumnIndexOrThrow(COLUMN_CREATED_AT)
+            val payloadIdx = cursor.getColumnIndexOrThrow(COLUMN_PAYLOAD)
+
             buildList {
                 while (cursor.moveToNext()) {
-                    val payload = cursor.getStringOrNull(COLUMN_PAYLOAD) ?: continue
+                    val payload = cursor.getStringOrNull(payloadIdx) ?: continue
                     val parsed = runCatching { submissionAdapter.fromJson(payload) }.getOrNull() ?: continue
                     add(
                         OutboxEntry(
-                            id = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_ID)),
-                            surveyId = cursor.getStringOrNull(COLUMN_SURVEY_ID),
-                            teamId = cursor.getStringOrNull(COLUMN_TEAM_ID),
-                            teamName = cursor.getStringOrNull(COLUMN_TEAM_NAME),
-                            surveyName = cursor.getStringOrNull(COLUMN_SURVEY_NAME),
-                            createdAt = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_CREATED_AT)),
+                            id = cursor.getLong(idIdx),
+                            surveyId = cursor.getStringOrNull(surveyIdIdx),
+                            teamId = cursor.getStringOrNull(teamIdIdx),
+                            teamName = cursor.getStringOrNull(teamNameIdx),
+                            surveyName = cursor.getStringOrNull(surveyNameIdx),
+                            createdAt = cursor.getLong(createdAtIdx),
                             submission = parsed,
                         ),
                     )
@@ -128,16 +136,24 @@ class DashboardSurveyOutboxStore(
             null,
             "1",
         ).use { cursor ->
+            val idIdx = cursor.getColumnIndexOrThrow(COLUMN_ID)
+            val surveyIdIdx = cursor.getColumnIndexOrThrow(COLUMN_SURVEY_ID)
+            val teamIdIdx = cursor.getColumnIndexOrThrow(COLUMN_TEAM_ID)
+            val teamNameIdx = cursor.getColumnIndexOrThrow(COLUMN_TEAM_NAME)
+            val surveyNameIdx = cursor.getColumnIndexOrThrow(COLUMN_SURVEY_NAME)
+            val createdAtIdx = cursor.getColumnIndexOrThrow(COLUMN_CREATED_AT)
+            val payloadIdx = cursor.getColumnIndexOrThrow(COLUMN_PAYLOAD)
+
             if (cursor.moveToFirst()) {
-                val payload = cursor.getStringOrNull(COLUMN_PAYLOAD) ?: return@use null
+                val payload = cursor.getStringOrNull(payloadIdx) ?: return@use null
                 val parsed = runCatching { submissionAdapter.fromJson(payload) }.getOrNull() ?: return@use null
                 OutboxEntry(
-                    id = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_ID)),
-                    surveyId = cursor.getStringOrNull(COLUMN_SURVEY_ID),
-                    teamId = cursor.getStringOrNull(COLUMN_TEAM_ID),
-                    teamName = cursor.getStringOrNull(COLUMN_TEAM_NAME),
-                    surveyName = cursor.getStringOrNull(COLUMN_SURVEY_NAME),
-                    createdAt = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_CREATED_AT)),
+                    id = cursor.getLong(idIdx),
+                    surveyId = cursor.getStringOrNull(surveyIdIdx),
+                    teamId = cursor.getStringOrNull(teamIdIdx),
+                    teamName = cursor.getStringOrNull(teamNameIdx),
+                    surveyName = cursor.getStringOrNull(surveyNameIdx),
+                    createdAt = cursor.getLong(createdAtIdx),
                     submission = parsed,
                 )
             } else {
@@ -161,7 +177,10 @@ class DashboardSurveyOutboxStore(
     )
 
     private fun Cursor.getStringOrNull(columnName: String): String? {
-        val index = getColumnIndexOrThrow(columnName)
+        return getStringOrNull(getColumnIndexOrThrow(columnName))
+    }
+
+    private fun Cursor.getStringOrNull(index: Int): String? {
         return if (isNull(index)) null else getString(index)
     }
 


### PR DESCRIPTION
This pull request implements a performance optimization in `DashboardSurveyOutboxStore.kt` by caching database column indices before iterating through `Cursor` results.

### 💡 What
The optimization involves calling `getColumnIndexOrThrow` once for each required column before entering the `while (cursor.moveToNext())` loop in `getPendingForTeam`. These cached indices are then used for all data retrieval within the loop. Similar caching was applied to `getEntry` for consistency.

Additionally, a `Cursor.getStringOrNull(index: Int)` extension function was added to facilitate safe retrieval of nullable strings using indices.

### 🎯 Why
Repeatedly calling `getColumnIndexOrThrow` with a string column name inside a loop is inefficient as it performs a map-like lookup for every row and every column. Caching these indices reduces CPU overhead during data retrieval from the local SQLite database.

### 📊 Measured Improvement
Direct benchmarking in the current environment was impractical due to network and execution timeouts preventing large-scale test runs. However, caching column indices is a documented Android performance best practice (especially for larger result sets) and eliminates redundant O(N) or O(log N) lookups per column per row, where N is the number of columns in the cursor.


---
*PR created automatically by Jules for task [414141238641252925](https://jules.google.com/task/414141238641252925) started by @dogi*