### PR TITLE
⚡ Concurrent fetching of initial images in CreateVoiceActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -59,6 +59,9 @@ import kotlin.math.roundToInt
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -977,14 +980,12 @@ class CreateVoiceActivity : AppCompatActivity() {
             return
         }
         val base = baseUrl ?: return
-        val loaded = mutableListOf<PendingVoiceImage>()
-        for (path in editInitialImagePaths) {
-            val pending = withContext(Dispatchers.IO) {
-                runCatching { fetchExistingVoiceImage(base, path) }.getOrNull()
-            }
-            if (pending != null) {
-                loaded += pending
-            }
+        val loaded = coroutineScope {
+            editInitialImagePaths.map { path ->
+                async(Dispatchers.IO) {
+                    runCatching { fetchExistingVoiceImage(base, path) }.getOrNull()
+                }
+            }.awaitAll().filterNotNull()
         }
         if (loaded.isEmpty()) {
             return


### PR DESCRIPTION
💡 **What:** Refactored `loadEditInitialImages` in `CreateVoiceActivity.kt` to fetch multiple existing voice images concurrently using Kotlin coroutines (`async` and `awaitAll`).
🎯 **Why:** The previous implementation fetched images sequentially within a loop, leading to increased latency, especially when multiple images were present in edit mode. By using `async` with `Dispatchers.IO`, network requests are now executed in parallel.
📊 **Measured Improvement:** While environmental constraints (Gradle timeouts) prevented running a full automated benchmark in this specific session, this change is a standard optimization for independent network I/O. Converting $N$ sequential network requests into $N$ concurrent requests reduces the total time from $\sum_{i=1}^{n} T_i$ to approximately $\max(T_1, \dots, T_n)$, which is a significant performance gain.
The implementation maintains structured concurrency with `coroutineScope` and preserves the existing error handling logic.

---
*PR created automatically by Jules for task [15902667930697983083](https://jules.google.com/task/15902667930697983083) started by @dogi*