### PR TITLE
🧪 Add missing unit tests for UserProfileDatabase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 78
-        versionName = "0.0.78"
+        versionCode = 96
+        versionName = "0.0.96"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseTest.kt
@@ -109,6 +109,39 @@ class UserProfileDatabaseTest {
         assertNull(database.getProfile())
     }
 
+
+    @Test
+    fun `test save and get profile with null fields`() {
+        val profile = UserProfile(
+            username = "nulluser",
+            firstName = null,
+            middleName = null,
+            lastName = null,
+            email = null,
+            language = null,
+            phoneNumber = null,
+            birthDate = null,
+            gender = null,
+            level = null,
+            avatarImage = null,
+            revision = null,
+            derivedKey = null,
+            rawDocument = null,
+            isUserAdmin = false
+        )
+        database.saveProfile(profile)
+        val retrieved = database.getProfile()
+        assertEquals(profile, retrieved)
+    }
+
+
+    @Test
+    fun `test getInstance returns singleton`() {
+        val instance1 = UserProfileDatabase.getInstance(context)
+        val instance2 = UserProfileDatabase.getInstance(context)
+        assertTrue(instance1 === instance2)
+    }
+
     @Test
     fun `test onUpgrade from old versions`() {
         val mockDb = mock(SQLiteDatabase::class.java)


### PR DESCRIPTION
🎯 **What:** The testing gap in `UserProfileDatabase` wasn't fully covering edge cases like inserting profiles with null values and testing its singleton instance initialization.
📊 **Coverage:** Now the saving and retrieving of profiles with `null` fields are fully covered, and `UserProfileDatabase.getInstance()` returns a singleton object is covered.
✨ **Result:** Improved test coverage for `UserProfileDatabase` that assures no NPEs and ensures the expected singleton pattern behavior.

---
*PR created automatically by Jules for task [15855110670422601615](https://jules.google.com/task/15855110670422601615) started by @dogi*