### PR TITLE
Refactor VoicesComposerRepository for Dependency Injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 129
+        versionName = "0.1.29"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -38,6 +38,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -72,6 +74,7 @@ import org.ole.planet.myplanet.lite.profile.UserProfile
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
+
 class CreateVoiceActivity : AppCompatActivity() {
 
     private lateinit var toolbar: MaterialToolbar
@@ -84,7 +87,10 @@ class CreateVoiceActivity : AppCompatActivity() {
     private lateinit var createVoiceEditorLabel: TextView
     private lateinit var markdownToolbar: LinearLayout
 
-    private val repository = VoicesComposerRepository()
+    private val repository = VoicesComposerRepository(
+        client = OkHttpClient.Builder().build(),
+        moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+    )
     private val newsActionsRepository = DashboardNewsActionsRepository()
     private val httpClient = OkHttpClient.Builder().build()
     private val pendingImages = LinkedHashMap<String, PendingVoiceImage>()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -50,6 +50,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputLayout
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -79,6 +81,7 @@ import org.ole.planet.myplanet.lite.profile.UserProfile
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
+
 private fun transformCommentMarkdownForDisplay(markdown: String): String {
     return markdown.replace("\n", "  \n")
 }
@@ -90,7 +93,10 @@ class DashboardPostDetailActivity : AppCompatActivity() {
 
     private val repository = DashboardNewsRepository()
     private val actionsRepository = DashboardNewsActionsRepository()
-    private val composerRepository = VoicesComposerRepository()
+    private val composerRepository = VoicesComposerRepository(
+        client = OkHttpClient.Builder().build(),
+        moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+    )
     private val httpClient = OkHttpClient.Builder().build()
     private lateinit var adapter: PostDetailAdapter
     private lateinit var markwon: Markwon

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepository.kt
@@ -11,6 +11,7 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -20,12 +21,12 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 
-class VoicesComposerRepository {
 
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
-    private val moshi: Moshi = Moshi.Builder()
-        .addLast(KotlinJsonAdapterFactory())
-        .build()
+class VoicesComposerRepository(
+    private val client: OkHttpClient,
+    private val moshi: Moshi,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
     private val requestAdapter = moshi.adapter(CreateVoiceRequest::class.java)
     private val responseAdapter = moshi.adapter(CreateVoiceResponse::class.java)
     private val resourceMetadataAdapter = moshi.adapter(ResourceMetadataRequest::class.java)
@@ -46,7 +47,7 @@ class VoicesComposerRepository {
         teamId: String? = null,
         teamName: String? = null
     ): Result<CreateVoiceResponse> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -98,7 +99,7 @@ class VoicesComposerRepository {
         credentials: StoredCredentials,
         metadata: ResourceMetadataRequest
     ): ResourceCreationResponse {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             val normalizedBase = baseUrl.trim().trimEnd('/')
             if (normalizedBase.isEmpty()) {
                 throw IOException("Missing server base URL")
@@ -130,7 +131,7 @@ class VoicesComposerRepository {
         revision: String,
         bytes: ByteArray
     ): ResourceUploadResponse {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             val normalizedBase = baseUrl.trim().trimEnd('/')
             if (normalizedBase.isEmpty()) {
                 throw IOException("Missing server base URL")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepositoryTest.kt
@@ -1,7 +1,10 @@
 package org.ole.planet.myplanet.lite.dashboard
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -12,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 
+
 class VoicesComposerRepositoryTest {
 
     private lateinit var mockWebServer: MockWebServer
@@ -21,7 +25,10 @@ class VoicesComposerRepositoryTest {
     fun setup() {
         mockWebServer = MockWebServer()
         mockWebServer.start()
-        repository = VoicesComposerRepository()
+        repository = VoicesComposerRepository(
+            client = OkHttpClient.Builder().build(),
+            moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+        )
     }
 
     @After


### PR DESCRIPTION
This PR refactors `VoicesComposerRepository` to accept `OkHttpClient`, `Moshi`, and a `CoroutineDispatcher` as constructor parameters. Previously, these were instantiated internally, preventing them from being easily mocked or shared across the application, and the `withContext` blocks were hardcoded to `Dispatchers.IO`. This change improves testability and follows dependency injection principles by passing these parameters from `CreateVoiceActivity`, `DashboardPostDetailActivity`, and tests.

---
*PR created automatically by Jules for task [1615359028615481074](https://jules.google.com/task/1615359028615481074) started by @dogi*