### PR TITLE
🔒 Fix Unsafe Exported Component intent filtering and validation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 97
-        versionName = "0.0.97"
+        versionCode = 98
+        versionName = "0.0.98"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 96
-        versionName = "0.0.96"
+        versionCode = 97
+        versionName = "0.0.97"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,13 @@
                     android:host="midominio.com"
                     android:pathPrefix="/post"
                     android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
                     android:host="post"
                     android:scheme="myplanetlite" />

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
@@ -3,13 +3,15 @@ package org.ole.planet.myplanet.lite.util
 import android.content.Intent
 
 object IntentUtils {
+    private val ID_PATTERN = Regex("^[a-zA-Z0-9_\\-:@.]+$")
+
     fun extractDeepLinkPostId(intent: Intent?): String? {
         if (intent?.action != Intent.ACTION_VIEW) {
             return null
         }
         val data = intent.data ?: return null
         val queryPostId = data.getQueryParameter("postId")
-        if (!queryPostId.isNullOrBlank()) {
+        if (!queryPostId.isNullOrBlank() && queryPostId.matches(ID_PATTERN)) {
             return queryPostId
         }
         val segments = data.pathSegments
@@ -23,6 +25,7 @@ object IntentUtils {
             postIndex >= 0 && postIndex + 1 < segments.size -> segments[postIndex + 1]
             else -> segments.last()
         }
-        return candidate.takeIf { it.isNotBlank() }
+        val id = candidate.takeIf { it.isNotBlank() }
+        return if (id != null && id.matches(ID_PATTERN)) id else null
     }
 }


### PR DESCRIPTION
- 🎯 **What:** Deep links processing lacked input validation on CouchDB database lookup ID (`postId`) and intent filters for deep links merged http(s) schemes and custom schemes.
- ⚠️ **Risk:** An attacker could exploit the custom scheme mixed with standard intent-filters or leverage the extracted `postId` into downstream operations without sanitization (e.g., path traversal or injections).
- 🛡️ **Solution:** Split the intent-filter block into two separate intent filters in the Android Manifest to prevent App Links merging vulnerabilities. Updated `IntentUtils.kt` to validate the extracted `postId` using a strict regex whitelist.

---
*PR created automatically by Jules for task [15579892604200305633](https://jules.google.com/task/15579892604200305633) started by @dogi*