### PR TITLE
Refactor: Inject dependencies into DashboardNewsRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 134
+        versionName = "0.1.34"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -6,6 +6,9 @@
 
 package org.ole.planet.myplanet.lite
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -88,7 +91,7 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
         }
     }
 
-    private val repository = DashboardNewsRepository()
+    private val repository = DashboardNewsRepository(OkHttpClient.Builder().build(), Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build())
     private val actionsRepository = DashboardNewsActionsRepository()
     private val items = mutableListOf<DashboardNewsItem>()
     private val commentCounts = mutableMapOf<String, Int>()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepository.kt
@@ -12,6 +12,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import java.io.Serializable
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -19,12 +20,12 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
-class DashboardNewsRepository {
+class DashboardNewsRepository(
+    private val client: OkHttpClient,
+    private val moshi: Moshi,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
 
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
-    private val moshi: Moshi = Moshi.Builder()
-        .addLast(KotlinJsonAdapterFactory())
-        .build()
     private val requestAdapter = moshi.adapter(NewsFindRequest::class.java)
     private val responseAdapter = moshi.adapter(NewsFindResponse::class.java)
 
@@ -38,7 +39,7 @@ class DashboardNewsRepository {
         parentCode: String?,
         teamName: String? = null
     ): Result<NewsPage> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -120,7 +121,7 @@ class DashboardNewsRepository {
         parentCode: String?,
         teamName: String? = null
     ): Result<List<NewsDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -68,6 +68,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
@@ -88,7 +90,7 @@ class DashboardPostDetailActivity : AppCompatActivity() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var loadingView: View
 
-    private val repository = DashboardNewsRepository()
+    private val repository by lazy { DashboardNewsRepository(httpClient, Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()) }
     private val actionsRepository = DashboardNewsActionsRepository()
     private val composerRepository = VoicesComposerRepository()
     private val httpClient = OkHttpClient.Builder().build()

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepositoryTest.kt
@@ -1,5 +1,8 @@
 package org.ole.planet.myplanet.lite.dashboard
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -21,7 +24,7 @@ class DashboardNewsRepositoryTest {
     fun setup() {
         mockWebServer = MockWebServer()
         mockWebServer.start()
-        repository = DashboardNewsRepository()
+        repository = DashboardNewsRepository(OkHttpClient.Builder().build(), Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build())
     }
 
     @After


### PR DESCRIPTION
Fixes issue with hardcoded dependency instantiations in `DashboardNewsRepository`. Allows for proper testing and memory management by injecting `OkHttpClient`, `Moshi`, and `CoroutineDispatcher` via the constructor. All relevant call sites have been updated to explicitly pass the required dependencies.

---
*PR created automatically by Jules for task [851342880203567237](https://jules.google.com/task/851342880203567237) started by @dogi*