### PR TITLE
Refactor DashboardCoursesRepository Dependency Injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 137
-        versionName = "0.1.37"
+        versionCode = 138
+        versionName = "0.1.38"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -12,6 +12,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -24,11 +25,13 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 
-class DashboardCoursesRepository {
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
+class DashboardCoursesRepository(
+    private val client: OkHttpClient = OkHttpClient.Builder().build(),
     private val moshi: Moshi = Moshi.Builder()
         .addLast(KotlinJsonAdapterFactory())
-        .build()
+        .build(),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
     private val findRequestAdapter = moshi.adapter(ShelfFindRequest::class.java)
     private val findResponseAdapter = moshi.adapter(ShelfFindResponse::class.java)
     private val shelfDocumentAdapter = moshi.adapter(ShelfDocument::class.java)
@@ -53,7 +56,7 @@ class DashboardCoursesRepository {
         baseUrl: String,
         credentials: StoredCredentials
     ): Result<List<String>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -92,7 +95,7 @@ class DashboardCoursesRepository {
         baseUrl: String,
         credentials: StoredCredentials
     ): Result<ShelfDocument> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -137,7 +140,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials,
         courseId: String
     ): Result<Unit> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -202,7 +205,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials,
         courseId: String
     ): Result<Unit> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -268,7 +271,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials,
         courseIds: List<String>
     ): Result<List<CourseDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -332,7 +335,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials,
         courseIds: List<String>
     ): Result<Map<String, Int>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -394,7 +397,7 @@ class DashboardCoursesRepository {
         courseIds: List<String>,
         stepNum: Int? = null
     ): Result<Map<String, CourseProgressDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -454,7 +457,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials,
         document: CourseProgressUpdateDocument
     ): Result<List<BulkDocResult>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -489,7 +492,7 @@ class DashboardCoursesRepository {
         skip: Int,
         limit: Int
     ): Result<PagedCourses> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -538,7 +541,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials,
         teamId: String
     ): Result<List<CourseDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -582,7 +585,7 @@ class DashboardCoursesRepository {
         credentials: StoredCredentials?,
         sessionCookie: String?
     ): Result<List<TagDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -625,7 +628,7 @@ class DashboardCoursesRepository {
         sessionCookie: String?,
         tagId: String
     ): Result<List<TagLinkDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -13,7 +13,6 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope


### PR DESCRIPTION
Refactored `DashboardCoursesRepository` to accept `OkHttpClient`, `Moshi`, and `CoroutineDispatcher` as constructor parameters with their current default values, removing the duplicate internal initializations. Also replaced all occurrences of `withContext(Dispatchers.IO)` with `withContext(dispatcher)` for better testability and clean architecture. Verified that dependent classes like `DashboardCoursePageFragment` and `CourseWizardActivity` still compile and run correctly with the default constructor.

---
*PR created automatically by Jules for task [15064803105730348868](https://jules.google.com/task/15064803105730348868) started by @dogi*