### PR TITLE
🧹 Code health: Simplify percentage calculations using implicit type promotion

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -671,7 +671,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             null
         }
         val progressPercent = if (steps.isNotEmpty() && completedSteps != null) {
-            ((completedSteps.toDouble() / steps.size.toDouble()) * 100)
+            (completedSteps * 100.0 / steps.size)
                 .toInt()
                 .coerceIn(0, 100)
         } else if (steps.isNotEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
@@ -685,7 +685,7 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
                 0
             }
         }.sum()
-        val percentage = ((earned.toDouble() / totalMarks.toDouble()) * 100).roundToInt()
+        val percentage = (earned * 100.0 / totalMarks).roundToInt()
         return percentage >= passingPercentage
     }
 


### PR DESCRIPTION
🎯 What: Simplified percentage calculations in `DashboardCoursePageFragment.kt` and `SurveyWizardFragment.kt` by removing explicit `.toDouble()` conversions.
💡 Why: Relying on implicit type promotion (multiplying by `100.0`) simplifies the mathematical expressions, making the code shorter, cleaner, and easier to read without changing behavior.
✅ Verification: Ran `./gradlew testDebugUnitTest` and `./gradlew lint`. Tests pass.
✨ Result: Cleaner, more maintainable code leveraging Kotlin's implicit type promotion.

---
*PR created automatically by Jules for task [14299293927333570121](https://jules.google.com/task/14299293927333570121) started by @dogi*