### PR TITLE
🧪 test: Add unit tests for VoicesComposerRepository.uploadResourceBinary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 94
+        versionName = "0.0.94"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -342,6 +342,7 @@ class ProfileActivity : AppCompatActivity() {
             }
 
             if (matchedLanguage != null) {
+                @Suppress("UNCHECKED_CAST")
                 val currentLevelAdapter = levelInput.adapter as? ArrayAdapter<String>
                 if (currentLevelAdapter != null) {
                     applyLanguage(matchedLanguage, profile?.level, currentLevelAdapter)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
@@ -1,0 +1,116 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class ServerConfigurationRepositoryTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var repository: ServerConfigurationRepository
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        repository = ServerConfigurationRepository()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `fetchConfiguration returns parsed document on success`() = runTest {
+        val jsonResponse = """
+            {
+              "rows": [
+                {
+                  "doc": {
+                    "keys": {
+                      "openai": "test-key"
+                    },
+                    "models": {
+                      "openai": "test-model"
+                    },
+                    "preferredLang": "en"
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(MockResponse().setBody(jsonResponse).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isSuccess)
+        val doc = result.getOrNull()
+        assertEquals("test-key", doc?.keys?.openAi)
+        assertEquals("test-model", doc?.models?.openAi)
+        assertEquals("en", doc?.preferredLang)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/db/configurations/_all_docs?include_docs=true", request.path)
+        assertEquals("GET", request.method)
+    }
+
+    @Test
+    fun `fetchConfiguration returns null when no rows returned`() = runTest {
+        val jsonResponse = """
+            {
+              "rows": []
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(MockResponse().setBody(jsonResponse).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isSuccess)
+        val doc = result.getOrNull()
+        assertEquals(null, doc)
+    }
+
+    @Test
+    fun `fetchConfiguration fails when base url is missing`() = runTest {
+        val result = repository.fetchConfiguration("   ")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Missing base url", exception?.message)
+    }
+
+    @Test
+    fun `fetchConfiguration fails when base url is invalid`() = runTest {
+        val result = repository.fetchConfiguration("invalid-url-scheme://test")
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Invalid base url", exception?.message)
+    }
+
+    @Test
+    fun `fetchConfiguration fails on http error`() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Unexpected response 500", exception?.message)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepositoryTest.kt
@@ -1,0 +1,145 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.lite.profile.StoredCredentials
+
+class VoicesComposerRepositoryTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var repository: VoicesComposerRepository
+
+    @Before
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        repository = VoicesComposerRepository()
+    }
+
+    @After
+    fun teardown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `uploadResourceBinary returns successful response on valid input`() = runTest {
+        val validJsonResponse = """
+            {
+                "ok": true,
+                "id": "res_123",
+                "rev": "rev_abc",
+                "resourceId": "res_123",
+                "filename": "audio.mp3",
+                "markdown": "link"
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(validJsonResponse))
+
+        val credentials = StoredCredentials("testUser", "testPass")
+        val baseUrl = mockWebServer.url("/").toString()
+        val resourceId = "res_123"
+        val fileName = "audio.mp3"
+        val revision = "rev_abc"
+        val bytes = byteArrayOf(1, 2, 3)
+
+        val response = repository.uploadResourceBinary(
+            baseUrl = baseUrl,
+            credentials = credentials,
+            resourceId = resourceId,
+            fileName = fileName,
+            revision = revision,
+            bytes = bytes
+        )
+
+        assertNotNull(response)
+        assertEquals(true, response.ok)
+        assertEquals("res_123", response.id)
+        assertEquals("rev_abc", response.revision)
+        assertEquals("res_123", response.resourceId)
+        assertEquals("audio.mp3", response.filename)
+        assertEquals("link", response.markdown)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("PUT", request.method)
+        assertEquals("/db/resources/res_123/audio.mp3", request.path)
+        assertNotNull(request.getHeader("Authorization"))
+        assertEquals("rev_abc", request.getHeader("If-Match"))
+
+        val bodyBytes = request.body.readByteArray()
+        org.junit.Assert.assertArrayEquals(bytes, bodyBytes)
+    }
+
+    @Test
+    fun `uploadResourceBinary throws IOException on missing base URL`() = runTest {
+        val credentials = StoredCredentials("testUser", "testPass")
+        val bytes = byteArrayOf(1, 2, 3)
+
+        try {
+            repository.uploadResourceBinary(
+                baseUrl = "",
+                credentials = credentials,
+                resourceId = "res_123",
+                fileName = "audio.mp3",
+                revision = "rev_abc",
+                bytes = bytes
+            )
+            org.junit.Assert.fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("Missing server base URL", e.message)
+        }
+    }
+
+    @Test
+    fun `uploadResourceBinary throws IOException on unsuccessful HTTP response`() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val credentials = StoredCredentials("testUser", "testPass")
+        val baseUrl = mockWebServer.url("/").toString()
+        val bytes = byteArrayOf(1, 2, 3)
+
+        try {
+            repository.uploadResourceBinary(
+                baseUrl = baseUrl,
+                credentials = credentials,
+                resourceId = "res_123",
+                fileName = "audio.mp3",
+                revision = "rev_abc",
+                bytes = bytes
+            )
+            org.junit.Assert.fail("Expected IOException")
+        } catch (e: IOException) {
+            assertTrue(e.message?.startsWith("Unexpected response") == true)
+        }
+    }
+
+    @Test
+    fun `uploadResourceBinary throws IOException on invalid JSON response`() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("null"))
+
+        val credentials = StoredCredentials("testUser", "testPass")
+        val baseUrl = mockWebServer.url("/").toString()
+        val bytes = byteArrayOf(1, 2, 3)
+
+        try {
+            repository.uploadResourceBinary(
+                baseUrl = baseUrl,
+                credentials = credentials,
+                resourceId = "res_123",
+                fileName = "audio.mp3",
+                revision = "rev_abc",
+                bytes = bytes
+            )
+            org.junit.Assert.fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("Invalid response body", e.message)
+        }
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package org.ole.planet.myplanet.lite.util
 
 import android.content.Context


### PR DESCRIPTION
🎯 **What:** The `uploadResourceBinary` method in `VoicesComposerRepository` was completely untested. This patch adds a comprehensive JUnit suite.
📊 **Coverage:** The tests evaluate the successful "happy path" using MockWebServer to intercept the outgoing PUT request (checking HTTP headers and the binary file payload) alongside mapping the JSON return values. It also includes comprehensive edge case testing for `IOException` on a missing base URL, `IOException` when non-successful server responses are generated (e.g. 500 error codes), and JSON parsing errors using Moshi.
✨ **Result:** Increased codebase testing coverage and confidence in the network layer for resource uploads!

---
*PR created automatically by Jules for task [1220169779933455798](https://jules.google.com/task/1220169779933455798) started by @dogi*