### PR TITLE
Explicitly configure Mockito as a Java agent for tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,13 @@ kotlin {
     }
 }
 val mockitoAgent by configurations.creating
+
+tasks.withType<Test> {
+    doFirst {
+        jvmArgs("-javaagent:${mockitoAgent.singleFile}")
+    }
+}
+
 dependencies {
     mockitoAgent(libs.mockito.core) { isTransitive = false }
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
This change addresses the Mockito dynamic attachment warning by explicitly configuring Mockito as a Java agent for unit tests. This ensures compatibility with future JDK releases where dynamic agent loading will be disallowed by default.

---
*PR created automatically by Jules for task [17623088950979827759](https://jules.google.com/task/17623088950979827759) started by @PlataformasInformaticas*