### PR TITLE
🧪 Add missing tests for team selection clearing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 106
-        versionName = "0.1.06"
+        versionCode = 109
+        versionName = "0.1.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamSelectionPreferencesTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamSelectionPreferencesTest.kt
@@ -49,6 +49,12 @@ class DashboardTeamSelectionPreferencesTest {
     }
 
     @Test
+    fun `getSelectedTeamId returns null when saved id is empty`() {
+        mockPrefs.edit().putString("selected_team_id", "").apply()
+        assertNull(DashboardTeamSelectionPreferences.getSelectedTeamId(mockContext))
+    }
+
+    @Test
     fun `getSelectedTeamName returns null when nothing is saved`() {
         assertNull(DashboardTeamSelectionPreferences.getSelectedTeamName(mockContext))
     }
@@ -62,6 +68,12 @@ class DashboardTeamSelectionPreferencesTest {
     @Test
     fun `getSelectedTeamName returns null when saved name is blank`() {
         mockPrefs.edit().putString("selected_team_name", "   ").apply()
+        assertNull(DashboardTeamSelectionPreferences.getSelectedTeamName(mockContext))
+    }
+
+    @Test
+    fun `getSelectedTeamName returns null when saved name is empty`() {
+        mockPrefs.edit().putString("selected_team_name", "").apply()
         assertNull(DashboardTeamSelectionPreferences.getSelectedTeamName(mockContext))
     }
 
@@ -99,6 +111,19 @@ class DashboardTeamSelectionPreferencesTest {
     }
 
     @Test
+    fun `setSelectedTeam clears both when id is empty`() {
+        mockPrefs.edit()
+            .putString("selected_team_id", "team-123")
+            .putString("selected_team_name", "Team Alpha")
+            .apply()
+
+        DashboardTeamSelectionPreferences.setSelectedTeam(mockContext, "", "Some Name")
+
+        assertNull(mockPrefs.getString("selected_team_id", null))
+        assertNull(mockPrefs.getString("selected_team_name", null))
+    }
+
+    @Test
     fun `setSelectedTeam saves id but clears name when name is null`() {
         mockPrefs.edit()
             .putString("selected_team_id", "team-123")
@@ -119,6 +144,19 @@ class DashboardTeamSelectionPreferencesTest {
             .apply()
 
         DashboardTeamSelectionPreferences.setSelectedTeam(mockContext, "team-456", "   ")
+
+        assertEquals("team-456", mockPrefs.getString("selected_team_id", null))
+        assertNull(mockPrefs.getString("selected_team_name", null))
+    }
+
+    @Test
+    fun `setSelectedTeam saves id but clears name when name is empty`() {
+        mockPrefs.edit()
+            .putString("selected_team_id", "team-123")
+            .putString("selected_team_name", "Team Alpha")
+            .apply()
+
+        DashboardTeamSelectionPreferences.setSelectedTeam(mockContext, "team-456", "")
 
         assertEquals("team-456", mockPrefs.getString("selected_team_id", null))
         assertNull(mockPrefs.getString("selected_team_name", null))


### PR DESCRIPTION
🎯 **What:** Added tests to cover the untested clearing of team selection when `teamId` or `teamName` are empty strings (`""`), mapping to the `isNullOrBlank()` condition in `DashboardTeamSelectionPreferences.kt`.
📊 **Coverage:** Added four new tests: `getSelectedTeamId returns null when saved id is empty`, `getSelectedTeamName returns null when saved name is empty`, `setSelectedTeam clears both when id is empty`, and `setSelectedTeam saves id but clears name when name is empty`.
✨ **Result:** Improved test coverage by explicitly testing empty string boundary cases for clearing preferences, providing better safety and predictability.

---
*PR created automatically by Jules for task [17137893964788213631](https://jules.google.com/task/17137893964788213631) started by @dogi*