### PR TITLE
🧹 Remove non-null assertion in CreateVoiceActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -1357,11 +1357,13 @@ class CreateVoiceActivity : AppCompatActivity() {
                 return resolved
             }
         }
-        val creationResponse = if (pending.resourceId != null && pending.resourceRevision != null) {
+        val resourceId = pending.resourceId
+        val resourceRevision = pending.resourceRevision
+        val creationResponse = if (resourceId != null && resourceRevision != null) {
             VoicesComposerRepository.ResourceCreationResponse(
                 ok = true,
-                id = pending.resourceId!!,
-                revision = pending.resourceRevision!!
+                id = resourceId,
+                revision = resourceRevision
             )
         } else {
             val metadata = buildResourceMetadata(context, pending.fileName)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `!!` non-null assertions inside `CreateVoiceActivity.kt` on line ~1363 (`id = pending.resourceId!!` and `revision = pending.resourceRevision!!`) were removed.

💡 **Why:** How this improves maintainability
Using `!!` bypasses Kotlin's null safety guarantees and can throw `NullPointerException`s if the underlying property somehow changes between the null check and the usage (e.g. if the object's properties are mutable, which `pending.resourceId` and `pending.resourceRevision` are). By assigning the properties to local immutable `val` variables before the null-check, the Kotlin compiler can smart-cast them to non-null safely.

✅ **Verification:** How you confirmed the change is safe
- Extracted local `val`s and confirmed the compile errors went away when `!!` was removed.
- Ran `./gradlew lint` (found pre-existing AndroidManifest error, no new errors)
- Ran `./gradlew testDebugUnitTest` and confirmed all tests passed successfully.

✨ **Result:** The improvement achieved
The code is now safer, more idiomatic Kotlin, and robust against `NullPointerException`s without changing its behavior.

---
*PR created automatically by Jules for task [215927993364933693](https://jules.google.com/task/215927993364933693) started by @dogi*