### PR TITLE
Fix type mismatch in PostShareHelperTest and resolve Mockito agent warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
+val mockitoAgent by configurations.creating {
+    isTransitive = false
+}
+
 android {
     namespace = "org.ole.planet.myplanet.lite"
     compileSdk = 36
@@ -84,4 +88,11 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.junit)
     testImplementation(libs.core.ktx)
+    mockitoAgent(libs.mockito.core)
+}
+
+tasks.withType<Test>().configureEach {
+    doFirst {
+        jvmArgs("-javaagent:${mockitoAgent.singleFile}")
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelperTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelperTest.kt
@@ -70,7 +70,7 @@ class PostShareHelperTest {
         `when`(context.getString(R.string.dashboard_share_post_title, "fallback server")).thenReturn("Shared from fallback server")
         `when`(context.getString(R.string.dashboard_share_post_chooser_title)).thenReturn("Share post")
         `when`(context.packageName).thenReturn("org.ole.planet.myplanet.lite")
-        `when`(context.cacheDir).thenReturn(File(System.getProperty("java.io.tmpdir")))
+        `when`(context.cacheDir).thenReturn(File(System.getProperty("java.io.tmpdir") ?: "."))
 
         helper = PostShareHelper(
             context = context,


### PR DESCRIPTION
This PR fixes a Kotlin compilation error in `PostShareHelperTest.kt` caused by a platform type mismatch and resolves a Mockito warning about dynamic agent loading by configuring it as a Java agent in the Gradle build script.

---
*PR created automatically by Jules for task [4791704385630102690](https://jules.google.com/task/4791704385630102690) started by @PlataformasInformaticas*