### PR TITLE
⚡ Optimize team member count fetching in TeamsFragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 62
-        versionName = "0.0.62"
+        versionCode = 63
+        versionName = "0.0.63"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/TeamsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/TeamsFragment.kt
@@ -185,14 +185,10 @@ class TeamsFragment : Fragment(R.layout.fragment_dashboard_teams) {
                 return@launch
             }
 
-            memberTeams.forEach { team ->
-                val id = team.id
-                if (!id.isNullOrBlank()) {
-                    val countResult = repository.fetchMemberCount(base, credentials, sessionCookie, id)
-                    countResult.getOrNull()?.let { count ->
-                        memberCounts[id] = count
-                    }
-                }
+            val memberTeamIds = memberTeams.mapNotNull { it.id }.filter { it.isNotBlank() }
+            val memberCountsResult = repository.fetchMemberCounts(base, credentials, sessionCookie, memberTeamIds)
+            memberCountsResult.getOrNull()?.let { counts ->
+                memberCounts.putAll(counts)
             }
 
             val availableLoaded = fetchAvailableTeamsPage(reset = true)
@@ -256,14 +252,10 @@ class TeamsFragment : Fragment(R.layout.fragment_dashboard_teams) {
 
         availableTeams.addAll(newTeams)
 
-        newTeams.forEach { team ->
-            val id = team.id
-            if (!id.isNullOrBlank()) {
-                val countResult = repository.fetchMemberCount(base, credentials, sessionCookie, id)
-                countResult.getOrNull()?.let { count ->
-                    memberCounts[id] = count
-                }
-            }
+        val newTeamIds = newTeams.mapNotNull { it.id }.filter { it.isNotBlank() }
+        val newCountsResult = repository.fetchMemberCounts(base, credentials, sessionCookie, newTeamIds)
+        newCountsResult.getOrNull()?.let { counts ->
+            memberCounts.putAll(counts)
         }
 
         renderTeams(memberTeams, availableTeams, memberCounts)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -75,6 +75,8 @@ class DashboardTeamsRepository {
     private val memberCountResponseAdapter = moshi.adapter(MemberCountFindResponse::class.java)
     private val teamsRequestAdapter = moshi.adapter(TeamsFindRequest::class.java)
     private val teamsResponseAdapter = moshi.adapter(TeamsFindResponse::class.java)
+    private val bulkMemberCountRequestAdapter = moshi.adapter(BulkMemberCountFindRequest::class.java)
+    private val bulkMemberCountResponseAdapter = moshi.adapter(BulkMemberCountFindResponse::class.java)
     private val availableTeamsRequestAdapter = moshi.adapter(NonMemberTeamsFindRequest::class.java)
     private val joinRequestFindAdapter = moshi.adapter(JoinRequestFindRequest::class.java)
     private val joinRequestFindResponseAdapter = moshi.adapter(JoinRequestFindResponse::class.java)
@@ -118,6 +120,70 @@ class DashboardTeamsRepository {
                         throw IOException("User not found")
                     }
                     users.first()
+                }
+            }
+        }
+    }
+
+    suspend fun fetchMemberCounts(
+        baseUrl: String,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        teamIds: List<String>
+    ): Result<Map<String, Int>> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                val normalizedBase = baseUrl.trim().trimEnd('/')
+                if (normalizedBase.isEmpty()) {
+                    throw IOException("Missing server base URL")
+                }
+                if (teamIds.isEmpty()) {
+                    return@runCatching emptyMap()
+                }
+
+                val selector = BulkMemberCountSelector(
+                    teamId = TeamIdInClause(ids = teamIds),
+                    docType = "membership",
+                    status = StatusClause(
+                        or = listOf(
+                            StatusCondition(exists = false),
+                            StatusCondition(notEquals = "archived")
+                        )
+                    )
+                )
+                val payload = bulkMemberCountRequestAdapter.toJson(
+                    BulkMemberCountFindRequest(
+                        selector = selector,
+                        fields = listOf("_id", "teamId"),
+                        limit = 50000
+                    )
+                )
+                val requestBuilder = Request.Builder()
+                    .url("$normalizedBase/db/teams/_find")
+                    .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+                credentials?.let {
+                    requestBuilder.addHeader("Authorization", Credentials.basic(it.username, it.password))
+                }
+                sessionCookie.nullIfBlank()?.let { cookie ->
+                    requestBuilder.addHeader("Cookie", cookie)
+                }
+
+                client.newCall(requestBuilder.build()).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IOException("Unexpected response ${response.code}")
+                    }
+                    val body = response.body?.string() ?: throw IOException("Empty response body")
+                    val docs = bulkMemberCountResponseAdapter.fromJson(body)?.docs ?: emptyList()
+
+                    val counts = mutableMapOf<String, Int>()
+                    teamIds.forEach { counts[it] = 0 }
+
+                    docs.forEach { doc ->
+                        doc.teamId?.let { tid ->
+                            counts[tid] = (counts[tid] ?: 0) + 1
+                        }
+                    }
+                    counts
                 }
             }
         }
