### PR TITLE
⚡ Optimize `prepareReplyImagesForPosting` to upload images concurrently

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -71,6 +71,9 @@ import kotlin.math.max
 import kotlin.math.min
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -1051,13 +1054,21 @@ class DashboardPostDetailActivity : AppCompatActivity() {
             return PreparedVoicePost(originalMessage, emptyList())
         }
         val context = buildReplyImageResourceContext(credentials)
+
+        val uploads = pendingReplyImages.values.filter { it.resourceId == null }
+        val uploadResults = coroutineScope {
+            uploads.map { pending ->
+                async {
+                    val markdown = ensureReplyImageUpload(baseUrl, credentials, context, pending)
+                    pending to markdown
+                }
+            }.awaitAll()
+        }
+
         var updatedMessage = originalMessage
         val preparedImages = mutableListOf<VoicesComposerRepository.ImagePayload>()
-        for (pending in pendingReplyImages.values) {
-            if (pending.resourceId != null) {
-                continue
-            }
-            val markdown = ensureReplyImageUpload(baseUrl, credentials, context, pending)
+
+        for ((pending, markdown) in uploadResults) {
             val replaced = replaceImagePlaceholder(updatedMessage, pending.fileName, markdown)
             updatedMessage = ensureMarkdownPresent(replaced, markdown)
             val resourceId = pending.resourceId


### PR DESCRIPTION
💡 **What:** The optimization refactored `prepareReplyImagesForPosting` to process the `pendingReplyImages` list concurrently using `coroutineScope`, `async`, and `awaitAll()` instead of sequential suspend functions in a `for` loop.

🎯 **Why:** The previous implementation performed a synchronous, sequential HTTP upload request for each pending image inside a for-loop. This caused delays that scaled linearly with the number of images O(N). By changing it to upload concurrently, we reduce the total processing time to the duration of the slowest upload O(1) (bounded by concurrent connection limits). It also makes sure to cleanly split off the asynchronous operations from the sequential string replacements, so that thread-safety is fully maintained.

📊 **Measured Improvement:** While formal benchmarking within an Android context isn't directly reproducible in the execution sandbox (due to emulator overhead and mock limitations), functionally parallelizing I/O-bound independent suspend operations guarantees transitioning the total execution time from the sum of all individual requests `sum(T_1, T_2, ... T_N)` to approximately `max(T_1, T_2, ... T_N)`.

---
*PR created automatically by Jules for task [16887803636549831534](https://jules.google.com/task/16887803636549831534) started by @dogi*