### PR TITLE
🧪 test: add edge case tests for GenderTranslator out of bounds scenarios

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 80
+        versionName = "0.0.80"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/GenderTranslatorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/GenderTranslatorTest.kt
@@ -69,6 +69,13 @@ class GenderTranslatorTest {
     }
 
     @Test
+    fun testToEnglish_IndexOutOfBoundsReturnsNull() {
+        // Mock a situation where the localized array has more elements than the English array
+        whenever(resources.getStringArray(R.array.signup_gender_options_language_es)).thenReturn(arrayOf("Masculino", "Femenino", "Otro"))
+        assertNull(GenderTranslator.toEnglish(context, "Otro"))
+    }
+
+    @Test
     fun testToLocalized_FromEnglish() {
         assertEquals("Masculino", GenderTranslator.toLocalized(context, "Male", R.array.signup_gender_options_language_es))
         assertEquals("Féminin", GenderTranslator.toLocalized(context, "Female", R.array.signup_gender_options_language_fr))
@@ -100,5 +107,13 @@ class GenderTranslatorTest {
         assertNull(GenderTranslator.toLocalized(context, null, R.array.signup_gender_options_language_es))
         assertNull(GenderTranslator.toLocalized(context, "", R.array.signup_gender_options_language_fr))
         assertNull(GenderTranslator.toLocalized(context, "   ", R.array.signup_gender_options_language_en))
+    }
+
+    @Test
+    fun testToLocalized_IndexOutOfBoundsReturnsEnglishValue() {
+        // Mock a situation where the target array has fewer elements than the English array
+        whenever(resources.getStringArray(R.array.signup_gender_options_language_en)).thenReturn(arrayOf("Male", "Female", "Other"))
+        whenever(resources.getStringArray(R.array.signup_gender_options_language_es)).thenReturn(arrayOf("Masculino", "Femenino"))
+        assertEquals("Other", GenderTranslator.toLocalized(context, "Other", R.array.signup_gender_options_language_es))
     }
 }


### PR DESCRIPTION
🎯 **What:** This PR adds two missing edge cases to `GenderTranslatorTest.kt` to cover out-of-bounds indices when parsing strings against localized and english translation arrays.
📊 **Coverage:** Specifically added coverage for:
1. When translating to English and the localized array has more elements than the English array.
2. When translating to localized values and the English array has more elements than the specific localized array.
✨ **Result:** Improved robustness by confirming the logic in `GenderTranslator` returns the expected nulls or fallback strings safely instead of throwing `IndexOutOfBoundsException`s in these unexpected mismatch situations.

---
*PR created automatically by Jules for task [14737377209810699845](https://jules.google.com/task/14737377209810699845) started by @dogi*