### PR TITLE
Refactor DashboardNewsRepository to inject dependencies via constructor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 137
+        versionName = "0.1.37"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepository.kt
@@ -12,6 +12,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import java.io.Serializable
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -19,12 +20,14 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
-class DashboardNewsRepository {
-
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
+class DashboardNewsRepository(
+    private val client: OkHttpClient = OkHttpClient.Builder().build(),
     private val moshi: Moshi = Moshi.Builder()
         .addLast(KotlinJsonAdapterFactory())
-        .build()
+        .build(),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+
     private val requestAdapter = moshi.adapter(NewsFindRequest::class.java)
     private val responseAdapter = moshi.adapter(NewsFindResponse::class.java)
 
@@ -38,7 +41,7 @@ class DashboardNewsRepository {
         parentCode: String?,
         teamName: String? = null
     ): Result<NewsPage> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -120,7 +123,7 @@ class DashboardNewsRepository {
         parentCode: String?,
         teamName: String? = null
     ): Result<List<NewsDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {


### PR DESCRIPTION
Refactor DashboardNewsRepository to inject dependencies via constructor

- Injected OkHttpClient, Moshi, and CoroutineDispatcher into DashboardNewsRepository with default parameter values to preserve backwards compatibility.
- Replaced internally initialized OkHttpClient and Moshi.
- Replaced hardcoded Dispatchers.IO with injected CoroutineDispatcher for fetchNews and fetchComments network calls.

---
*PR created automatically by Jules for task [14421809621683747320](https://jules.google.com/task/14421809621683747320) started by @dogi*