### PR TITLE
Refactor CourseAdapter.submitCourses to use DiffUtil

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 133
+        versionName = "0.1.33"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -1156,11 +1156,45 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         }
 
         fun submitCourses(newItems: List<CourseItem>) {
+            val oldDisplayed = displayedItems.toList()
+
             items.clear()
             items.addAll(newItems.distinctBy { it.id })
             displayedItems.clear()
             displayedItems.addAll(items)
-            notifyDataSetChanged()
+
+            val newDisplayed = displayedItems.toList()
+
+            val diffResult = androidx.recyclerview.widget.DiffUtil.calculateDiff(object : androidx.recyclerview.widget.DiffUtil.Callback() {
+                override fun getOldListSize() = oldDisplayed.size
+                override fun getNewListSize() = newDisplayed.size
+
+                override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+                    return oldDisplayed[oldItemPosition].id == newDisplayed[newItemPosition].id
+                }
+
+                override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+                    return oldDisplayed[oldItemPosition] == newDisplayed[newItemPosition]
+                }
+            })
+
+            diffResult.dispatchUpdatesTo(object : androidx.recyclerview.widget.ListUpdateCallback {
+                override fun onInserted(position: Int, count: Int) {
+                    notifyItemRangeInserted(position + 1, count)
+                }
+
+                override fun onRemoved(position: Int, count: Int) {
+                    notifyItemRangeRemoved(position + 1, count)
+                }
+
+                override fun onMoved(fromPosition: Int, toPosition: Int) {
+                    notifyItemMoved(fromPosition + 1, toPosition + 1)
+                }
+
+                override fun onChanged(position: Int, count: Int, payload: Any?) {
+                    notifyItemRangeChanged(position + 1, count, payload)
+                }
+            })
         }
 
         fun appendCourses(newItems: List<CourseItem>) {


### PR DESCRIPTION
Refactors the `CourseAdapter.submitCourses` logic to use `DiffUtil` for list updates. Since the adapter has a sticky header at position 0, `DiffUtil.calculateDiff` result is applied using a custom `ListUpdateCallback` that accurately shifts position updates by `+1` to preserve the header. This resolves efficiency and list redrawing issues compared to calling `notifyDataSetChanged`.

---
*PR created automatically by Jules for task [13276635331695915536](https://jules.google.com/task/13276635331695915536) started by @dogi*