### PR TITLE
🧪 Add missing unit tests for ServerConfigurationRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 101
-        versionName = "0.1.01"
+        versionCode = 106
+        versionName = "0.1.06"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConfigurationRepositoryTest.kt
@@ -113,4 +113,88 @@ class ServerConfigurationRepositoryTest {
         assertTrue(exception is IOException)
         assertEquals("Unexpected response 500", exception?.message)
     }
+
+    @Test
+    fun `fetchConfiguration fails when base url is null`() = runTest {
+        val result = repository.fetchConfiguration(null)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Missing base url", exception?.message)
+    }
+
+    @Test
+    fun `fetchConfiguration normalizes base url`() = runTest {
+        val jsonResponse = "{\"rows\": []}"
+        mockWebServer.enqueue(MockResponse().setBody(jsonResponse).setResponseCode(200))
+
+        val baseUrl = "  " + mockWebServer.url("/").toString() + "///  "
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isSuccess)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/db/configurations/_all_docs?include_docs=true", request.path)
+    }
+
+    @Test
+    fun `fetchConfiguration ignores rows with null doc`() = runTest {
+        val jsonResponse = """
+            {
+              "rows": [
+                {
+                  "doc": null
+                },
+                {
+                  "doc": {
+                    "keys": {
+                      "openai": "test-key-2"
+                    }
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(MockResponse().setBody(jsonResponse).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isSuccess)
+        val doc = result.getOrNull()
+        assertEquals("test-key-2", doc?.keys?.openAi)
+    }
+
+    @Test
+    fun `fetchConfiguration fails when json is malformed`() = runTest {
+        val malformedJson = "{ malformed json "
+        mockWebServer.enqueue(MockResponse().setBody(malformedJson).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val result = repository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is com.squareup.moshi.JsonDataException || exception is java.io.EOFException || exception is com.squareup.moshi.JsonEncodingException)
+    }
+
+    @Test
+    fun `fetchConfiguration fails on network exception`() = runTest {
+        val errorClient = okhttp3.OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                throw IOException("Network error")
+            }
+            .build()
+        val errorRepository = ServerConfigurationRepository(client = errorClient)
+
+        val baseUrl = "http://localhost:8080"
+        val result = errorRepository.fetchConfiguration(baseUrl)
+
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertTrue(exception is IOException)
+        assertEquals("Network error", exception?.message)
+    }
 }


### PR DESCRIPTION
🎯 **What**: The testing gap addressed was the lack of edge-case tests in `ServerConfigurationRepositoryTest.kt` for `ServerConfigurationRepository`.

📊 **Coverage**: The scenarios now tested include:
1. When the `baseUrl` parameter is explicitly null.
2. Handling of base URLs with extraneous spaces and slashes (normalization).
3. Ignoring missing documents gracefully within the parsed JSON rows.
4. Proper handling of malformed JSON with corresponding Moshi exceptions.
5. Handling network-layer exceptions like connectivity errors.

✨ **Result**: `ServerConfigurationRepository` logic is now much better covered by test paths, adding reliability and catching previously unverified error conditions.

---
*PR created automatically by Jules for task [16148405863928370359](https://jules.google.com/task/16148405863928370359) started by @dogi*