### PR TITLE
🔒 Secure user credentials using EncryptedSharedPreferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.security.crypto)
     implementation(libs.kotlinx.coroutines.android)
     implementation("androidx.media3:media3-exoplayer:1.9.0")
     implementation("androidx.media3:media3-ui:1.9.0")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -27,6 +27,8 @@ import android.widget.Toast
 
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
@@ -124,6 +126,18 @@ class MyPlanetLite : AppCompatActivity() {
     private val serverPreferences: SharedPreferences by lazy {
         applicationContext.getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
     }
+    private val securePreferences: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(applicationContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            applicationContext,
+            SECURE_PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
     private val moshi: Moshi by lazy { Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build() }
     private val serverMetadataAdapter by lazy { moshi.adapter(ServerMetadataResponse::class.java) }
 
@@ -160,6 +174,7 @@ class MyPlanetLite : AppCompatActivity() {
         window.statusBarColor = ContextCompat.getColor(this, R.color.white)
         WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
         ProfileCredentialsStore.setSessionCredentials(null)
+        migrateCredentialsIfNecessary()
         clearStoredSessionIfNotRemembered()
         autoLoginEnabled = intent?.getBooleanExtra(EXTRA_ALLOW_AUTO_LOGIN, false) == true
         deepLinkPostId = extractDeepLinkPostId(intent)
@@ -1077,6 +1092,8 @@ class MyPlanetLite : AppCompatActivity() {
     private fun saveRememberedCredentials(username: String, password: String) {
         serverPreferences.edit()
             .putBoolean(KEY_REMEMBER_CREDENTIALS, true)
+            .apply()
+        securePreferences.edit()
             .putString(KEY_REMEMBERED_USERNAME, username)
             .putString(KEY_REMEMBERED_PASSWORD, password)
             .apply()
@@ -1085,6 +1102,10 @@ class MyPlanetLite : AppCompatActivity() {
     private fun clearRememberedCredentials() {
         serverPreferences.edit()
             .putBoolean(KEY_REMEMBER_CREDENTIALS, false)
+            .remove(KEY_REMEMBERED_USERNAME)
+            .remove(KEY_REMEMBERED_PASSWORD)
+            .apply()
+        securePreferences.edit()
             .remove(KEY_REMEMBERED_USERNAME)
             .remove(KEY_REMEMBERED_PASSWORD)
             .apply()
@@ -1104,12 +1125,29 @@ class MyPlanetLite : AppCompatActivity() {
         }
     }
 
+    private fun migrateCredentialsIfNecessary() {
+        val username = serverPreferences.getString(KEY_REMEMBERED_USERNAME, null)
+        val password = serverPreferences.getString(KEY_REMEMBERED_PASSWORD, null)
+
+        if (!username.isNullOrEmpty() || !password.isNullOrEmpty()) {
+            securePreferences.edit()
+                .putString(KEY_REMEMBERED_USERNAME, username)
+                .putString(KEY_REMEMBERED_PASSWORD, password)
+                .apply()
+
+            serverPreferences.edit()
+                .remove(KEY_REMEMBERED_USERNAME)
+                .remove(KEY_REMEMBERED_PASSWORD)
+                .apply()
+        }
+    }
+
     private fun loadRememberedCredentials(): RememberedCredentials? {
         if (!serverPreferences.getBoolean(KEY_REMEMBER_CREDENTIALS, false)) {
             return null
         }
-        val username = serverPreferences.getString(KEY_REMEMBERED_USERNAME, null)
-        val password = serverPreferences.getString(KEY_REMEMBERED_PASSWORD, null)
+        val username = securePreferences.getString(KEY_REMEMBERED_USERNAME, null)
+        val password = securePreferences.getString(KEY_REMEMBERED_PASSWORD, null)
         if (username.isNullOrEmpty() && password.isNullOrEmpty()) {
             return null
         }
@@ -1167,6 +1205,7 @@ class MyPlanetLite : AppCompatActivity() {
     private companion object {
         private const val MIN_PASSWORD_LENGTH = 4
         private const val PREFS_NAME = "server_preferences"
+        private const val SECURE_PREFS_NAME = "secure_server_preferences"
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_SERVER_PARENT_CODE = "server_parent_code"
         private const val KEY_SERVER_CODE = "server_code"

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileCredentialsStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileCredentialsStore.kt
@@ -7,12 +7,16 @@
 package org.ole.planet.myplanet.lite.profile
 
 import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 
 /**
  * Reads the credentials that were persisted after login so the profile screen can refresh data.
  */
 object ProfileCredentialsStore {
     private const val PREFS_NAME = "server_preferences"
+    private const val SECURE_PREFS_NAME = "secure_server_preferences"
+    private const val KEY_REMEMBER_CREDENTIALS = "remember_credentials"
     private const val KEY_REMEMBERED_USERNAME = "remembered_username"
     private const val KEY_REMEMBERED_PASSWORD = "remembered_password"
     @Volatile
@@ -24,9 +28,27 @@ object ProfileCredentialsStore {
 
     fun getStoredCredentials(context: Context): StoredCredentials? {
         sessionCredentials?.let { return it }
-        val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val username = prefs.getString(KEY_REMEMBERED_USERNAME, null)?.takeIf { it.isNotBlank() }
-        val password = prefs.getString(KEY_REMEMBERED_PASSWORD, null)?.takeIf { it.isNotBlank() }
+        val appContext = context.applicationContext
+        val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        if (!prefs.getBoolean(KEY_REMEMBER_CREDENTIALS, false)) {
+            return null
+        }
+
+        val masterKey = MasterKey.Builder(appContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        val securePrefs = EncryptedSharedPreferences.create(
+            appContext,
+            SECURE_PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
+        val username = securePrefs.getString(KEY_REMEMBERED_USERNAME, null)?.takeIf { it.isNotBlank() }
+        val password = securePrefs.getString(KEY_REMEMBERED_PASSWORD, null)?.takeIf { it.isNotBlank() }
+
         return if (username != null && password != null) {
             StoredCredentials(username, password)
         } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ worldcountrydata = "1.5.3"
 ucrop = "2.2.8"
 swiperefreshlayout = "1.2.0"
 json = "20251224"
+security-crypto = "1.1.0-alpha06"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,6 +51,7 @@ photoview = { module = "com.github.chrisbanes:PhotoView", version.ref = "photovi
 worldcountrydata = { module = "com.github.blongho:worldCountryData", version.ref = "worldcountrydata" }
 ucrop = { module = "com.github.yalantis:ucrop", version.ref = "ucrop" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses a critical security issue where user passwords were being stored in cleartext in the standard Android `SharedPreferences`.

⚠️ **Risk:** The potential impact if left unfixed
Cleartext storage of passwords poses a significant risk. If an attacker gains access to the device's file system (e.g., via a compromised app or physical access to a rooted device), they can easily extract user credentials, leading to unauthorized account access and potential data breaches.

🛡️ **Solution:** How the fix addresses the vulnerability
The solution involves:
1.  **Introducing `EncryptedSharedPreferences`:** Utilizing the `androidx.security:security-crypto` library to provide a secure alternative to standard `SharedPreferences`. It uses the Android Keystore system to protect encryption keys.
2.  **Refactoring Credential Logic:** Updating all methods responsible for saving, loading, and clearing remembered credentials in `MyPlanetLite.kt` and `ProfileCredentialsStore.kt` to use the new `securePreferences`.
3.  **Migration Path:** Implementing a one-time migration logic (`migrateCredentialsIfNecessary`) that automatically moves any existing insecurely stored credentials to the encrypted store when the app is launched, ensuring no loss of functionality for existing users.
4.  **Separation of Concerns:** Non-sensitive data (like the "Remember Me" flag) remains in standard `SharedPreferences` to allow for efficient checks before initializing the encrypted store.

By implementing these changes, user credentials are now encrypted at rest, providing a robust layer of security against unauthorized access.

---
*PR created automatically by Jules for task [14107768981071673444](https://jules.google.com/task/14107768981071673444) started by @dogi*