### PR TITLE
🧪 Add edge case tests for StringExtensions.nullIfBlank

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 86
+        versionName = "0.0.86"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/StringExtensionsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/StringExtensionsTest.kt
@@ -36,4 +36,29 @@ class StringExtensionsTest {
     fun `nullIfBlank returns string when string has surrounding whitespace`() {
         assertEquals(" hello ", " hello ".nullIfBlank())
     }
+
+    @Test
+    fun `nullIfBlank returns null when string contains only tabs`() {
+        assertEquals(null, "\t\t".nullIfBlank())
+    }
+
+    @Test
+    fun `nullIfBlank returns null when string contains only newlines`() {
+        assertEquals(null, "\n\n".nullIfBlank())
+    }
+
+    @Test
+    fun `nullIfBlank returns null when string contains only carriage returns`() {
+        assertEquals(null, "\r\r".nullIfBlank())
+    }
+
+    @Test
+    fun `nullIfBlank returns null when string contains non-breaking spaces`() {
+        assertEquals(null, "\u00A0".nullIfBlank())
+    }
+
+    @Test
+    fun `nullIfBlank returns string when string contains whitespace in the middle`() {
+        assertEquals("a b", "a b".nullIfBlank())
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `StringExtensionsTest.kt` for the `nullIfBlank()` extension function was addressed. Previously, it tested basic strings, empty strings, and space-only strings, but omitted other whitespace variations.

📊 **Coverage:**
- Tests were added for tab-only (`"\t\t"`) strings.
- Tests were added for newline-only (`"\n\n"`) strings.
- Tests were added for carriage-return-only (`"\r\r"`) strings.
- Tests were added for strings containing non-breaking spaces (`"\u00A0"`).
- Tests were added for a standard string containing whitespace in the middle (`"a b"`).

✨ **Result:** Test coverage is now complete for all major whitespace-character edge cases, ensuring `nullIfBlank()` correctly handles all scenarios defined as 'blank' by Kotlin on the JVM.

---
*PR created automatically by Jules for task [17555304370329714321](https://jules.google.com/task/17555304370329714321) started by @dogi*