### PR TITLE
🧹 Refactor `configureLogin` in MyPlanetLite.kt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 88
+        versionName = "0.0.88"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,14 +32,17 @@
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
-
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
                 <data
                     android:host="midominio.com"
                     android:pathPrefix="/post"
                     android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:host="post"
                     android:scheme="myplanetlite" />

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -309,10 +309,14 @@ class MyPlanetLite : AppCompatActivity() {
     }
 
     private fun configureLogin() {
-        val usernameLayout: TextInputLayout = findViewById(R.id.usernameInputLayout)
-        val passwordLayout: TextInputLayout = findViewById(R.id.passwordInputLayout)
-        val serverLayout: TextInputLayout = serverInputLayoutView
-        val serverInput: MaterialAutoCompleteTextView = serverAutoCompleteView
+        initializeLoginViews()
+        setupRememberMeCheckbox()
+        setupServerDropdown()
+        setupLoginButton()
+        maybeRestoreSessionOrAutoLogin()
+    }
+
+    private fun initializeLoginViews() {
         loginButtonView = findViewById(R.id.loginButton)
         rememberMeCheckBox = findViewById(R.id.rememberCheckBox)
         loginErrorTextView = findViewById(R.id.errorText)
@@ -321,11 +325,13 @@ class MyPlanetLite : AppCompatActivity() {
         updateLoginButtonAvailability()
 
         serverAdapter = ServerOptionAdapter(this)
-        serverInput.setAdapter(serverAdapter)
-        serverLayout.setStartIconTintList(null)
+        serverAutoCompleteView.setAdapter(serverAdapter)
+        serverInputLayoutView.setStartIconTintList(null)
 
-        refreshServerOptions(serverInput, serverLayout)
+        refreshServerOptions(serverAutoCompleteView, serverInputLayoutView)
+    }
 
+    private fun setupRememberMeCheckbox() {
         val rememberedCredentials = loadRememberedCredentials()
         applyRememberedCredentials(rememberedCredentials)
 
@@ -349,57 +355,64 @@ class MyPlanetLite : AppCompatActivity() {
                 }
             }
         }
+    }
 
-        serverInput.setOnClickListener {
-            serverInput.showDropDownWhenSafe()
+    private fun setupServerDropdown() {
+        serverAutoCompleteView.setOnClickListener {
+            serverAutoCompleteView.showDropDownWhenSafe()
         }
-        serverInput.setOnFocusChangeListener { _, hasFocus ->
+        serverAutoCompleteView.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                serverInput.showDropDownWhenSafe()
+                serverAutoCompleteView.showDropDownWhenSafe()
             }
         }
-        serverInput.setOnItemClickListener { _, _, position, _ ->
+        serverAutoCompleteView.setOnItemClickListener { _, _, position, _ ->
             val selected = serverAdapter.getItem(position) ?: return@setOnItemClickListener
             if (selected.isAction) {
                 when (selected.actionType) {
                     ServerAction.CONFIGURE -> {
                         val previousConfig = loadServerConfiguration()
-                        serverInput.setText(previousConfig.displayName, false)
-                        serverInput.tag = previousConfig.baseUrl
-                        updateServerFlag(serverLayout, previousConfig.countryCode)
+                        serverAutoCompleteView.setText(previousConfig.displayName, false)
+                        serverAutoCompleteView.tag = previousConfig.baseUrl
+                        updateServerFlag(serverInputLayoutView, previousConfig.countryCode)
                         updateServerStatusIcon(previousConfig.baseUrl)
-                        serverInput.dismissDropDown()
-                        showServerConfigurationDialog(serverInput, serverLayout)
+                        serverAutoCompleteView.dismissDropDown()
+                        showServerConfigurationDialog(serverAutoCompleteView, serverInputLayoutView)
                     }
                     ServerAction.CLEAR -> {
                         clearCustomServers()
-                        refreshServerOptions(serverInput, serverLayout)
-                        serverInput.dismissDropDown()
+                        refreshServerOptions(serverAutoCompleteView, serverInputLayoutView)
+                        serverAutoCompleteView.dismissDropDown()
                     }
                     null -> {
-                        serverInput.dismissDropDown()
+                        serverAutoCompleteView.dismissDropDown()
                     }
                 }
             } else {
-                serverInput.setText(selected.displayName, false)
-                serverInput.tag = selected.baseUrl
-                updateServerFlag(serverLayout, selected.countryCode)
+                serverAutoCompleteView.setText(selected.displayName, false)
+                serverAutoCompleteView.tag = selected.baseUrl
+                updateServerFlag(serverInputLayoutView, selected.countryCode)
                 saveServerConfiguration(selected.baseUrl, selected.countryCode, selected.displayName)
                 updateServerStatusIcon(selected.baseUrl)
-                serverInput.dismissDropDown()
+                serverAutoCompleteView.dismissDropDown()
             }
         }
-        serverInput.keyListener = null
+        serverAutoCompleteView.keyListener = null
+    }
+
+    private fun setupLoginButton() {
+        val usernameLayout: TextInputLayout = findViewById(R.id.usernameInputLayout)
+        val passwordLayout: TextInputLayout = findViewById(R.id.passwordInputLayout)
 
         loginButtonView.setOnClickListener {
             usernameLayout.error = null
             passwordLayout.error = null
-            serverLayout.error = null
+            serverInputLayoutView.error = null
             loginErrorTextView.isVisible = false
 
             val username = loginUsernameInput.text?.toString()?.trim().orEmpty()
             val password = loginPasswordInput.text?.toString().orEmpty()
-            val serverBaseUrl = (serverInput.tag as? String).orEmpty().trim()
+            val serverBaseUrl = (serverAutoCompleteView.tag as? String).orEmpty().trim()
 
             var hasError = false
             if (username.isEmpty()) {
@@ -411,7 +424,7 @@ class MyPlanetLite : AppCompatActivity() {
                 hasError = true
             }
             if (serverBaseUrl.isEmpty()) {
-                serverLayout.error = getString(R.string.login_server_error)
+                serverInputLayoutView.error = getString(R.string.login_server_error)
                 hasError = true
             }
             if (hasError) return@setOnClickListener
@@ -436,8 +449,6 @@ class MyPlanetLite : AppCompatActivity() {
                 }
             }
         }
-
-        maybeRestoreSessionOrAutoLogin()
     }
 
     private fun ensureSurveyTranslationConsent(onConsentGranted: () -> Unit) {


### PR DESCRIPTION
🎯 **What:** 
- Refactored the monolithic `configureLogin` method in `MyPlanetLite.kt` into smaller, focused helper methods (`initializeLoginViews`, `setupRememberMeCheckbox`, `setupServerDropdown`, `setupLoginButton`).
- Fixed a related AndroidManifest.xml lint error where intent filters for custom schemas were mixed with web schemas.

💡 **Why:** 
- The `configureLogin` method was over 130 lines long, making it difficult to read and maintain. By splitting it up, the responsibility of each setup phase is clearer. 
- The manifest fix resolves a standard AppLink lint warning that occurs when combining `http(s)` schemes with custom schemes in the same `intent-filter` under `autoVerify="true"`.

✅ **Verification:** 
- All code compiles successfully.
- Executed `./gradlew lint testDebugUnitTest`, and verified tests pass and lint checks are satisfied. 
- Conducted manual inspection to ensure the UI setup logic accurately reflects the original code.

✨ **Result:** 
- Improved maintainability and modularity within `MyPlanetLite.kt`.
- Improved static analysis compliance.

---
*PR created automatically by Jules for task [11786299849391517779](https://jules.google.com/task/11786299849391517779) started by @dogi*