### PR TITLE
Cache OkHttpClient and Moshi in AuthDependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 138
+        versionName = "0.1.38"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/auth/AuthDependencies.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/auth/AuthDependencies.kt
@@ -16,6 +16,13 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 object AuthDependencies {
     @Volatile
     private var authServiceOverride: AuthService? = null
+
+    @Volatile
+    private var cachedClient: OkHttpClient? = null
+
+    @Volatile
+    private var cachedMoshi: Moshi? = null
+
     fun provideAuthService(context: Context, baseUrl: String = BuildConfig.PLANET_BASE_URL): AuthService {
         return authServiceOverride ?: createAuthService(context.applicationContext, baseUrl)
     }
@@ -23,11 +30,15 @@ object AuthDependencies {
         authServiceOverride = service
     }
     private fun createAuthService(context: Context, baseUrl: String): AuthService {
-        val client = OkHttpClient.Builder()
-            .build()
-        val moshi = Moshi.Builder()
-            .addLast(KotlinJsonAdapterFactory())
-            .build()
+        val client = cachedClient ?: synchronized(this) {
+            cachedClient ?: OkHttpClient.Builder()
+                .build().also { cachedClient = it }
+        }
+        val moshi = cachedMoshi ?: synchronized(this) {
+            cachedMoshi ?: Moshi.Builder()
+                .addLast(KotlinJsonAdapterFactory())
+                .build().also { cachedMoshi = it }
+        }
         val retrofit = Retrofit.Builder()
             .baseUrl(baseUrl)
             .addConverterFactory(MoshiConverterFactory.create(moshi))


### PR DESCRIPTION
Refactored AuthDependencies to cache and reuse OkHttpClient and Moshi instances via double-checked locking lazy initialization, avoiding redundant rebuilds while keeping Retrofit URL-specific as requested. Deleted junk working files from sandbox. Verified changes compile and tests pass successfully.

---
*PR created automatically by Jules for task [13389628650307371335](https://jules.google.com/task/13389628650307371335) started by @dogi*