### PR TITLE
🧹 Remove non-null assertions in DashboardVoicesFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -196,21 +196,22 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
             val profile = loadCurrentUserProfile()
             currentUsername = profile?.username
             isUserAdmin = profile?.isUserAdmin == true
-            if (baseUrl.isNullOrEmpty()) {
+            val currentBaseUrl = baseUrl
+            if (currentBaseUrl.isNullOrEmpty()) {
                 showEmptyState(R.string.dashboard_voices_no_server)
                 updateLoadingVisibility()
                 return@launch
             }
-            avatarLoader = DashboardAvatarLoader(baseUrl!!, sessionCookie, credentials, viewLifecycleOwner.lifecycleScope)
+            avatarLoader = DashboardAvatarLoader(currentBaseUrl, sessionCookie, credentials, viewLifecycleOwner.lifecycleScope)
             avatarUpdateListener = AvatarUpdateNotifier.register(AvatarUpdateNotifier.Listener { username ->
                 handleAvatarUpdated(username)
             })
-            postImageLoader = DashboardPostImageLoader(baseUrl!!, sessionCookie, viewLifecycleOwner.lifecycleScope)
+            postImageLoader = DashboardPostImageLoader(currentBaseUrl, sessionCookie, viewLifecycleOwner.lifecycleScope)
             postShareHelper = PostShareHelper(
                 requireContext().applicationContext,
-                { baseUrl },
+                { currentBaseUrl },
                 { sessionCookie },
-                { serverCode ?: baseUrl?.let { Uri.parse(it).host } }
+                { serverCode ?: Uri.parse(currentBaseUrl).host }
             )
             loadInitial()
         }


### PR DESCRIPTION
🎯 **What:** Removed the non-null assertions (`!!`) on `baseUrl` in `DashboardVoicesFragment.kt` lines 204 and 208.

💡 **Why:** `baseUrl` is a mutable property, meaning Kotlin cannot smart-cast it to a non-null type even after checking if it is null. Using the non-null assertion operator (`!!`) is considered a bad practice as it can lead to `NullPointerException`s if the variable is modified between the check and its use. By creating a local immutable variable (`currentBaseUrl = baseUrl`), we can safely check for nullability, and the compiler will smart-cast the variable inside the scope, avoiding the need for `!!`.

✅ **Verification:** 
* Ran `./gradlew lint` (existing error from AndroidManifest AppLinkSplitToWebAndCustom, unrelated to these changes).
* Ran `./gradlew testDebugUnitTest` and confirmed all unit tests passed.

✨ **Result:** Improved codebase maintainability and safety by eliminating unsafe non-null assertions, and cleaner variable usages in trailing lambdas.

---
*PR created automatically by Jules for task [16568181554545154375](https://jules.google.com/task/16568181554545154375) started by @dogi*