### PR TITLE
🧹 Refactor translateSurvey function in SurveyTranslationManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 91
+        versionName = "0.0.91"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
@@ -24,6 +24,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
 import org.ole.planet.myplanet.lite.dashboard.ServerConfigurationRepository
 
 class SurveyTranslationManager(
@@ -73,7 +74,40 @@ class SurveyTranslationManager(
             return SurveyTranslationResult(sourceLanguage, null, null, emptyMap())
         }
 
-        val translations = mutableMapOf<Int, TranslatedQuestion>()
+        val (translatedTitle, translatedDescription) = translateSurveyMetadata(
+            survey = survey,
+            cachedTitle = cachedTitle,
+            cachedDescription = cachedDescription,
+            cacheSurveyId = cacheSurveyId,
+            normalizedTargetLanguage = normalizedTargetLanguage,
+            sourceLanguage = sourceLanguage,
+            openAiKey = openAiKey,
+            openAiModel = openAiModel,
+        )
+
+        val translations = translateSurveyQuestionList(
+            questions = survey.questions.orEmpty(),
+            cachedQuestionTranslations = cachedQuestionTranslations,
+            cacheSurveyId = cacheSurveyId,
+            normalizedTargetLanguage = normalizedTargetLanguage,
+            sourceLanguage = sourceLanguage,
+            openAiKey = openAiKey,
+            openAiModel = openAiModel,
+        )
+
+        return SurveyTranslationResult(sourceLanguage, translatedTitle, translatedDescription, translations)
+    }
+
+    private suspend fun translateSurveyMetadata(
+        survey: SurveyDocument,
+        cachedTitle: String?,
+        cachedDescription: String?,
+        cacheSurveyId: String?,
+        normalizedTargetLanguage: String,
+        sourceLanguage: String,
+        openAiKey: String,
+        openAiModel: String,
+    ): Pair<String?, String?> {
         val translatedTitle = survey.name?.let { title ->
             cachedTitle ?: translationClient.translate(
                 text = title,
@@ -110,7 +144,20 @@ class SurveyTranslationManager(
                 )
             }
         }
-        survey.questions.orEmpty().forEachIndexed { index, question ->
+        return Pair(translatedTitle, translatedDescription)
+    }
+
+    private suspend fun translateSurveyQuestionList(
+        questions: List<SurveyQuestion>,
+        cachedQuestionTranslations: Map<Int, TranslatedQuestion>,
+        cacheSurveyId: String?,
+        normalizedTargetLanguage: String,
+        sourceLanguage: String,
+        openAiKey: String,
+        openAiModel: String,
+    ): Map<Int, TranslatedQuestion> {
+        val translations = mutableMapOf<Int, TranslatedQuestion>()
+        questions.forEachIndexed { index, question ->
             val cached = cachedQuestionTranslations[index]
             val translatedBody: String?
             val translatedChoices: List<String?>
@@ -155,8 +202,7 @@ class SurveyTranslationManager(
                 )
             }
         }
-
-        return SurveyTranslationResult(sourceLanguage, translatedTitle, translatedDescription, translations)
+        return translations
     }
 
     suspend fun translateQuestion(


### PR DESCRIPTION
🎯 **What:** Extracted logic from the overly long `translateSurvey` function in `SurveyTranslationManager.kt` into smaller, private helper functions (`translateSurveyMetadata` and `translateSurveyQuestionList`).

💡 **Why:** The original method was over 100 lines and handled multiple concerns (metadata translation, question list mapping, cache interaction). Splitting these makes the code significantly more readable and maintainable.

✅ **Verification:**
- Ran full test suite (`./gradlew testDebugUnitTest`) to ensure no logical regressions occurred. All tests passed.
- Linted the codebase (`./gradlew lintDebug`); the remaining issues were unrelated baseline warnings.

✨ **Result:** Improved code readability and maintainability within `SurveyTranslationManager`.

---
*PR created automatically by Jules for task [5332145273912674680](https://jules.google.com/task/5332145273912674680) started by @dogi*