### PR TITLE
🧪 Refactor and test DashboardTeamSelectionPreferences clearing logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 120
-        versionName = "0.1.20"
+        versionCode = 124
+        versionName = "0.1.24"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamSelectionPreferences.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamSelectionPreferences.kt
@@ -25,19 +25,26 @@ object DashboardTeamSelectionPreferences {
     }
 
     fun setSelectedTeam(context: Context, teamId: String?, teamName: String?) {
+        if (teamId.isNullOrBlank()) {
+            clearSelectedTeam(context)
+            return
+        }
         val prefs = SecurePreferencesProvider.getServerPreferences(context.applicationContext)
         prefs.edit().apply {
-            if (teamId.isNullOrBlank()) {
-                remove(KEY_SELECTED_TEAM_ID)
+            putString(KEY_SELECTED_TEAM_ID, teamId)
+            if (teamName.isNullOrBlank()) {
                 remove(KEY_SELECTED_TEAM_NAME)
             } else {
-                putString(KEY_SELECTED_TEAM_ID, teamId)
-                if (teamName.isNullOrBlank()) {
-                    remove(KEY_SELECTED_TEAM_NAME)
-                } else {
-                    putString(KEY_SELECTED_TEAM_NAME, teamName)
-                }
+                putString(KEY_SELECTED_TEAM_NAME, teamName)
             }
+        }.apply()
+    }
+
+    fun clearSelectedTeam(context: Context) {
+        val prefs = SecurePreferencesProvider.getServerPreferences(context.applicationContext)
+        prefs.edit().apply {
+            remove(KEY_SELECTED_TEAM_ID)
+            remove(KEY_SELECTED_TEAM_NAME)
         }.apply()
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamSelectionPreferencesTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamSelectionPreferencesTest.kt
@@ -124,6 +124,19 @@ class DashboardTeamSelectionPreferencesTest {
         assertNull(mockPrefs.getString("selected_team_name", null))
     }
 
+    @Test
+    fun `clearSelectedTeam clears both id and name`() {
+        mockPrefs.edit()
+            .putString("selected_team_id", "team-123")
+            .putString("selected_team_name", "Team Alpha")
+            .apply()
+
+        DashboardTeamSelectionPreferences.clearSelectedTeam(mockContext)
+
+        assertNull(mockPrefs.getString("selected_team_id", null))
+        assertNull(mockPrefs.getString("selected_team_name", null))
+    }
+
     // --- Fakes ---
 
     class FakeContext(private val prefs: SharedPreferences) : ContextWrapper(null) {


### PR DESCRIPTION
🎯 What: The implicit and untested behavior of clearing preferences by passing `null` or blank strings to `setSelectedTeam` was refactored into an explicit `clearSelectedTeam` method.
📊 Coverage: Added a dedicated test that explicitly verifies `clearSelectedTeam` successfully purges both `KEY_SELECTED_TEAM_ID` and `KEY_SELECTED_TEAM_NAME` from the underlying `SharedPreferences`.
✨ Result: The code intent is now clearer, and the explicit clearing operation is fully covered by unit tests, increasing the overall reliability of the team selection preferences logic.

---
*PR created automatically by Jules for task [6815017502910730411](https://jules.google.com/task/6815017502910730411) started by @dogi*