### PR TITLE
🧪 [test] Improve test coverage and map HTTP error paths in AuthService

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 81
+        versionName = "0.0.81"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -950,6 +950,14 @@ class MyPlanetLite : AppCompatActivity() {
                 errorText.text = errorMessage
                 errorText.isVisible = true
             }
+            is AuthResult.Failure.InvalidCredentials -> {
+                errorText.text = getString(R.string.login_invalid_credentials)
+                errorText.isVisible = true
+            }
+            is AuthResult.Failure.NetworkError -> {
+                errorText.text = getString(R.string.login_generic_error)
+                errorText.isVisible = true
+            }
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/auth/AuthService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/auth/AuthService.kt
@@ -17,6 +17,10 @@ import retrofit2.HttpException
 sealed class AuthResult {
     data class Success(val response: LoginResponse) : AuthResult()
     data class Error(val code: Int?, val message: String) : AuthResult()
+    sealed class Failure : AuthResult() {
+        object InvalidCredentials : Failure()
+        data class NetworkError(val http: HttpException) : Failure()
+    }
 }
 interface AuthService {
     suspend fun login(usernameOrEmail: String, password: String): AuthResult
@@ -58,7 +62,11 @@ class NetworkAuthService(
                 AuthResult.Error(response.code(), errorMessage)
             }
         } catch (http: HttpException) {
-            AuthResult.Error(http.code(), http.message())
+            if (http.code() == 401 || http.code() == 404) {
+                AuthResult.Failure.InvalidCredentials
+            } else {
+                AuthResult.Failure.NetworkError(http)
+            }
         } catch (io: IOException) {
             AuthResult.Error(null, "Error de red: ${io.localizedMessage ?: io.message}")
         } catch (e: CancellationException) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -394,7 +394,7 @@ class ProfileActivity : AppCompatActivity() {
                         username = loginResult.response.name ?: storedCredentials.username
                     }
                 }
-                is AuthResult.Error -> Unit
+                is AuthResult.Error, is AuthResult.Failure -> Unit
             }
         }
 
@@ -430,7 +430,7 @@ class ProfileActivity : AppCompatActivity() {
                     sessionCookie = loginResult.response.sessionCookie ?: sessionCookie
                 }
 
-                is AuthResult.Error -> {
+                is AuthResult.Error, is AuthResult.Failure -> {
                     if (sessionCookie.isNullOrBlank()) {
                         return false
                     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -160,13 +160,83 @@ class NetworkAuthServiceTest {
             500,
             "Internal Server Error".toResponseBody("text/plain".toMediaType())
         )
+        val httpException = HttpException(errorResponse)
+        whenever(mockApi.login(any())).thenThrow(httpException)
+
+        val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
+        val result = serviceWithMockApi.login("user", "pass")
+
+        assertTrue(result is AuthResult.Failure.NetworkError)
+        val error = result as AuthResult.Failure.NetworkError
+        assertEquals(httpException, error.http)
+    }
+
+    @Test
+    fun `login http exception 401 returns error`() = runTest {
+        val mockApi = mock<AuthApi>()
+        val errorResponse = Response.error<LoginResponse>(
+            401,
+            "Unauthorized".toResponseBody("text/plain".toMediaType())
+        )
         whenever(mockApi.login(any())).thenThrow(HttpException(errorResponse))
+
+        val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
+        val result = serviceWithMockApi.login("user", "pass")
+
+        assertEquals(AuthResult.Failure.InvalidCredentials, result)
+    }
+
+    @Test
+    fun `login http exception 404 returns error`() = runTest {
+        val mockApi = mock<AuthApi>()
+        val errorResponse = Response.error<LoginResponse>(
+            404,
+            "Not Found".toResponseBody("text/plain".toMediaType())
+        )
+        whenever(mockApi.login(any())).thenThrow(HttpException(errorResponse))
+
+        val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
+        val result = serviceWithMockApi.login("user", "pass")
+
+        assertEquals(AuthResult.Failure.InvalidCredentials, result)
+    }
+
+    @Test
+    fun `login io exception returns network error`() = runTest {
+        val mockApi = mock<AuthApi>()
+        val ioException = java.io.IOException("Custom IO error")
+        whenever(mockApi.login(any())).thenAnswer { throw ioException }
 
         val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
         val result = serviceWithMockApi.login("user", "pass")
 
         assertTrue(result is AuthResult.Error)
         val error = result as AuthResult.Error
-        assertEquals(500, error.code)
+        assertEquals(null, error.code)
+        assertTrue(error.message.contains("Error de red: Custom IO error"))
+    }
+
+    @Test(expected = kotlinx.coroutines.CancellationException::class)
+    fun `login cancellation exception is rethrown`() = runTest {
+        val mockApi = mock<AuthApi>()
+        whenever(mockApi.login(any())).thenThrow(kotlinx.coroutines.CancellationException("Cancelled"))
+
+        val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
+        serviceWithMockApi.login("user", "pass")
+    }
+
+    @Test
+    fun `login unexpected exception returns generic error`() = runTest {
+        val mockApi = mock<AuthApi>()
+        val unexpectedException = RuntimeException("Something bad happened")
+        whenever(mockApi.login(any())).thenThrow(unexpectedException)
+
+        val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
+        val result = serviceWithMockApi.login("user", "pass")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(null, error.code)
+        assertTrue(error.message.contains("Error inesperado: Something bad happened"))
     }
 }


### PR DESCRIPTION
🎯 **What:** The `AuthService.kt` missing error path mappings were implemented. It now correctly maps HTTP 401 and HTTP 404 to `AuthResult.Failure.InvalidCredentials`. The `AuthResult.Failure` subclasses were created, and the cascading impacts on `ProfileActivity` and `MyPlanetLite` `when` statements were handled to ensure exhaustive checking.
  
📊 **Coverage:** Test coverage was expanded in `NetworkAuthServiceTest.kt` to cover the new `HttpException` paths (401 and 404), as well as generic `IOException`, `CancellationException`, and unexpected `RuntimeException`.
  
✨ **Result:** A significant improvement in the robustness of network error handling in `AuthService`, ensuring that invalid credentials mapping and edge case failures are fully tested and protected against regressions.

---
*PR created automatically by Jules for task [17295971842150764265](https://jules.google.com/task/17295971842150764265) started by @dogi*