### PR TITLE
Refactor DashboardNewsActionsRepository to use constructor injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 127
+        versionName = "0.1.27"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsActionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsActionsRepository.kt
@@ -11,6 +11,7 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -18,12 +19,14 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
-class DashboardNewsActionsRepository {
-
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
+class DashboardNewsActionsRepository(
+    private val client: OkHttpClient = OkHttpClient.Builder().build(),
     private val moshi: Moshi = Moshi.Builder()
         .addLast(KotlinJsonAdapterFactory())
-        .build()
+        .build(),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+
     private val deleteRequestAdapter = moshi.adapter(DeleteNewsRequest::class.java)
     private val updateRequestAdapter = moshi.adapter(UpdateNewsRequest::class.java)
     private val responseAdapter = moshi.adapter(DeleteNewsResponse::class.java)
@@ -35,7 +38,7 @@ class DashboardNewsActionsRepository {
         teamId: String? = null,
         teamName: String? = null
     ): Result<DeleteNewsResponse> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -89,7 +92,7 @@ class DashboardNewsActionsRepository {
         teamId: String? = null,
         teamName: String? = null
     ): Result<DeleteNewsResponse> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {


### PR DESCRIPTION
Refactored `DashboardNewsActionsRepository` to inject `OkHttpClient`, `Moshi`, and `CoroutineDispatcher` via the primary constructor. Removed hardcoded internal instantiations of `client` and `moshi`, and replaced `Dispatchers.IO` with the injected `dispatcher` in network-bound coroutines to improve testability and conform to standard repository DI patterns.

---
*PR created automatically by Jules for task [2659530973695605335](https://jules.google.com/task/2659530973695605335) started by @dogi*