@@ -902,6 +968,34 @@ class DashboardTeamsRepository {
 
     @JsonClass(generateAdapter = true)
     data class MemberCountFindResponse(val docs: List<MemberIdDocument>?)
+
+    @JsonClass(generateAdapter = true)
+    data class BulkMemberCountFindRequest(
+        val selector: BulkMemberCountSelector,
+        val fields: List<String>,
+        val limit: Int? = null
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class BulkMemberCountSelector(
+        @param:Json(name = "teamId") val teamId: TeamIdInClause,
+        val docType: String,
+        val status: StatusClause
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class TeamIdInClause(
+        @param:Json(name = "\$in") val ids: List<String>
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class MemberDocWithTeamId(
+        @param:Json(name = "_id") val id: String?,
+        val teamId: String?
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class BulkMemberCountFindResponse(val docs: List<MemberDocWithTeamId>?)
 
     @JsonClass(generateAdapter = true)
     data class MembershipDocument(

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryTest.kt
@@ -1,0 +1,125 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.lite.profile.StoredCredentials
+
+class DashboardTeamsRepositoryTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var repository: DashboardTeamsRepository
+    private val credentials = StoredCredentials("user", "pass")
+
+    @Before
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        repository = DashboardTeamsRepository()
+    }
+
+    @After
+    fun teardown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `fetchMemberCount returns correct count`() = runTest {
+        val teamId = "team123"
+        val responseBody = """
+            {
+                "docs": [
+                    { "_id": "member1" },
+                    { "_id": "member2" },
+                    { "_id": "member3" }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val result = repository.fetchMemberCount(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            teamId = teamId
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(3, result.getOrNull())
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/db/teams/_find", request.path)
+        val bodyStr = request.body.readUtf8()
+        assertTrue(bodyStr.contains("\"teamId\":\"$teamId\""))
+    }
+
+    @Test
+    fun `fetchMemberCounts returns correct counts map`() = runTest {
+        val teamIds = listOf("team1", "team2")
+        val responseBody = """
+            {
+                "docs": [
+                    { "_id": "m1", "teamId": "team1" },
+                    { "_id": "m2", "teamId": "team1" },
+                    { "_id": "m3", "teamId": "team2" }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val result = repository.fetchMemberCounts(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            teamIds = teamIds
+        )
+
+        assertTrue(result.isSuccess)
+        val counts = result.getOrNull()
+        assertNotNull(counts)
+        assertEquals(2, counts!!["team1"])
+        assertEquals(1, counts["team2"])
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/db/teams/_find", request.path)
+        val bodyStr = request.body.readUtf8()
+        assertTrue(bodyStr.contains("\"teamId\":{\"\$in\":[\"team1\",\"team2\"]}"))
+        assertTrue(bodyStr.contains("\"limit\":50000"))
+    }
+
+    @Test
+    fun `fetchMemberCounts returns empty map when teamIds is empty`() = runTest {
+        val result = repository.fetchMemberCounts(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            teamIds = emptyList()
+        )
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+        assertEquals(0, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun `fetchMemberCount returns failure on non-200 response`() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val result = repository.fetchMemberCount(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            teamId = "team123"
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IOException)
+    }
+}


### PR DESCRIPTION
### 💡 What:
Implemented a bulk fetch operation for team member counts in `DashboardTeamsRepository` and updated `TeamsFragment` to use it. This replaces multiple individual network requests with a single batched request.

### 🎯 Why:
The previous implementation fetched the member count for each team individually within a loop (`forEach`), leading to an N+1 query problem. This was inefficient, especially as the number of teams grew, causing multiple unnecessary network round-trips and potential UI lag.

### 📊 Measured Improvement:
While environment limitations prevented running a full benchmark, the optimization reduces the number of network requests from $O(N)$ to $O(1)$ per section (My Teams and Explore Teams). For a user with 25 teams, this reduces 25 requests to just 1, significantly improving loading speed and reducing server load.

The changes include:
- `fetchMemberCounts` in `DashboardTeamsRepository.kt` which retrieves all relevant membership documents in one call.
- Data classes for bulk request/response in CouchDB.
- Refactored `TeamsFragment.kt` to collect all team IDs and call the new bulk method.
- New unit tests in `DashboardTeamsRepositoryTest.kt` verifying the bulk fetch logic.

---
*PR created automatically by Jules for task [13825600809100695683](https://jules.google.com/task/13825600809100695683) started by @dogi*