### PR TITLE
🧹 Extract duplicated `nullIfBlank` to common string utility

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -6,6 +6,7 @@
 
 package org.ole.planet.myplanet.lite.dashboard
 
+import org.ole.planet.myplanet.lite.util.nullIfBlank
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
@@ -949,7 +950,7 @@ class DashboardTeamsRepository {
             }
     }
 
-    private fun String.nullIfBlank(): String? = if (isBlank()) null else this
+
 
     @JsonClass(generateAdapter = true)
     data class TeamsFindRequest(val selector: TeamsSelector)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -6,6 +6,7 @@
 
 package org.ole.planet.myplanet.lite.profile
 
+import org.ole.planet.myplanet.lite.util.nullIfBlank
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
@@ -951,7 +952,7 @@ class ProfileActivity : AppCompatActivity() {
         return optString(key).nullIfBlank()
     }
 
-    private fun String?.nullIfBlank(): String? = if (this.isNullOrBlank()) null else this
+
 
     private companion object {
         private const val AVATAR_ATTACHMENT_KEY = "img"

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/UserProfileSync.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/UserProfileSync.kt
@@ -6,6 +6,7 @@
 
 package org.ole.planet.myplanet.lite.profile
 
+import org.ole.planet.myplanet.lite.util.nullIfBlank
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -111,7 +112,7 @@ class UserProfileSync(
         }
     }
 
-    private fun String.nullIfBlank(): String? = if (isBlank()) null else this
+
 
     private companion object {}
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/StringExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/StringExtensions.kt
@@ -1,0 +1,3 @@
+package org.ole.planet.myplanet.lite.util
+
+fun String?.nullIfBlank(): String? = if (this.isNullOrBlank()) null else this


### PR DESCRIPTION
🎯 **What:** Extracted the `nullIfBlank` extension function from multiple files (`DashboardTeamsRepository.kt`, `UserProfileSync.kt`, `ProfileActivity.kt`) into a single, common utility file `StringExtensions.kt` in the `util` package.

💡 **Why:** The function was duplicated in multiple places as a private extension. Extracting it to a common location reduces code duplication and improves code maintainability. Operating on `String?` rather than `String` makes it safer and more robust for all existing usages.

✅ **Verification:** 
* Checked that the extracted function works for both `String` and `String?` types correctly.
* Run `./gradlew lint` to ensure code formatting and lint checks pass.
* Run `./gradlew testDebugUnitTest` to confirm all unit tests pass without regressions.
* Used the Code Review tool and received a "Correct" review score confirming the safety and validity of the changes.

✨ **Result:** A cleaner codebase with less duplicated code and improved maintainability.

---
*PR created automatically by Jules for task [12934171482944556733](https://jules.google.com/task/12934171482944556733) started by @dogi*