### PR TITLE
Unify bitmap loaders around shared client cache and in-flight dedupe

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 134
+        versionName = "0.1.34"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoader.kt
@@ -14,9 +14,10 @@ import androidx.core.widget.ImageViewCompat
 import java.io.IOException
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -29,7 +30,7 @@ class DashboardAvatarLoader(
     private val sessionCookie: String?,
     private val credentials: StoredCredentials?,
     private val scope: CoroutineScope,
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
+    private val client: OkHttpClient = SharedBitmapDependencies.client
 ) {
 
     private val cache = sharedCache
@@ -66,8 +67,21 @@ class DashboardAvatarLoader(
         }
         imageView.tag = cacheKey
         scope.launch {
-            val bitmap = withContext(Dispatchers.IO) {
-                runCatching { fetchAvatarBitmap(username) }.getOrNull()
+            val deferred = synchronized(inFlightRequests) {
+                inFlightRequests.getOrPut(cacheKey) {
+                    inFlightScope.async {
+                        runCatching { fetchAvatarBitmap(username) }.getOrNull()
+                    }
+                }
+            }
+            val bitmap = try {
+                deferred.await()
+            } finally {
+                synchronized(inFlightRequests) {
+                    if (inFlightRequests[cacheKey] == deferred) {
+                        inFlightRequests.remove(cacheKey)
+                    }
+                }
             }
             if (bitmap != null && imageView.tag == cacheKey) {
                 cache.put(cacheKey, bitmap)
@@ -115,6 +129,8 @@ class DashboardAvatarLoader(
     private companion object {
         private const val CACHE_SIZE_BYTES = 2 * 1024 * 1024 // 2MB cache for avatars
         private val missingAvatars = mutableSetOf<String>()
+        private val inFlightScope = CoroutineScope(Dispatchers.IO + kotlinx.coroutines.SupervisorJob())
+        private val inFlightRequests = mutableMapOf<String, Deferred<Bitmap?>>()
         private val sharedCache = object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
             override fun sizeOf(key: String, value: Bitmap): Int {
                 return value.byteCount

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
@@ -15,24 +15,21 @@ import android.widget.ImageView
 import java.io.File
 import java.io.IOException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
 class DashboardPostImageLoader(
     private val baseUrl: String,
     private val sessionCookie: String?,
-    private val scope: CoroutineScope
+    private val scope: CoroutineScope,
+    private val client: OkHttpClient = SharedBitmapDependencies.client
 ) {
 
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
-    private val cache = object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
-        override fun sizeOf(key: String, value: Bitmap): Int {
-            return value.byteCount
-        }
-    }
+    private val cache = sharedCache
 
     fun bind(imageView: ImageView, imagePath: String, onResult: ((Boolean) -> Unit)? = null) {
         imageView.setImageDrawable(null)
@@ -45,8 +42,21 @@ class DashboardPostImageLoader(
         }
         imageView.tag = cacheKey
         scope.launch {
-            val bitmap = withContext(Dispatchers.IO) {
-                runCatching { fetchImageBitmap(imagePath) }.getOrNull()
+            val deferred = synchronized(inFlightRequests) {
+                inFlightRequests.getOrPut(cacheKey) {
+                    inFlightScope.async {
+                        runCatching { fetchImageBitmap(imagePath) }.getOrNull()
+                    }
+                }
+            }
+            val bitmap = try {
+                deferred.await()
+            } finally {
+                synchronized(inFlightRequests) {
+                    if (inFlightRequests[cacheKey] == deferred) {
+                        inFlightRequests.remove(cacheKey)
+                    }
+                }
             }
             if (imageView.tag != cacheKey) {
                 onResult?.invoke(bitmap != null)
@@ -115,5 +125,12 @@ class DashboardPostImageLoader(
 
     private companion object {
         private const val CACHE_SIZE_BYTES = 6 * 1024 * 1024 // 6MB cache for post images
+        private val inFlightScope = CoroutineScope(Dispatchers.IO + kotlinx.coroutines.SupervisorJob())
+        private val inFlightRequests = mutableMapOf<String, Deferred<Bitmap?>>()
+        private val sharedCache = object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
+            override fun sizeOf(key: String, value: Bitmap): Int {
+                return value.byteCount
+            }
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/SharedBitmapDependencies.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/SharedBitmapDependencies.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import okhttp3.OkHttpClient
+
+object SharedBitmapDependencies {
+    val client: OkHttpClient by lazy { OkHttpClient.Builder().build() }
+}


### PR DESCRIPTION
Move OkHttpClient ownership for avatar and post image loading to a shared dependency.
Make post image loading use a shared cache strategy instead of a per-loader cache instance.
Add in-flight request dedupe keyed by username or image path so rapid rebinding does not trigger duplicate fetches.
Keep the public bind APIs stable to minimize review surface.

---
*PR created automatically by Jules for task [10436538135426553910](https://jules.google.com/task/10436538135426553910) started by @dogi*