### PR TITLE
all: smoother importing (fixes #324)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 101
-        versionName = "0.1.01"
+        versionCode = 102
+        versionName = "0.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/OfflineCourseStorageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/OfflineCourseStorageTest.kt
@@ -1,13 +1,13 @@
 package org.ole.planet.myplanet.lite
 
 import android.content.Context
+import java.io.File
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import java.io.File
+import org.mockito.Mockito.mock
 
 class OfflineCourseStorageTest {
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SignupActivityExceptionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SignupActivityExceptionTest.kt
@@ -1,34 +1,33 @@
 package org.ole.planet.myplanet.lite
 
+import android.content.SharedPreferences
 import android.os.Looper
-import androidx.test.core.app.ApplicationProvider
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.jvm.isAccessible
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import kotlinx.coroutines.test.runTest
-import okhttp3.MediaType.Companion.toMediaType
-import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
-import android.content.SharedPreferences
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.async
-import kotlin.reflect.full.callSuspend
-import kotlin.reflect.full.memberFunctions
-import kotlin.reflect.jvm.isAccessible
-import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.MockResponse
-import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.lite.dashboard
 
+import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -8,7 +9,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.IOException
 
 class ServerConfigurationRepositoryTest {
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileSyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileSyncTest.kt
@@ -1,5 +1,6 @@
 package org.ole.planet.myplanet.lite.profile
 
+import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.Dispatcher
@@ -14,7 +15,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.IOException
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DateUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DateUtilsTest.kt
@@ -1,8 +1,8 @@
 package org.ole.planet.myplanet.lite.util
 
+import android.os.Build
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import android.os.Build
 
 class DateUtilsTest {
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -6,16 +6,16 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.Assert.assertEquals
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.mockStatic
-import org.mockito.Mockito.mockConstruction
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockConstruction
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
 
 class SecurePreferencesProviderTest {
 


### PR DESCRIPTION
This PR formats the import statements across all Kotlin files. It ensures they are alphabetically sorted, expands any catchalls, and removes unused ones, while preserving necessary imports like Mockito's `when`. It also enforces exactly one empty line before and after the import blocks.

---
*PR created automatically by Jules for task [603244677748089087](https://jules.google.com/task/603244677748089087) started by @dogi*