### PR TITLE
suppress unchecked cast and deprecation warnings

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -342,6 +342,7 @@ class ProfileActivity : AppCompatActivity() {
             }
 
             if (matchedLanguage != null) {
+                @Suppress("UNCHECKED_CAST")
                 val currentLevelAdapter = levelInput.adapter as? ArrayAdapter<String>
                 if (currentLevelAdapter != null) {
                     applyLanguage(matchedLanguage, profile?.level, currentLevelAdapter)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package org.ole.planet.myplanet.lite.util
 
 import android.content.Context


### PR DESCRIPTION
Suppressed unavoidable unchecked cast warning in ProfileActivity.kt and silenced deprecation warnings in SecurePreferencesProviderTest.kt to clean up build output.

---
*PR created automatically by Jules for task [18313666831521784379](https://jules.google.com/task/18313666831521784379) started by @PlataformasInformaticas*