### PR TITLE
Resolve Byte Buddy dynamic loading warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
+val mockkAgent: Configuration by configurations.creating
+
 android {
     namespace = "org.ole.planet.myplanet.lite"
     compileSdk = 36
@@ -38,6 +40,18 @@ android {
     }
 }
 
+tasks.withType<Test>().configureEach {
+    doFirst {
+        val agentFile = mockkAgent.find { it.name.startsWith("byte-buddy-agent") }
+        if (agentFile != null) {
+            jvmArgs("-javaagent:$agentFile")
+        }
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+            jvmArgs("-XX:+EnableDynamicAgentLoading")
+        }
+    }
+}
+
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_11)
@@ -45,6 +59,8 @@ kotlin {
 }
 
 dependencies {
+    mockkAgent(libs.byte.buddy)
+    mockkAgent(libs.byte.buddy.agent)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,8 +29,10 @@ worldcountrydata = "1.5.3"
 ucrop = "2.2.8"
 swiperefreshlayout = "1.2.0"
 json = "20251224"
+bytebuddy = "1.18.2"
 
 [libraries]
+byte-buddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "bytebuddy" }
 androidx-core = { module = "androidx.test:core", version.ref = "coreKtxVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espressoCore" }
@@ -59,6 +61,7 @@ androidx-security-crypto = { group = "androidx.security", name = "security-crypt
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-agent-jvm = { module = "io.mockk:mockk-agent-jvm", version.ref = "mockk" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshiKotlin" }
 photoview = { module = "com.github.chrisbanes:PhotoView", version.ref = "photoview" }
@@ -67,6 +70,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 worldcountrydata = { module = "com.github.blongho:worldCountryData", version.ref = "worldcountrydata" }
 ucrop = { module = "com.github.yalantis:ucrop", version.ref = "ucrop" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+byte-buddy-agent = { group = "net.bytebuddy", name = "byte-buddy-agent", version.ref = "bytebuddy" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR resolves the "Java agent has been loaded dynamically" warning that appears when running unit tests with JDK 21+. It implements static agent loading for Byte Buddy (required by MockK) by configuring the `-javaagent` JVM argument for all test tasks in the `app` module. This change is future-proof and aligns with modern JVM security requirements.

---
*PR created automatically by Jules for task [15392060963658316800](https://jules.google.com/task/15392060963658316800) started by @PlataformasInformaticas*