### PR TITLE
Refactor: Inject dependencies into DashboardSurveysRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 130
+        versionName = "0.1.30"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
@@ -11,6 +11,7 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -22,12 +23,13 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 
-class DashboardSurveysRepository {
-
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
+class DashboardSurveysRepository(
+    private val client: OkHttpClient = OkHttpClient.Builder().build(),
     private val moshi: Moshi = Moshi.Builder()
         .addLast(KotlinJsonAdapterFactory())
-        .build()
+        .build(),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
     private val findRequestAdapter = moshi.adapter(SurveysFindRequest::class.java)
     private val findResponseAdapter = moshi.adapter(SurveysFindResponse::class.java)
     private val completionsRequestAdapter = moshi.adapter(SurveyCompletionsRequest::class.java)
@@ -39,7 +41,7 @@ class DashboardSurveysRepository {
         sessionCookie: String?,
         teamId: String,
     ): Result<List<SurveyDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -128,7 +130,7 @@ class DashboardSurveysRepository {
         teamId: String,
         surveyId: String,
     ): Result<Int> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -179,7 +181,7 @@ class DashboardSurveysRepository {
         teamId: String,
         surveyIds: List<String>,
     ): Result<Map<String, Int>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {


### PR DESCRIPTION
Injects OkHttpClient, Moshi, and CoroutineDispatcher into DashboardSurveysRepository via its constructor to improve testability and allow shared instances to be used. Default parameter values are provided to ensure backwards compatibility with current instantiations. Hardcoded Dispatchers.IO have been updated to use the injected dispatcher.

---
*PR created automatically by Jules for task [18116760175609983447](https://jules.google.com/task/18116760175609983447) started by @dogi*