### PR TITLE
🐛 Fix blank middle name being saved as undefined (#365)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 120
-        versionName = "0.1.20"
+        versionCode = 121
+        versionName = "0.1.21"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -382,7 +382,7 @@ class ProfileActivity : AppCompatActivity() {
 
         return ProfileFormValues(
             firstName = firstNameInput.text?.toString()?.trim().nullIfBlank(),
-            middleName = middleNameInput.text?.toString()?.trim().nullIfBlank(),
+            middleName = middleNameInput.text?.toString()?.trim().orEmpty(),
             lastName = lastNameInput.text?.toString()?.trim().nullIfBlank(),
             email = emailInput.text?.toString()?.trim().nullIfBlank(),
             phoneNumber = phoneInput.text?.toString()?.trim().nullIfBlank(),
@@ -586,7 +586,7 @@ class ProfileActivity : AppCompatActivity() {
 
     private fun applyFormValuesToDocument(document: JSONObject, values: ProfileFormValues) {
         document.putOrRemove("firstName", values.firstName)
-        document.putOrRemove("middleName", values.middleName)
+        document.put("middleName", values.middleName.orEmpty())
         document.putOrRemove("lastName", values.lastName)
         document.putOrRemove("email", values.email)
         document.putOrRemove("phoneNumber", values.phoneNumber)


### PR DESCRIPTION
Update `ProfileActivity` to ensure the middle name is saved as an empty string rather than being removed from the JSON document when left blank. This prevents the field from appearing as undefined in the profile. Also increments the version to 0.1.21.