### PR TITLE
Reuse decoded bitmaps in CreateVoiceActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 131
+        versionName = "0.1.31"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -88,6 +88,7 @@ class CreateVoiceActivity : AppCompatActivity() {
     private val newsActionsRepository = DashboardNewsActionsRepository()
     private val httpClient = OkHttpClient.Builder().build()
     private val pendingImages = LinkedHashMap<String, PendingVoiceImage>()
+    private val decodedBitmaps = java.util.concurrent.ConcurrentHashMap<String, Bitmap>()
     private val imagePickerLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         uri?.let {
             lifecycleScope.launch {
@@ -223,6 +224,12 @@ class CreateVoiceActivity : AppCompatActivity() {
             }
         }
         pendingImages.clear()
+        decodedBitmaps.values.forEach { bitmap ->
+            if (!bitmap.isRecycled) {
+                bitmap.recycle()
+            }
+        }
+        decodedBitmaps.clear()
         super.onDestroy()
     }
 
@@ -546,7 +553,9 @@ class CreateVoiceActivity : AppCompatActivity() {
             }
             wrapper.addView(preview)
             lifecycleScope.launch(Dispatchers.Default) {
-                val bitmap = BitmapFactory.decodeByteArray(pending.jpegBytes, 0, pending.jpegBytes.size)
+                val bitmap = decodedBitmaps.getOrPut(pending.id) {
+                    BitmapFactory.decodeByteArray(pending.jpegBytes, 0, pending.jpegBytes.size)
+                }
                 withContext(Dispatchers.Main) {
                     preview.setImageBitmap(bitmap)
                 }
@@ -589,7 +598,9 @@ class CreateVoiceActivity : AppCompatActivity() {
             setPadding(padding, padding, padding, padding)
         }
         lifecycleScope.launch(Dispatchers.Default) {
-            val bitmap = BitmapFactory.decodeByteArray(pending.jpegBytes, 0, pending.jpegBytes.size)
+            val bitmap = decodedBitmaps.getOrPut(pending.id) {
+                BitmapFactory.decodeByteArray(pending.jpegBytes, 0, pending.jpegBytes.size)
+            }
             withContext(Dispatchers.Main) {
                 imageView.setImageBitmap(bitmap)
             }
@@ -609,6 +620,11 @@ class CreateVoiceActivity : AppCompatActivity() {
 
         idsToRemove.forEach { id ->
             val removed = pendingImages.remove(id) ?: return@forEach
+            decodedBitmaps.remove(id)?.let { bitmap ->
+                if (!bitmap.isRecycled) {
+                    bitmap.recycle()
+                }
+            }
             removeImageMarkdownReferences(removed)
             if (removed.file.exists()) {
                 removed.file.delete()


### PR DESCRIPTION
Cache decoded preview thumbnails by pending image id.
Reuse the same decoded bitmap for the thumbnail column and the preview dialog.
Invalidate cached entries when an image is deleted or the activity is destroyed.

---
*PR created automatically by Jules for task [15848953464724086515](https://jules.google.com/task/15848953464724086515) started by @dogi*