### PR TITLE
🧹 Refactor: Remove non-null assertions on baseUrl in DashboardVoicesFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -196,16 +196,17 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
             val profile = loadCurrentUserProfile()
             currentUsername = profile?.username
             isUserAdmin = profile?.isUserAdmin == true
-            if (baseUrl.isNullOrEmpty()) {
+            val currentBaseUrl = baseUrl
+            if (currentBaseUrl.isNullOrEmpty()) {
                 showEmptyState(R.string.dashboard_voices_no_server)
                 updateLoadingVisibility()
                 return@launch
             }
-            avatarLoader = DashboardAvatarLoader(baseUrl!!, sessionCookie, credentials, viewLifecycleOwner.lifecycleScope)
+            avatarLoader = DashboardAvatarLoader(currentBaseUrl, sessionCookie, credentials, viewLifecycleOwner.lifecycleScope)
             avatarUpdateListener = AvatarUpdateNotifier.register(AvatarUpdateNotifier.Listener { username ->
                 handleAvatarUpdated(username)
             })
-            postImageLoader = DashboardPostImageLoader(baseUrl!!, sessionCookie, viewLifecycleOwner.lifecycleScope)
+            postImageLoader = DashboardPostImageLoader(currentBaseUrl, sessionCookie, viewLifecycleOwner.lifecycleScope)
             postShareHelper = PostShareHelper(
                 requireContext().applicationContext,
                 { baseUrl },


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the non-null assertions (`!!`) on the mutable `baseUrl` property in `DashboardVoicesFragment.kt` around line 208.

💡 **Why:** How this improves maintainability
Using `!!` on a mutable property circumvents Kotlin's null-safety system because a mutable property can technically be updated by another thread after a null check. By capturing it into a local `val` variable first, the compiler is able to smart-cast it as non-null, removing the risk of a `NullPointerException` and avoiding code smells associated with non-null assertions.

✅ **Verification:** How you confirmed the change is safe
Ran `./gradlew lint` to check for Kotlin styling and conventions, and `./gradlew testDebugUnitTest` to ensure all existing tests continue to pass without regression. The changes successfully compiled and all tests passed.

✨ **Result:** The improvement achieved
A clean and idiomatic code structure that relies correctly on Kotlin's smart-casting.

---
*PR created automatically by Jules for task [14490922781582154075](https://jules.google.com/task/14490922781582154075) started by @dogi*