### PR TITLE
🧪 Add tests for DashboardSurveyStatusStore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 66
-        versionName = "0.0.66"
+        versionCode = 76
+        versionName = "0.0.76"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyStatusStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyStatusStoreTest.kt
@@ -92,7 +92,7 @@ class DashboardSurveyStatusStoreTest {
         store.ensureNewDefaults(listOf("survey1", "survey2"))
 
         org.mockito.kotlin.verify(mockEditor).putString("survey1", "NEW")
-        org.mockito.kotlin.verify(mockEditor, org.mockito.kotlin.never()).putString("survey2", any())
+        org.mockito.kotlin.verify(mockEditor, org.mockito.kotlin.never()).putString(org.mockito.kotlin.eq("survey2"), any())
         org.mockito.kotlin.verify(mockEditor).apply()
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyStatusStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyStatusStoreTest.kt
@@ -1,0 +1,136 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class DashboardSurveyStatusStoreTest {
+
+    private lateinit var context: Context
+    private lateinit var mockPrefs: SharedPreferences
+    private lateinit var mockEditor: SharedPreferences.Editor
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        mockPrefs = mock()
+        mockEditor = mock()
+        whenever(mockPrefs.edit()).thenReturn(mockEditor)
+        whenever(mockEditor.putString(any(), any())).thenReturn(mockEditor)
+        SecurePreferencesProvider.injectedPreferences = mockPrefs
+    }
+
+    @After
+    fun tearDown() {
+        SecurePreferencesProvider.injectedPreferences = null
+    }
+
+    @org.junit.Test
+    fun `getStatus returns null when ID is null`() {
+        val store = DashboardSurveyStatusStore(context)
+        org.junit.Assert.assertNull(store.getStatus(null))
+    }
+
+    @org.junit.Test
+    fun `getStatus returns null when ID is blank`() {
+        val store = DashboardSurveyStatusStore(context)
+        org.junit.Assert.assertNull(store.getStatus("   "))
+    }
+
+    @org.junit.Test
+    fun `getStatus returns null when key not in prefs`() {
+        val store = DashboardSurveyStatusStore(context)
+        whenever(mockPrefs.getString("survey123", null)).thenReturn(null)
+        org.junit.Assert.assertNull(store.getStatus("survey123"))
+    }
+
+    @org.junit.Test
+    fun `getStatus returns NEW when stored in prefs`() {
+        val store = DashboardSurveyStatusStore(context)
+        whenever(mockPrefs.getString("survey123", null)).thenReturn("NEW")
+        org.junit.Assert.assertEquals(SurveyStatus.NEW, store.getStatus("survey123"))
+    }
+
+    @org.junit.Test
+    fun `getStatus returns null when invalid status stored`() {
+        val store = DashboardSurveyStatusStore(context)
+        whenever(mockPrefs.getString("survey123", null)).thenReturn("INVALID")
+        org.junit.Assert.assertNull(store.getStatus("survey123"))
+    }
+
+    @org.junit.Test
+    fun `getStatus with username uses namespaced key`() {
+        val store = DashboardSurveyStatusStore(context, "user1")
+        whenever(mockPrefs.getString("user1:survey123", null)).thenReturn("COMPLETED")
+        org.junit.Assert.assertEquals(SurveyStatus.COMPLETED, store.getStatus("survey123"))
+    }
+
+    @org.junit.Test
+    fun `ensureNewDefaults with empty list does nothing`() {
+        val store = DashboardSurveyStatusStore(context)
+        store.ensureNewDefaults(emptyList())
+        org.mockito.kotlin.verify(mockPrefs, org.mockito.kotlin.never()).edit()
+    }
+
+    @org.junit.Test
+    fun `ensureNewDefaults sets NEW for missing keys`() {
+        val store = DashboardSurveyStatusStore(context)
+        whenever(mockPrefs.contains("survey1")).thenReturn(false)
+        whenever(mockPrefs.contains("survey2")).thenReturn(true)
+
+        store.ensureNewDefaults(listOf("survey1", "survey2"))
+
+        org.mockito.kotlin.verify(mockEditor).putString("survey1", "NEW")
+        org.mockito.kotlin.verify(mockEditor, org.mockito.kotlin.never()).putString("survey2", any())
+        org.mockito.kotlin.verify(mockEditor).apply()
+    }
+
+    @org.junit.Test
+    fun `ensureNewDefaults with username uses namespaced keys`() {
+        val store = DashboardSurveyStatusStore(context, "user1")
+        whenever(mockPrefs.contains("user1:survey1")).thenReturn(false)
+
+        store.ensureNewDefaults(listOf("survey1"))
+
+        org.mockito.kotlin.verify(mockEditor).putString("user1:survey1", "NEW")
+        org.mockito.kotlin.verify(mockEditor).apply()
+    }
+
+    @org.junit.Test
+    fun `markViewed sets status to VIEWED`() {
+        val store = DashboardSurveyStatusStore(context)
+        store.markViewed("survey123")
+
+        org.mockito.kotlin.verify(mockEditor).putString("survey123", "VIEWED")
+        org.mockito.kotlin.verify(mockEditor).apply()
+    }
+
+    @org.junit.Test
+    fun `markCompleted sets status to COMPLETED`() {
+        val store = DashboardSurveyStatusStore(context)
+        store.markCompleted("survey123")
+
+        org.mockito.kotlin.verify(mockEditor).putString("survey123", "COMPLETED")
+        org.mockito.kotlin.verify(mockEditor).apply()
+    }
+
+    @org.junit.Test
+    fun `markViewed with username uses namespaced key`() {
+        val store = DashboardSurveyStatusStore(context, "user1")
+        store.markViewed("survey123")
+
+        org.mockito.kotlin.verify(mockEditor).putString("user1:survey123", "VIEWED")
+        org.mockito.kotlin.verify(mockEditor).apply()
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `DashboardSurveyStatusStore` class.

### 🎯 What:
Addressed the missing test coverage for `DashboardSurveyStatusStore`, which manages survey statuses (NEW, VIEWED, COMPLETED) in `SharedPreferences`.

### 📊 Coverage:
The new `DashboardSurveyStatusStoreTest` covers:
- **`getStatus`**:
    - Returns `null` for null or blank IDs.
    - Returns `null` when the key does not exist in preferences.
    - Returns the correct `SurveyStatus` enum when a valid value is stored.
    - Returns `null` (graceful failure) when an invalid string is stored in preferences.
    - Correctly handles namespacing when a `username` is provided.
- **`ensureNewDefaults`**:
    - Skips processing for empty lists.
    - Sets `NEW` status only for keys that do not already exist in preferences.
    - Correctly uses namespaced keys.
- **`markViewed` / `markCompleted`**:
    - Correctly updates preferences with the expected status string.
    - Correctly uses namespaced keys.

### ✨ Result:
Increased reliability and test coverage for the dashboard survey functionality. The tests use standard project patterns (Robolectric + Mockito) and include proper cleanup to avoid side effects on other tests. Fixed a Mockito matcher issue found during verification.

---
*PR created automatically by Jules for task [2205673809679576246](https://jules.google.com/task/2205673809679576246) started by @dogi*