### PR TITLE
🧹 [Code Health] Remove non-null assertion from ViewBinding in DashboardTeamMembersFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.withContext
 class DashboardTeamMembersFragment : Fragment() {
 
     private var _binding: FragmentDashboardTeamMembersBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding is only valid between onCreateView and onDestroyView")
 
     private val repository = DashboardTeamsRepository()
     private var avatarLoader: DashboardAvatarLoader? = null


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a non-null assertion (`!!`) used for the `binding` property in `DashboardTeamMembersFragment.kt`.

💡 **Why:** Relying on `!!` can lead to generic `NullPointerException`s that are difficult to trace. Replacing it with `?: error(...)` ensures that if the property is accessed out of the valid lifecycle (between `onCreateView` and `onDestroyView`), a clear and descriptive `IllegalStateException` is thrown, making debugging easier and the codebase more robust.

✅ **Verification:** I ran `./gradlew lint`, `./gradlew assembleDebug`, and `./gradlew testDebugUnitTest` to confirm the project builds, formatting is sound, and existing tests pass.

✨ **Result:** A safer, more predictable way to access view bindings that aligns with Android best practices and improves maintainability.

---
*PR created automatically by Jules for task [11099545588738831473](https://jules.google.com/task/11099545588738831473) started by @dogi*