### PR TITLE
Refactor VoicesComposerRepository for DI

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/VoicesComposerRepository.kt
@@ -11,6 +11,7 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -20,12 +21,12 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 
-class VoicesComposerRepository {
+class VoicesComposerRepository(
+    private val client: OkHttpClient = OkHttpClient.Builder().build(),
+    private val moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
 
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
-    private val moshi: Moshi = Moshi.Builder()
-        .addLast(KotlinJsonAdapterFactory())
-        .build()
     private val requestAdapter = moshi.adapter(CreateVoiceRequest::class.java)
     private val responseAdapter = moshi.adapter(CreateVoiceResponse::class.java)
     private val resourceMetadataAdapter = moshi.adapter(ResourceMetadataRequest::class.java)
@@ -46,7 +47,7 @@ class VoicesComposerRepository {
         teamId: String? = null,
         teamName: String? = null
     ): Result<CreateVoiceResponse> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -98,7 +99,7 @@ class VoicesComposerRepository {
         credentials: StoredCredentials,
         metadata: ResourceMetadataRequest
     ): ResourceCreationResponse {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             val normalizedBase = baseUrl.trim().trimEnd('/')
             if (normalizedBase.isEmpty()) {
                 throw IOException("Missing server base URL")
@@ -130,7 +131,7 @@ class VoicesComposerRepository {
         revision: String,
         bytes: ByteArray
     ): ResourceUploadResponse {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             val normalizedBase = baseUrl.trim().trimEnd('/')
             if (normalizedBase.isEmpty()) {
                 throw IOException("Missing server base URL")


### PR DESCRIPTION
Injected OkHttpClient, Moshi, and CoroutineDispatcher into the constructor of VoicesComposerRepository to improve testability. Replaced hardcoded Dispatchers.IO with the injected dispatcher. Maintained backward compatibility using default values for the new constructor parameters.

---
*PR created automatically by Jules for task [3984169233579155353](https://jules.google.com/task/3984169233579155353) started by @dogi*