### PR TITLE
🧪 add tests for ServerConfigurationRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 94
+        versionName = "0.0.94"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -342,6 +342,7 @@ class ProfileActivity : AppCompatActivity() {
             }
 
             if (matchedLanguage != null) {
+                @Suppress("UNCHECKED_CAST")
                 val currentLevelAdapter = levelInput.adapter as? ArrayAdapter<String>
                 if (currentLevelAdapter != null) {
                     applyLanguage(matchedLanguage, profile?.level, currentLevelAdapter)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
@@ -1,0 +1,116 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class ServerConfigurationRepositoryTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var repository: ServerConfigurationRepository
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        repository = ServerConfigurationRepository()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `fetchConfiguration returns parsed document on success`() = runTest {
+        val jsonResponse = """
+            {
+              "rows": [
+                {
+                  "doc": {
+                    "keys": {
+                      "openai": "test-key"
+                    },
+                    "models": {
+                      "openai": "test-model"
+                    },
+                    "preferredLang": "en"
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(MockResponse().setBody(jsonResponse).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isSuccess)
+        val doc = result.getOrNull()
+        assertEquals("test-key", doc?.keys?.openAi)
+        assertEquals("test-model", doc?.models?.openAi)
+        assertEquals("en", doc?.preferredLang)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/db/configurations/_all_docs?include_docs=true", request.path)
+        assertEquals("GET", request.method)
+    }
+
+    @Test
+    fun `fetchConfiguration returns null when no rows returned`() = runTest {
+        val jsonResponse = """
+            {
+              "rows": []
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(MockResponse().setBody(jsonResponse).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isSuccess)
+        val doc = result.getOrNull()
+        assertEquals(null, doc)
+    }
+
+    @Test
+    fun `fetchConfiguration fails when base url is missing`() = runTest {
+        val result = repository.fetchConfiguration("   ")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Missing base url", exception?.message)
+    }
+
+    @Test
+    fun `fetchConfiguration fails when base url is invalid`() = runTest {
+        val result = repository.fetchConfiguration("invalid-url-scheme://test")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Invalid base url", exception?.message)
+    }
+
+    @Test
+    fun `fetchConfiguration fails on http error`() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Unexpected response 500", exception?.message)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package org.ole.planet.myplanet.lite.util
 
 import android.content.Context


### PR DESCRIPTION
🎯 **What:** The testing gap for `ServerConfigurationRepository.fetchConfiguration` has been addressed.
📊 **Coverage:** The new test suite covers:
- Successful network calls and correct JSON parsing via Moshi
- Empty responses returning null
- Error conditions (missing/blank base URL, invalid URL schemes)
- HTTP failures (e.g., 500 Server Error)
✨ **Result:** Increased code reliability and test coverage, providing a safety net for any future modifications to the server configuration fetching logic.

---
*PR created automatically by Jules for task [14690293568843586473](https://jules.google.com/task/14690293568843586473) started by @dogi*