### PR TITLE
Resolve Resources deprecation in LearningLevelTranslatorTest

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/LearningLevelTranslatorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/LearningLevelTranslatorTest.kt
@@ -1,46 +1,87 @@
 package org.ole.planet.myplanet.lite.profile
 
 import android.content.Context
-import android.content.res.Resources
+import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.R
-import java.lang.reflect.InvocationHandler
-import java.lang.reflect.Proxy
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
 class LearningLevelTranslatorTest {
 
-    private lateinit var mockContext: Context
-
-    private val englishArray = arrayOf("Beginner", "Intermediate", "Advanced", "Expert")
-    private val spanishArray = arrayOf("Principiante", "Intermedio", "Avanzado", "Experto")
-    private val frenchArray = arrayOf("Débutant", "Intermédiaire", "Avancé", "Expert")
+    private lateinit var context: Context
 
     @Before
     fun setUp() {
-        val customResources = object : Resources(null, null, null) {
-            override fun getStringArray(id: Int): Array<String> {
-                return when (id) {
-                    R.array.signup_level_options_language_en -> englishArray
-                    R.array.signup_level_options_language_es -> spanishArray
-                    R.array.signup_level_options_language_fr -> frenchArray
-                    R.array.signup_level_options_language_pt,
-                    R.array.signup_level_options_language_ar,
-                    R.array.signup_level_options_language_so,
-                    R.array.signup_level_options_language_ne,
-                    R.array.signup_level_options_language_hi -> emptyArray()
-                    else -> emptyArray()
-                }
-            }
-        }
+        context = ApplicationProvider.getApplicationContext()
+    }
 
-        // We use Proxy to mock the Context class to avoid abstract method errors and the need for Mockito.
-        // Wait! We can just use an anonymous Context subclass?
-        // Let's proxy a common mock wrapper around context?
-        // No, Context is an abstract class, not an interface.
+    @Test
+    fun testToEnglish_ReturnsNullForEmptyInput() {
+        assertNull(LearningLevelTranslator.toEnglish(context, ""))
+        assertNull(LearningLevelTranslator.toEnglish(context, null))
+        assertNull(LearningLevelTranslator.toEnglish(context, "   "))
+    }
 
-        // Wait... can we just use Robolectric?
+    @Test
+    fun testToEnglish_TranslatesSpanishToEnglish() {
+        // Based on app/src/main/res/values-es/strings.xml
+        // <string-array name="signup_level_options_language_es">
+        //     <item>Principiante</item>
+        //     <item>Intermedio</item>
+        //     <item>Avanzado</item>
+        //     <item>Experto</item>
+        // </string-array>
+        assertEquals("Beginner", LearningLevelTranslator.toEnglish(context, "Principiante"))
+        assertEquals("Intermediate", LearningLevelTranslator.toEnglish(context, "Intermedio"))
+        assertEquals("Advanced", LearningLevelTranslator.toEnglish(context, "Avanzado"))
+        assertEquals("Expert", LearningLevelTranslator.toEnglish(context, "Experto"))
+    }
+
+    @Test
+    fun testToEnglish_TranslatesFrenchToEnglish() {
+        // Based on app/src/main/res/values-fr/strings.xml
+        // <string-array name="signup_level_options_language_fr">
+        //     <item>Débutant</item>
+        //     <item>Intermédiaire</item>
+        //     <item>Avancé</item>
+        //     <item>Expert</item>
+        // </string-array>
+        assertEquals("Beginner", LearningLevelTranslator.toEnglish(context, "Débutant"))
+        assertEquals("Intermediate", LearningLevelTranslator.toEnglish(context, "Intermédiaire"))
+        assertEquals("Advanced", LearningLevelTranslator.toEnglish(context, "Avancé"))
+        assertEquals("Expert", LearningLevelTranslator.toEnglish(context, "Expert"))
+    }
+
+    @Test
+    fun testToEnglish_ReturnsOriginalIfNotFound() {
+        assertEquals("UnknownLevel", LearningLevelTranslator.toEnglish(context, "UnknownLevel"))
+    }
+
+    @Test
+    fun testToLocalized_TranslatesEnglishToSpanish() {
+        assertEquals("Principiante", LearningLevelTranslator.toLocalized(context, "Beginner", R.array.signup_level_options_language_es))
+        assertEquals("Intermedio", LearningLevelTranslator.toLocalized(context, "Intermediate", R.array.signup_level_options_language_es))
+        assertEquals("Avanzado", LearningLevelTranslator.toLocalized(context, "Advanced", R.array.signup_level_options_language_es))
+        assertEquals("Experto", LearningLevelTranslator.toLocalized(context, "Expert", R.array.signup_level_options_language_es))
+    }
+
+    @Test
+    fun testToLocalized_TranslatesEnglishToFrench() {
+        assertEquals("Débutant", LearningLevelTranslator.toLocalized(context, "Beginner", R.array.signup_level_options_language_fr))
+        assertEquals("Intermédiaire", LearningLevelTranslator.toLocalized(context, "Intermediate", R.array.signup_level_options_language_fr))
+        assertEquals("Avancé", LearningLevelTranslator.toLocalized(context, "Advanced", R.array.signup_level_options_language_fr))
+        assertEquals("Expert", LearningLevelTranslator.toLocalized(context, "Expert", R.array.signup_level_options_language_fr))
+    }
+
+    @Test
+    fun testToLocalized_ReturnsOriginalIfNotFound() {
+        assertEquals("UnknownLevel", LearningLevelTranslator.toLocalized(context, "UnknownLevel", R.array.signup_level_options_language_es))
     }
 }


### PR DESCRIPTION
This change resolves a deprecation warning in `LearningLevelTranslatorTest.kt` where the `Resources` constructor was being called manually. The test was refactored to use Robolectric, which is the preferred way to interact with Android resources in JVM unit tests. Additionally, the test suite was expanded to include full coverage for the `toEnglish` and `toLocalized` methods in `LearningLevelTranslator`, verifying translations for Spanish and French as well as handling for null/empty inputs.

---
*PR created automatically by Jules for task [15553484341265989234](https://jules.google.com/task/15553484341265989234) started by @PlataformasInformaticas*