### PR TITLE
Mock android.util.Log for unit tests

### DIFF
--- a/app/src/test/java/android/util/Log.java
+++ b/app/src/test/java/android/util/Log.java
@@ -1,0 +1,62 @@
+package android.util;
+
+public class Log {
+    public static final int VERBOSE = 2;
+    public static final int DEBUG = 3;
+    public static final int INFO = 4;
+    public static final int WARN = 5;
+    public static final int ERROR = 6;
+    public static final int ASSERT = 7;
+
+    public static int v(String tag, String msg) {
+        return 0;
+    }
+
+    public static int v(String tag, String msg, Throwable tr) {
+        return 0;
+    }
+
+    public static int d(String tag, String msg) {
+        return 0;
+    }
+
+    public static int d(String tag, String msg, Throwable tr) {
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        return 0;
+    }
+
+    public static int i(String tag, String msg, Throwable tr) {
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        return 0;
+    }
+
+    public static int w(String tag, String msg, Throwable tr) {
+        return 0;
+    }
+
+    public static int w(String tag, Throwable tr) {
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        return 0;
+    }
+
+    public static int e(String tag, String msg, Throwable tr) {
+        return 0;
+    }
+
+    public static int println(int priority, String tag, String msg) {
+        return 0;
+    }
+
+    public static boolean isLoggable(String tag, int level) {
+        return false;
+    }
+}


### PR DESCRIPTION
Resolved the `java.lang.RuntimeException: Method isLoggable in android.util.Log not mocked` error by providing a mock `Log` implementation in the `app/src/test/java/android/util/` directory. This allows unit tests to run correctly on the JVM without needing Robolectric.

---
*PR created automatically by Jules for task [9289807377935431572](https://jules.google.com/task/9289807377935431572) started by @PlataformasInformaticas*