### PR TITLE
Optimize avatar refreshes with username-to-position index

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 132
+        versionName = "0.1.32"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -234,11 +234,16 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
         if (!::adapter.isInitialized) {
             return
         }
-        val positions = adapter.currentList.mapIndexedNotNull { index, item ->
-            if (item.username?.equals(username, ignoreCase = true) == true) {
-                index
-            } else {
-                null
+
+        val positions = if (adapter.isIndexAvailable()) {
+            adapter.getPositionsForUsername(username)?.toList() ?: emptyList()
+        } else {
+            adapter.currentList.mapIndexedNotNull { index, item ->
+                if (item.username?.equals(username, ignoreCase = true) == true) {
+                    index
+                } else {
+                    null
+                }
             }
         }
         if (positions.isEmpty()) {
@@ -700,6 +705,27 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
 
         override fun onBindViewHolder(holder: DashboardNewsViewHolder, position: Int) {
             holder.bind(getItem(position))
+        }
+
+        private var usernameIndex: Map<String, IntArray>? = null
+
+        override fun onCurrentListChanged(
+            previousList: List<DashboardNewsItem>,
+            currentList: List<DashboardNewsItem>
+        ) {
+            super.onCurrentListChanged(previousList, currentList)
+            usernameIndex = currentList.mapIndexedNotNull { index, item ->
+                item.username?.let { it.lowercase() to index }
+            }.groupBy({ it.first }, { it.second })
+            .mapValues { it.value.toIntArray() }
+        }
+
+        fun getPositionsForUsername(username: String): IntArray? {
+            return usernameIndex?.get(username.lowercase())
+        }
+
+        fun isIndexAvailable(): Boolean {
+            return usernameIndex != null
         }
 
         companion object {


### PR DESCRIPTION
Introduces a `Map<String, IntArray>` index (`usernameIndex`) within `DashboardNewsAdapter` that gets rebuilt inside `onCurrentListChanged` to map lowercased usernames to their list positions. Updates `handleAvatarUpdated` in `DashboardVoicesFragment` to query the new index using `getPositionsForUsername()`, which executes in constant time (per matched user) instead of always falling back to an `O(N)` scan over the entire list. Preserves the full list scan logic as a safety fallback in cases where the index is temporarily uninitialized. Ensures compilation compatibility by matching the exact `List<DashboardNewsItem>` parameters for the overridden AndroidX `ListAdapter` method.

---
*PR created automatically by Jules for task [5588156042405209538](https://jules.google.com/task/5588156042405209538) started by @dogi*