### PR TITLE
🧹 [Refactoring] Extract logic from MyPlanetLite onCreate

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 90
+        versionName = "0.0.90"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -166,9 +166,29 @@ class MyPlanetLite : AppCompatActivity() {
         applyDeviceOrientationLock()
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
+
+        setupWindowState()
+        initializeState(savedInstanceState)
+
+        val logoImageView: ImageView = findViewById(R.id.logoImageView)
+        val appVersionTextView: TextView = findViewById(R.id.appVersionTextView)
+        val loginScroll: ScrollView = findViewById(R.id.loginScroll)
+
+        setupViews(logoImageView, appVersionTextView, loginScroll)
+        setupWindowInsets(logoImageView, appVersionTextView, loginScroll)
+
+        World.init(applicationContext)
+
+        configureLogin()
+    }
+
+    private fun setupWindowState() {
         @Suppress("DEPRECATION")
         window.statusBarColor = ContextCompat.getColor(this, R.color.white)
         WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
+    }
+
+    private fun initializeState(savedInstanceState: Bundle?) {
         ProfileCredentialsStore.setSessionCredentials(null)
         clearStoredSessionIfNotRemembered()
         autoLoginEnabled = intent?.getBooleanExtra(EXTRA_ALLOW_AUTO_LOGIN, false) == true
@@ -187,17 +207,20 @@ class MyPlanetLite : AppCompatActivity() {
                 }
             }
         }
+    }
 
-        val logoImageView: ImageView = findViewById(R.id.logoImageView)
+    private fun setupViews(
+        logoImageView: ImageView,
+        appVersionTextView: TextView,
+        loginScroll: ScrollView
+    ) {
         val languageSelectorIcon: ImageView = findViewById(R.id.languageSelectorIcon)
         serverInputLayoutView = findViewById(R.id.serverInputLayout)
         serverAutoCompleteView = findViewById(R.id.serverUrlInput)
         loginUsernameInput = findViewById(R.id.usernameInput)
         loginPasswordInput = findViewById(R.id.passwordInput)
         serverStatusIconView = findViewById(R.id.serverStatusIcon)
-        val appVersionTextView: TextView = findViewById(R.id.appVersionTextView)
         val poweredByTextView: TextView = findViewById(R.id.poweredByText)
-        val loginScroll: ScrollView = findViewById(R.id.loginScroll)
         signupPromptView = findViewById(R.id.signupPrompt)
         signupButtonView = findViewById(R.id.signupButton)
         privacyPolicyPromptView = findViewById(R.id.privacyPolicyPrompt)
@@ -239,12 +262,14 @@ class MyPlanetLite : AppCompatActivity() {
             (resources.displayMetrics.density * APP_VERSION_SHRUNK_BOTTOM_MARGIN_DP).roundToInt()
         shrunkLoginScrollPaddingTopPx =
             (resources.displayMetrics.density * LOGIN_SCROLL_SHRUNK_PADDING_TOP_DP).roundToInt()
+
         logoImageView.doOnLayout {
             if (originalLogoWidth == 0 || originalLogoHeight == 0) {
                 originalLogoWidth = it.width
                 originalLogoHeight = it.height
             }
         }
+
         appVersionTextView.doOnLayout {
             if (originalAppVersionBottomMargin == 0) {
                 val params = it.layoutParams as? ViewGroup.MarginLayoutParams
@@ -256,6 +281,17 @@ class MyPlanetLite : AppCompatActivity() {
                 originalLoginScrollPaddingTop = it.paddingTop
             }
         }
+
+        languageSelectorIcon.setOnClickListener {
+            LanguagePreferences.showLanguageSelectionDialog(this)
+        }
+    }
+
+    private fun setupWindowInsets(
+        logoImageView: ImageView,
+        appVersionTextView: TextView,
+        loginScroll: ScrollView
+    ) {
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
@@ -272,14 +308,6 @@ class MyPlanetLite : AppCompatActivity() {
 
             insets
         }
-
-        languageSelectorIcon.setOnClickListener {
-            LanguagePreferences.showLanguageSelectionDialog(this)
-        }
-
-        World.init(applicationContext)
-
-        configureLogin()
     }
 
     private fun launchDashboard() {


### PR DESCRIPTION
🎯 **What:** Extracted the massive block of inline code in `MyPlanetLite.kt`'s `onCreate` function into several scoped, private helper methods (`setupWindowState`, `initializeState`, `setupViews`, and `setupWindowInsets`).

💡 **Why:** `onCreate` was over a hundred lines long, handling everything from configuring view dimensions and inline click listeners, to window state, inset handling, and credential management. Breaking this down into smaller helper functions adheres to the Single Responsibility Principle and significantly improves readability and maintainability.

✅ **Verification:** Verified locally via `git diff` that the correct statements were extracted, ran `./gradlew lint` to verify no new regressions were introduced, and executed `./gradlew testDebugUnitTest` which passed. Finally requested a code review to verify code correctness.

✨ **Result:** A clean, easy-to-read `onCreate` function that highlights the top-level lifecycle execution path without bogging down the reader in inline implementation details.

---
*PR created automatically by Jules for task [2367567198697850687](https://jules.google.com/task/2367567198697850687) started by @dogi*