### PR TITLE
🧪 Add SecurePreferencesProviderTest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 92
+        versionName = "0.0.92"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -1,0 +1,154 @@
+package org.ole.planet.myplanet.lite.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.mockConstruction
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+
+class SecurePreferencesProviderTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockPrefs: SharedPreferences
+
+    @Before
+    fun setup() {
+        mockContext = mock(Context::class.java)
+        `when`(mockContext.applicationContext).thenReturn(mockContext)
+        mockPrefs = mock(SharedPreferences::class.java)
+
+        // reset instance
+        val instanceField = SecurePreferencesProvider::class.java.getDeclaredField("instance")
+        instanceField.isAccessible = true
+        instanceField.set(SecurePreferencesProvider, null)
+    }
+
+    @After
+    fun teardown() {
+        SecurePreferencesProvider.injectedPreferences = null
+        val instanceField = SecurePreferencesProvider::class.java.getDeclaredField("instance")
+        instanceField.isAccessible = true
+        instanceField.set(SecurePreferencesProvider, null)
+    }
+
+    @Test
+    fun `getServerPreferences returns injectedPreferences when set`() {
+        SecurePreferencesProvider.injectedPreferences = mockPrefs
+        val result = SecurePreferencesProvider.getServerPreferences(mockContext)
+        assertEquals(mockPrefs, result)
+    }
+
+    @Test
+    fun `getServerPreferences returns instance when already created`() {
+        val instanceField = SecurePreferencesProvider::class.java.getDeclaredField("instance")
+        instanceField.isAccessible = true
+        instanceField.set(SecurePreferencesProvider, mockPrefs)
+
+        val result = SecurePreferencesProvider.getServerPreferences(mockContext)
+        assertEquals(mockPrefs, result)
+    }
+
+    @Test
+    fun `getServerPreferences creates EncryptedSharedPreferences when instance is null`() {
+        val legacyPrefs = mock(SharedPreferences::class.java)
+        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE)).thenReturn(legacyPrefs)
+        `when`(legacyPrefs.all).thenReturn(emptyMap<String, Any?>())
+
+        val mockMasterKey = mock(MasterKey::class.java)
+
+        val encryptedPrefsStatic = mockStatic(EncryptedSharedPreferences::class.java)
+
+        try {
+            encryptedPrefsStatic.`when`<SharedPreferences> {
+                EncryptedSharedPreferences.create(
+                    eq(mockContext),
+                    eq("encrypted_server_preferences"),
+                    any(),
+                    any(),
+                    any()
+                )
+            }.thenReturn(mockPrefs)
+
+            mockConstruction(MasterKey.Builder::class.java) { mock, context ->
+                `when`(mock.setKeyScheme(any())).thenReturn(mock)
+                `when`(mock.build()).thenReturn(mockMasterKey)
+            }.use { builderMock ->
+                val result = SecurePreferencesProvider.getServerPreferences(mockContext)
+                assertEquals(mockPrefs, result)
+            }
+        } finally {
+            encryptedPrefsStatic.close()
+        }
+    }
+
+    @Test
+    fun `migrateLegacyPreferences migrates data and clears legacy prefs`() {
+        val mockLegacyPrefs = mock(SharedPreferences::class.java)
+        val mockLegacyEditor = mock(SharedPreferences.Editor::class.java)
+
+        val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+        val mockEncryptedEditor = mock(SharedPreferences.Editor::class.java)
+
+        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
+            .thenReturn(mockLegacyPrefs)
+
+        val legacyData = mapOf<String, Any?>(
+            "string_key" to "value",
+            "int_key" to 42,
+            "bool_key" to true,
+            "float_key" to 3.14f,
+            "long_key" to 100L,
+            "set_key" to setOf("a", "b")
+        )
+
+        `when`(mockLegacyPrefs.all).thenReturn(legacyData)
+        `when`(mockLegacyPrefs.edit()).thenReturn(mockLegacyEditor)
+        `when`(mockLegacyEditor.clear()).thenReturn(mockLegacyEditor)
+
+        `when`(mockEncryptedPrefs.edit()).thenReturn(mockEncryptedEditor)
+
+        val method = SecurePreferencesProvider::class.java.getDeclaredMethod("migrateLegacyPreferences", Context::class.java, SharedPreferences::class.java)
+        method.isAccessible = true
+        method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs)
+
+        verify(mockEncryptedEditor).putString("string_key", "value")
+        verify(mockEncryptedEditor).putInt("int_key", 42)
+        verify(mockEncryptedEditor).putBoolean("bool_key", true)
+        verify(mockEncryptedEditor).putFloat("float_key", 3.14f)
+        verify(mockEncryptedEditor).putLong("long_key", 100L)
+        verify(mockEncryptedEditor).putStringSet("set_key", setOf("a", "b"))
+        verify(mockEncryptedEditor).apply()
+
+        verify(mockLegacyEditor).clear()
+        verify(mockLegacyEditor).apply()
+    }
+
+    @Test
+    fun `migrateLegacyPreferences does nothing when legacy prefs are empty`() {
+        val mockLegacyPrefs = mock(SharedPreferences::class.java)
+        val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+
+        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
+            .thenReturn(mockLegacyPrefs)
+
+        `when`(mockLegacyPrefs.all).thenReturn(emptyMap<String, Any?>())
+
+        val method = SecurePreferencesProvider::class.java.getDeclaredMethod("migrateLegacyPreferences", Context::class.java, SharedPreferences::class.java)
+        method.isAccessible = true
+        method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs)
+
+        // Verify that edit() was never called on either prefs
+        verify(mockEncryptedPrefs, org.mockito.Mockito.never()).edit()
+        verify(mockLegacyPrefs, org.mockito.Mockito.never()).edit()
+    }
+}


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for `SecurePreferencesProvider` which was previously untested. The rationale specifically states this was missing due to the complexity of mocking `Context` and `EncryptedSharedPreferences`.

📊 **Coverage:**
- Tests retrieving pre-existing injected preferences (`getServerPreferences returns injectedPreferences when set`).
- Tests retrieving an already-initialized instance using reflection (`getServerPreferences returns instance when already created`).
- Tests the first-time creation logic using `mockStatic` and `mockConstruction` to intercept the creation of `EncryptedSharedPreferences` and `MasterKey.Builder`, successfully bypassing Android Keystore limitations while verifying the proper `SharedPreferences` instantiation path.
- Tests the migration from legacy `SharedPreferences` to the encrypted ones (`migrateLegacyPreferences migrates data and clears legacy prefs`).
- Tests that migration is bypassed if no legacy keys exist (`migrateLegacyPreferences does nothing when legacy prefs are empty`).

✨ **Result:** Comprehensive test coverage of the sensitive properties initialization logic, ensuring caching, migration, and proper `EncryptedSharedPreferences` setups are validated automatically.

---
*PR created automatically by Jules for task [10118285735987876635](https://jules.google.com/task/10118285735987876635) started by @dogi*