### PR TITLE
🧹 Remove non-null assertion in DashboardTeamsRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -297,7 +297,7 @@ class DashboardTeamsRepository {
                 val profileMap = profiles.associateBy { it._id }
 
                 validMemberships.mapNotNull { member ->
-                    val userId = member.userId!!
+                    val userId = member.userId ?: return@mapNotNull null
                     val username = userId.substringAfter("org.couchdb.user:")
                     if (username.isBlank()) {
                         return@mapNotNull null


### PR DESCRIPTION
🎯 **What:** Replaced `val userId = member.userId!!` with `val userId = member.userId ?: return@mapNotNull null` in `fetchTeamMemberDetails` inside `DashboardTeamsRepository.kt`.
💡 **Why:** This prevents a potential `NullPointerException` runtime crash by safely handling cases where `userId` could unexpectedly be null. Since the assignment is within a `mapNotNull` block, returning null correctly drops the invalid member from the result.
✅ **Verification:** Verified that linting passes (`./gradlew lint`) without introducing any new issues, and ran unit tests (`./gradlew testDebugUnitTest`) which successfully executed.
✨ **Result:** Improved code safety and reliability by removing an unsafe non-null assertion.

---
*PR created automatically by Jules for task [9038771756817686150](https://jules.google.com/task/9038771756817686150) started by @dogi*