### PR TITLE
🧹 Remove non-null assertion in FullscreenPdfActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/FullscreenPdfActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/FullscreenPdfActivity.kt
@@ -83,8 +83,9 @@ class FullscreenPdfActivity : AppCompatActivity() {
                 return@launch
             }
             pdfFile = file
-            fileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-            pdfRenderer = PdfRenderer(fileDescriptor!!)
+            val fd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            fileDescriptor = fd
+            pdfRenderer = PdfRenderer(fd)
             val renderer = pdfRenderer
             if (renderer == null || renderer.pageCount == 0) {
                 Toast.makeText(


### PR DESCRIPTION
🎯 **What:** Removed the `!!` non-null assertion in `FullscreenPdfActivity` by using a local variable (`val fd`).
💡 **Why:** `fileDescriptor` is a nullable property but is instantiated synchronously immediately before use. Capturing the newly instantiated `ParcelFileDescriptor` in a local `val` leverages Kotlin's type system to ensure null safety without relying on the risky `!!` operator, improving maintainability and robustness.
✅ **Verification:** Rebuilt the project (`./gradlew assembleDebug`) and ran unit tests (`./gradlew testDebugUnitTest`) to ensure the change compiles correctly and doesn't break existing functionality.
✨ **Result:** A safer, more idiomatic Kotlin implementation devoid of non-null assertions.

---
*PR created automatically by Jules for task [1500753383234090162](https://jules.google.com/task/1500753383234090162) started by @dogi*