### PR TITLE
Resolve Intent extra deprecations and refactor Kotlin files

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -3,14 +3,11 @@
  * Email: loppra@plataformasinformaticas.com
  * Creation date: 2026-01-04
  */
-
 package org.ole.planet.myplanet.lite
-
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageButton
@@ -19,6 +16,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.IntentCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -42,10 +40,8 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
-
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class CourseWizardActivity : AppCompatActivity() {
-
     private lateinit var markwon: Markwon
     private var steps: List<StepDisplay> = emptyList()
     private var baseUrl: String? = null
@@ -97,26 +93,20 @@ class CourseWizardActivity : AppCompatActivity() {
                 )
             }
         }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         WindowCompat.setDecorFitsSystemWindows(window, true)
         setContentView(R.layout.activity_course_wizard)
-
         markwon = Markwon.builder(this)
             .usePlugin(TablePlugin.create(this))
             .build()
-
         val (courseTitle, startIndex) = parseIntentData(savedInstanceState)
-
         if (steps.isEmpty()) {
             finish()
             return
         }
-
         setupViews(courseTitle)
-
         lifecycleScope.launch {
             currentIndex = resolveInitialStepIndex(startIndex)
             bindStep(
@@ -132,7 +122,6 @@ class CourseWizardActivity : AppCompatActivity() {
             maybeAutoCompleteFirstStep()
         }
     }
-
     private fun parseIntentData(savedInstanceState: Bundle?): Pair<String, Int> {
         val courseTitle = intent.getStringExtra(EXTRA_TITLE).orEmpty()
         courseId = intent.getStringExtra(EXTRA_COURSE_ID)
@@ -143,19 +132,12 @@ class CourseWizardActivity : AppCompatActivity() {
             completedExamSteps.clear()
             completedExamSteps.addAll(restored)
         }
-
         val stepPayload: ArrayList<DashboardCoursePageFragment.CourseItem.LessonStep>? =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                intent.getSerializableExtra(EXTRA_STEPS, ArrayList::class.java)
-                    ?.filterIsInstance<DashboardCoursePageFragment.CourseItem.LessonStep>()
-                    ?.let { ArrayList(it) }
-            } else {
-                @Suppress("DEPRECATION")
-                (intent.getSerializableExtra(EXTRA_STEPS) as? ArrayList<*>)
-                    ?.filterIsInstance<DashboardCoursePageFragment.CourseItem.LessonStep>()
-                    ?.let { ArrayList(it) }
-            }
-
+            IntentCompat.getSerializableExtra(
+                intent,
+                EXTRA_STEPS,
+                ArrayList::class.java
+            ) as? ArrayList<DashboardCoursePageFragment.CourseItem.LessonStep>
         steps = stepPayload?.map { step ->
             StepDisplay(
                 title = step.title,
@@ -165,17 +147,12 @@ class CourseWizardActivity : AppCompatActivity() {
                 exam = step.exam
             )
         }.orEmpty()
-
         return Pair(courseTitle, startIndex)
     }
-
     private fun setupViews(courseTitle: String) {
-        val toolbar: MaterialToolbar = findViewById(R.id.courseWizardToolbar)
-
         val root: View = findViewById(R.id.courseWizardRoot)
         WindowInsetsControllerCompat(window, root).isAppearanceLightStatusBars = true
         val titleView: TextView = findViewById(R.id.courseWizardTitle)
-
         stepPositionView = findViewById(R.id.courseWizardStepPosition)
         stepTitleView = findViewById(R.id.courseWizardStepTitle)
         descriptionView = findViewById(R.id.courseWizardDescription)
@@ -184,12 +161,10 @@ class CourseWizardActivity : AppCompatActivity() {
         attachmentsTitle = findViewById(R.id.courseWizardAttachmentsTitle)
         previousButton = findViewById(R.id.courseWizardPrevious)
         nextButton = findViewById(R.id.courseWizardNext)
-
         val initialPaddingLeft = root.paddingLeft
         val initialPaddingTop = root.paddingTop
         val initialPaddingRight = root.paddingRight
         val initialPaddingBottom = root.paddingBottom
-
         ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             view.setPadding(
@@ -200,15 +175,12 @@ class CourseWizardActivity : AppCompatActivity() {
             )
             WindowInsetsCompat.CONSUMED
         }
-
         titleView.text = courseTitle
     }
-
     override fun onDestroy() {
         super.onDestroy()
         releaseAudioPlayers()
     }
-
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putIntegerArrayList(
@@ -216,7 +188,6 @@ class CourseWizardActivity : AppCompatActivity() {
             ArrayList(completedExamSteps)
         )
     }
-
     private suspend fun resolveInitialStepIndex(fallbackIndex: Int): Int {
         val normalizedBase = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return fallbackIndex
         val creds = credentials ?: return fallbackIndex
@@ -230,7 +201,6 @@ class CourseWizardActivity : AppCompatActivity() {
         val resolvedIndex = progressStep?.minus(1) ?: fallbackIndex
         return resolvedIndex.coerceIn(0, steps.lastIndex)
     }
-
     private fun maybeAutoCompleteFirstStep() {
         if (hasAutoCompletedFirstStep || currentIndex != 0) return
         hasAutoCompletedFirstStep = true
@@ -238,7 +208,6 @@ class CourseWizardActivity : AppCompatActivity() {
             runCatching { updateCourseProgressIfNeeded(1) }
         }
     }
-
     private fun bindStep(
         stepPositionView: TextView,
         stepTitleView: TextView,
@@ -257,7 +226,6 @@ class CourseWizardActivity : AppCompatActivity() {
         )
         stepTitleView.text = step.title
         markwon.setMarkdown(descriptionView, step.description.replace("\n", "  \n"))
-
         bindAttachments(
             step.resources,
             step.survey,
@@ -266,7 +234,6 @@ class CourseWizardActivity : AppCompatActivity() {
             attachmentsTitle,
             attachmentsList
         )
-
         previousButton.isEnabled = currentIndex > 0
         previousButton.setOnClickListener {
             if (currentIndex > 0) {
@@ -283,7 +250,6 @@ class CourseWizardActivity : AppCompatActivity() {
                 )
             }
         }
-
         val examPending = step.exam?.questions?.isNotEmpty() == true &&
             !completedExamSteps.contains(currentIndex)
         if (currentIndex >= steps.lastIndex) {
@@ -318,7 +284,6 @@ class CourseWizardActivity : AppCompatActivity() {
             nextButton.isEnabled = false
         }
     }
-
     private suspend fun advanceToNextStep(
         stepPositionView: TextView,
         stepTitleView: TextView,
@@ -346,7 +311,6 @@ class CourseWizardActivity : AppCompatActivity() {
             nextButton
         )
     }
-
     private suspend fun updateCourseProgressIfNeeded(targetStepNumber: Int) {
         val normalizedBase = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return
         val creds = credentials ?: return
@@ -356,7 +320,6 @@ class CourseWizardActivity : AppCompatActivity() {
         val existingDoc = existingDocuments?.get(id)
         val existingStep = existingDoc?.stepNum ?: 0
         if (existingStep >= targetStepNumber) return
-
         val targetStepDocuments = coursesRepository.fetchCoursesProgressDocuments(
             normalizedBase,
             creds,
@@ -364,7 +327,6 @@ class CourseWizardActivity : AppCompatActivity() {
             targetStepNumber
         ).getOrNull()
         val targetStepDoc = targetStepDocuments?.get(id)
-
         val now = System.currentTimeMillis()
         val document = DashboardCoursesRepository.CourseProgressUpdateDocument(
             id = targetStepDoc?.id,
@@ -380,10 +342,8 @@ class CourseWizardActivity : AppCompatActivity() {
             createdDate = targetStepDoc?.createdDate ?: now,
             updatedDate = now
         )
-
         coursesRepository.saveCourseProgress(normalizedBase, creds, document)
     }
-
     private fun bindAttachments(
         resources: List<DashboardCoursePageFragment.CourseItem.LessonResource>,
         survey: SurveyDocument?,
@@ -400,7 +360,6 @@ class CourseWizardActivity : AppCompatActivity() {
         releaseAudioPlayers()
         val videoResources = resources.filter { it.mediaType.lowercase(Locale.ROOT).contains("video") }
         val imageResources = resources.filter { it.mediaType.lowercase(Locale.ROOT).contains("image") }
-        val audioResources = resources.filter { it.mediaType.lowercase(Locale.ROOT).contains("audio") }
         val displayResources = resources.filter { resource ->
             val mediaType = resource.mediaType.lowercase(Locale.ROOT)
             mediaType.contains("video") || mediaType.contains("pdf") || mediaType.contains("image") ||
@@ -414,7 +373,6 @@ class CourseWizardActivity : AppCompatActivity() {
             container.visibility = View.GONE
             return
         }
-
         container.visibility = View.VISIBLE
         titleView.visibility = View.VISIBLE
         val inflater = layoutInflater
@@ -425,14 +383,12 @@ class CourseWizardActivity : AppCompatActivity() {
                 currentPlaylistUrls.add(resolvedUrl)
             }
         }
-
         if (videoResources.isNotEmpty() && currentPlaylistUrls.isEmpty()) {
             container.visibility = View.GONE
             Toast.makeText(this, getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT)
                 .show()
             return
         }
-
         if (hasSurvey) {
             val itemView = inflater.inflate(
                 R.layout.item_course_wizard_attachment,
@@ -498,7 +454,6 @@ class CourseWizardActivity : AppCompatActivity() {
             playButton.setOnClickListener { openExam() }
             listContainer.addView(itemView)
         }
-
         displayResources.forEach { resource ->
             val isAudio = resource.mediaType.lowercase(Locale.ROOT).contains("audio")
             val itemView = if (isAudio) {
@@ -572,7 +527,6 @@ class CourseWizardActivity : AppCompatActivity() {
             listContainer.addView(itemView)
         }
     }
-
     private fun bindAudioPlayer(
         itemView: View,
         resource: DashboardCoursePageFragment.CourseItem.LessonResource
@@ -594,30 +548,25 @@ class CourseWizardActivity : AppCompatActivity() {
         player.playWhenReady = false
         audioPlayers.add(player)
     }
-
     private fun buildAudioDataSourceFactory(authorizationHeader: String?): DefaultHttpDataSource.Factory {
         val factory = DefaultHttpDataSource.Factory().setAllowCrossProtocolRedirects(true)
         authorizationHeader?.let { factory.setDefaultRequestProperties(mapOf("Authorization" to it)) }
         return factory
     }
-
     private fun releaseAudioPlayers() {
         audioPlayers.forEach { it.release() }
         audioPlayers.clear()
     }
-
     private fun selectResource(resource: DashboardCoursePageFragment.CourseItem.LessonResource) {
         val targetIndex = playlistIndexByResourceId[resource.id] ?: return
         launchFullscreenPlayer(targetIndex)
     }
-
     private fun launchFullscreenPlayer(startIndex: Int) {
         if (currentPlaylistUrls.isEmpty()) {
             Toast.makeText(this, getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT)
                 .show()
             return
         }
-
         val startPosition = if (startIndex == lastPlaybackIndex) {
             lastPlaybackPositionMs
         } else {
@@ -633,7 +582,6 @@ class CourseWizardActivity : AppCompatActivity() {
         )
         fullscreenLauncher.launch(intent)
     }
-
     private fun openPdfResource(resource: DashboardCoursePageFragment.CourseItem.LessonResource) {
         val url = buildResourceUrl(resource)
         if (url.isNullOrBlank()) {
@@ -645,7 +593,6 @@ class CourseWizardActivity : AppCompatActivity() {
         val intent = FullscreenPdfActivity.createIntent(this, url, authHeader)
         startActivity(intent)
     }
-
     private fun openImageResource(
         resource: DashboardCoursePageFragment.CourseItem.LessonResource,
         imageResources: List<DashboardCoursePageFragment.CourseItem.LessonResource>
@@ -672,7 +619,6 @@ class CourseWizardActivity : AppCompatActivity() {
         }
         startActivity(intent)
     }
-
     private fun buildResourceUrl(resource: DashboardCoursePageFragment.CourseItem.LessonResource): String? {
         val normalizedBase = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return null
         val parsed = Uri.parse(normalizedBase)
@@ -688,13 +634,11 @@ class CourseWizardActivity : AppCompatActivity() {
             .build()
             .toString()
     }
-
     private fun buildResourcePath(resource: DashboardCoursePageFragment.CourseItem.LessonResource): String? {
         val resourceId = resource.id.trim().takeIf { it.isNotEmpty() } ?: return null
         val filename = resource.filename.trim().takeIf { it.isNotEmpty() } ?: return null
         return "resources/$resourceId/$filename"
     }
-
     data class StepDisplay(
         val title: String,
         val description: String,
@@ -702,14 +646,12 @@ class CourseWizardActivity : AppCompatActivity() {
         val survey: SurveyDocument? = null,
         val exam: SurveyDocument? = null
     )
-
     companion object {
         private const val EXTRA_TITLE = "extra_title"
         private const val EXTRA_COURSE_ID = "extra_course_id"
         private const val EXTRA_STEPS = "extra_steps"
         private const val EXTRA_START_STEP = "extra_start_step"
         private const val EXTRA_COMPLETED_EXAM_STEPS = "extra_completed_exam_steps"
-
         fun start(
             context: Context,
             courseId: String,

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelperTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelperTest.kt
@@ -1,9 +1,9 @@
 package org.ole.planet.myplanet.lite.dashboard
-
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.core.content.FileProvider
+import androidx.core.content.IntentCompat
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -15,12 +15,13 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.MockedStatic
 import org.mockito.Mockito.`when`
@@ -29,48 +30,36 @@ import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.verify
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.ole.planet.myplanet.lite.R
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28])
 class PostShareHelperTest {
-
     private lateinit var mockWebServer: MockWebServer
     private lateinit var helper: PostShareHelper
-
     @Mock
     private lateinit var context: Context
-
     private val testDispatcher = StandardTestDispatcher()
-
     private lateinit var htmlStaticMock: MockedStatic<android.text.Html>
     private lateinit var fileProviderStaticMock: MockedStatic<FileProvider>
-
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
         Dispatchers.setMain(testDispatcher)
-
         mockWebServer = MockWebServer()
         mockWebServer.start()
-
         htmlStaticMock = mockStatic(android.text.Html::class.java)
         htmlStaticMock.`when`<String> { android.text.Html.escapeHtml(anyString()) }.thenAnswer { invocation ->
             val str = invocation.getArgument<String>(0)
             str.replace("<", "&lt;").replace(">", "&gt;")
         }
-
         fileProviderStaticMock = mockStatic(FileProvider::class.java)
         fileProviderStaticMock.`when`<Uri> { FileProvider.getUriForFile(any(Context::class.java), anyString(), any(File::class.java)) }.thenAnswer {
             mock(Uri::class.java)
         }
-
         `when`(context.getString(R.string.dashboard_share_post_fallback)).thenReturn("fallback text")
         `when`(context.getString(R.string.dashboard_share_post_server_fallback)).thenReturn("fallback server")
         `when`(context.getString(R.string.dashboard_share_post_title, "my server")).thenReturn("Shared from my server")
@@ -78,7 +67,6 @@ class PostShareHelperTest {
         `when`(context.getString(R.string.dashboard_share_post_chooser_title)).thenReturn("Share post")
         `when`(context.packageName).thenReturn("org.ole.planet.myplanet.lite")
         `when`(context.cacheDir).thenReturn(File(System.getProperty("java.io.tmpdir") ?: "."))
-
         helper = PostShareHelper(
             context = context,
             baseUrlProvider = { mockWebServer.url("/").toString() },
@@ -86,7 +74,6 @@ class PostShareHelperTest {
             serverNameProvider = { "my server" }
         )
     }
-
     @After
     fun teardown() {
         mockWebServer.shutdown()
@@ -94,7 +81,6 @@ class PostShareHelperTest {
         htmlStaticMock.close()
         fileProviderStaticMock.close()
     }
-
     @Test
     fun testSanitizeMessage() {
         val raw = "Hello **world**! [link](http://example.com) ![image](http://example.com/image.jpg)"
@@ -102,13 +88,11 @@ class PostShareHelperTest {
         val result = PostShareHelper.sanitizeMessage(raw)
         assertEquals(expected, result)
     }
-
     @Test
     fun testSanitizeMessageEmpty() {
         assertNull(PostShareHelper.sanitizeMessage(null))
         assertNull(PostShareHelper.sanitizeMessage("   "))
     }
-
     @Test
     fun testSanitizeForHtml() {
         val raw = "Hello! ![image](http://example.com/image.jpg)"
@@ -116,13 +100,11 @@ class PostShareHelperTest {
         val result = PostShareHelper.sanitizeForHtml(raw)
         assertEquals(expected, result)
     }
-
     @Test
     fun testSanitizeForHtmlEmpty() {
         assertNull(PostShareHelper.sanitizeForHtml(null))
         assertNull(PostShareHelper.sanitizeForHtml("   "))
     }
-
     @Test
     fun testToHtml() {
         val text = "Hello **world**\n[link](http://example.com)"
@@ -130,20 +112,17 @@ class PostShareHelperTest {
         val expected = "Hello <b>world</b><br/><a href=\"http://example.com\">link</a>"
         assertEquals(expected, result)
     }
-
     @Test
     fun testResolveUrl() {
         val companion = PostShareHelper.Companion
         val method = companion::class.java.getDeclaredMethod("resolveUrl", String::class.java, String::class.java)
         method.isAccessible = true
-
         assertEquals("http://test.com/db/image.jpg", method.invoke(companion, "image.jpg", "http://test.com/"))
         assertEquals("http://test.com/db/image.jpg", method.invoke(companion, "db/image.jpg", "http://test.com/"))
         assertEquals("https://external.com/image.jpg", method.invoke(companion, "https://external.com/image.jpg", "http://test.com/"))
         assertNull(method.invoke(companion, "   ", "http://test.com/"))
         assertNull(method.invoke(companion, "image.jpg", "   "))
     }
-
     @Test
     fun testSharePostWithoutImages() = runTest {
         helper.sharePost(
@@ -153,18 +132,14 @@ class PostShareHelperTest {
             imagePaths = emptyList()
         )
         testDispatcher.scheduler.advanceUntilIdle()
-
         val intentCaptor = ArgumentCaptor.forClass(Intent::class.java)
         verify(context).startActivity(intentCaptor.capture())
-
         val chooserIntent = intentCaptor.value
         assertEquals("Share post", chooserIntent.getStringExtra(Intent.EXTRA_TITLE))
-
-        val targetIntent = chooserIntent.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        val targetIntent = IntentCompat.getParcelableExtra(chooserIntent, Intent.EXTRA_INTENT, Intent::class.java)
         assertNotNull(targetIntent)
         assertEquals(Intent.ACTION_SEND, targetIntent?.action)
         assertEquals("text/plain", targetIntent?.type)
-
         val expectedText = "Shared from my server\n\nJohn Doe\n\nHello world!"
         assertEquals(expectedText, targetIntent?.getStringExtra(Intent.EXTRA_TEXT))
         val expectedHtml = "Shared from my server<br/><br/>Hello world!"
@@ -172,19 +147,15 @@ class PostShareHelperTest {
         assertEquals("Shared from my server", targetIntent?.getStringExtra(Intent.EXTRA_SUBJECT))
         assertEquals("Shared from my server", targetIntent?.getStringExtra(Intent.EXTRA_TITLE))
     }
-
     @Test
     fun testSharePostWithImages() = runTest {
         mockWebServer.enqueue(MockResponse().setBody("image content").setResponseCode(200))
-
         val mockContentResolver = mock(android.content.ContentResolver::class.java)
         `when`(context.contentResolver).thenReturn(mockContentResolver)
-
         val clipDataStaticMock = mockStatic(android.content.ClipData::class.java)
         try {
             val mockClipData = mock(android.content.ClipData::class.java)
             clipDataStaticMock.`when`<android.content.ClipData> { android.content.ClipData.newUri(any(), anyString(), any()) }.thenReturn(mockClipData)
-
             helper.sharePost(
                 _postId = "123",
                 author = "John Doe",
@@ -192,34 +163,28 @@ class PostShareHelperTest {
                 imagePaths = listOf("image1.jpg")
             )
             testDispatcher.scheduler.advanceUntilIdle()
-
             val intentCaptor = ArgumentCaptor.forClass(Intent::class.java)
             verify(context).startActivity(intentCaptor.capture())
-
-            val targetIntent = intentCaptor.value.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+            val targetIntent = IntentCompat.getParcelableExtra(intentCaptor.value, Intent.EXTRA_INTENT, Intent::class.java)
             assertNotNull(targetIntent)
             assertEquals(Intent.ACTION_SEND, targetIntent?.action)
             assertEquals("image/*", targetIntent?.type)
             assertTrue((targetIntent?.flags ?: 0) and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
-            assertNotNull(targetIntent?.getParcelableExtra<Uri>(Intent.EXTRA_STREAM))
+            assertNotNull(targetIntent?.let { IntentCompat.getParcelableExtra(it, Intent.EXTRA_STREAM, Uri::class.java) })
         } finally {
             clipDataStaticMock.close()
         }
     }
-
     @Test
     fun testSharePostWithMultipleImages() = runTest {
         mockWebServer.enqueue(MockResponse().setBody("image content 1").setResponseCode(200))
         mockWebServer.enqueue(MockResponse().setBody("image content 2").setResponseCode(200))
-
         val mockContentResolver = mock(android.content.ContentResolver::class.java)
         `when`(context.contentResolver).thenReturn(mockContentResolver)
-
         val clipDataStaticMock = mockStatic(android.content.ClipData::class.java)
         try {
             val mockClipData = mock(android.content.ClipData::class.java)
             clipDataStaticMock.`when`<android.content.ClipData> { android.content.ClipData.newUri(any(), anyString(), any()) }.thenReturn(mockClipData)
-
             helper.sharePost(
                 _postId = "123",
                 author = "John Doe",
@@ -227,24 +192,20 @@ class PostShareHelperTest {
                 imagePaths = listOf("image1.jpg", "image2.jpg")
             )
             testDispatcher.scheduler.advanceUntilIdle()
-
             val intentCaptor = ArgumentCaptor.forClass(Intent::class.java)
             verify(context).startActivity(intentCaptor.capture())
-
-            val targetIntent = intentCaptor.value.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+            val targetIntent = IntentCompat.getParcelableExtra(intentCaptor.value, Intent.EXTRA_INTENT, Intent::class.java)
             assertNotNull(targetIntent)
             assertEquals(Intent.ACTION_SEND_MULTIPLE, targetIntent?.action)
             assertEquals("image/*", targetIntent?.type)
             assertTrue((targetIntent?.flags ?: 0) and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
-
-            val streams = targetIntent?.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+            val streams = targetIntent?.let { IntentCompat.getParcelableArrayListExtra(it, Intent.EXTRA_STREAM, Uri::class.java) }
             assertNotNull(streams)
             assertEquals(2, streams?.size)
         } finally {
             clipDataStaticMock.close()
         }
     }
-
     @Test
     fun testSharePostMissingBaseUrl() = runTest {
         val helperNoUrl = PostShareHelper(
@@ -253,7 +214,6 @@ class PostShareHelperTest {
             sessionCookieProvider = { "session=1234" },
             serverNameProvider = { "my server" }
         )
-
         helperNoUrl.sharePost(
             _postId = "123",
             author = "John Doe",
@@ -261,36 +221,29 @@ class PostShareHelperTest {
             imagePaths = listOf("image1.jpg")
         )
         testDispatcher.scheduler.advanceUntilIdle()
-
         val intentCaptor = ArgumentCaptor.forClass(Intent::class.java)
         verify(context).startActivity(intentCaptor.capture())
-
-        val targetIntent = intentCaptor.value.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        val targetIntent = IntentCompat.getParcelableExtra(intentCaptor.value, Intent.EXTRA_INTENT, Intent::class.java)
         assertNotNull(targetIntent)
-        // Since URL is missing, images aren't downloaded, and it falls back to text/plain
         assertEquals(Intent.ACTION_SEND, targetIntent?.action)
         assertEquals("text/plain", targetIntent?.type)
-        assertNull(targetIntent?.getParcelableExtra<Uri>(Intent.EXTRA_STREAM))
+        assertNull(targetIntent?.let { IntentCompat.getParcelableExtra(it, Intent.EXTRA_STREAM, Uri::class.java) })
     }
-
     @Test
     fun testSharePostMissingCookie() = runTest {
         mockWebServer.enqueue(MockResponse().setBody("image content").setResponseCode(200))
         val mockContentResolver = mock(android.content.ContentResolver::class.java)
         `when`(context.contentResolver).thenReturn(mockContentResolver)
-
         val clipDataStaticMock = mockStatic(android.content.ClipData::class.java)
         try {
             val mockClipData = mock(android.content.ClipData::class.java)
             clipDataStaticMock.`when`<android.content.ClipData> { android.content.ClipData.newUri(any(), anyString(), any()) }.thenReturn(mockClipData)
-
             val helperNoCookie = PostShareHelper(
                 context = context,
                 baseUrlProvider = { mockWebServer.url("/").toString() },
                 sessionCookieProvider = { null },
                 serverNameProvider = { "my server" }
             )
-
             helperNoCookie.sharePost(
                 _postId = "123",
                 author = "John Doe",
@@ -298,25 +251,20 @@ class PostShareHelperTest {
                 imagePaths = listOf("image1.jpg")
             )
             testDispatcher.scheduler.advanceUntilIdle()
-
             val intentCaptor = ArgumentCaptor.forClass(Intent::class.java)
             verify(context).startActivity(intentCaptor.capture())
-
-            val targetIntent = intentCaptor.value.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+            val targetIntent = IntentCompat.getParcelableExtra(intentCaptor.value, Intent.EXTRA_INTENT, Intent::class.java)
             assertNotNull(targetIntent)
-            // Image still downloads even without a cookie header if server doesn't reject it
             assertEquals(Intent.ACTION_SEND, targetIntent?.action)
             assertEquals("image/*", targetIntent?.type)
-            assertNotNull(targetIntent?.getParcelableExtra<Uri>(Intent.EXTRA_STREAM))
+            assertNotNull(targetIntent?.let { IntentCompat.getParcelableExtra(it, Intent.EXTRA_STREAM, Uri::class.java) })
         } finally {
             clipDataStaticMock.close()
         }
     }
-
     @Test
     fun testSharePostNetworkError() = runTest {
         mockWebServer.enqueue(MockResponse().setResponseCode(500))
-
         helper.sharePost(
             _postId = "123",
             author = "John Doe",
@@ -324,16 +272,12 @@ class PostShareHelperTest {
             imagePaths = listOf("image1.jpg")
         )
         testDispatcher.scheduler.advanceUntilIdle()
-
         val intentCaptor = ArgumentCaptor.forClass(Intent::class.java)
         verify(context).startActivity(intentCaptor.capture())
-
-        val targetIntent = intentCaptor.value.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        val targetIntent = IntentCompat.getParcelableExtra(intentCaptor.value, Intent.EXTRA_INTENT, Intent::class.java)
         assertNotNull(targetIntent)
-        // Server returned 500, so image download failed. Falls back to text/plain.
         assertEquals(Intent.ACTION_SEND, targetIntent?.action)
         assertEquals("text/plain", targetIntent?.type)
-        assertNull(targetIntent?.getParcelableExtra<Uri>(Intent.EXTRA_STREAM))
+        assertNull(targetIntent?.let { IntentCompat.getParcelableExtra(it, Intent.EXTRA_STREAM, Uri::class.java) })
     }
-
 }


### PR DESCRIPTION
This change resolves several deprecation warnings in `PostShareHelperTest.kt` and `CourseWizardActivity.kt` by using `androidx.core.content.IntentCompat` for intent data retrieval. This ensures compatibility with modern Android versions (API 33+) while maintaining support for older versions. Additionally, the modified Kotlin files have been refactored to follow the project's "compressed" style (no unnecessary blank lines, sorted imports).

---
*PR created automatically by Jules for task [6458885660091125480](https://jules.google.com/task/6458885660091125480) started by @PlataformasInformaticas*