### PR TITLE
Refactor: Add and use DiffUtils.itemCallback helper

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 139
+        versionName = "0.1.39"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -703,15 +703,7 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
         }
 
         companion object {
-            private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<DashboardNewsItem>() {
-                override fun areItemsTheSame(oldItem: DashboardNewsItem, newItem: DashboardNewsItem): Boolean {
-                    return oldItem.id == newItem.id
-                }
-
-                override fun areContentsTheSame(oldItem: DashboardNewsItem, newItem: DashboardNewsItem): Boolean {
-                    return oldItem == newItem
-                }
-            }
+            private val DIFF_CALLBACK = org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback<DashboardNewsItem>({ oldItem, newItem -> oldItem.id == newItem.id })
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -1919,19 +1919,13 @@ class DashboardPostDetailActivity : AppCompatActivity() {
             private const val VIEW_TYPE_HEADER = 0
             private const val VIEW_TYPE_COMMENT = 1
 
-            private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<PostDetailItem>() {
-                override fun areItemsTheSame(oldItem: PostDetailItem, newItem: PostDetailItem): Boolean {
-                    return when {
-                        oldItem is PostDetailItem.Header && newItem is PostDetailItem.Header -> oldItem.id == newItem.id
-                        oldItem is PostDetailItem.Comment && newItem is PostDetailItem.Comment -> oldItem.id == newItem.id
-                        else -> false
-                    }
+            private val DIFF_CALLBACK = org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback<PostDetailItem>({ oldItem, newItem ->
+                when {
+                    oldItem is PostDetailItem.Header && newItem is PostDetailItem.Header -> oldItem.id == newItem.id
+                    oldItem is PostDetailItem.Comment && newItem is PostDetailItem.Comment -> oldItem.id == newItem.id
+                    else -> false
                 }
-
-                override fun areContentsTheSame(oldItem: PostDetailItem, newItem: PostDetailItem): Boolean {
-                    return oldItem == newItem
-                }
-            }
+            })
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/DiffUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/DiffUtils.kt
@@ -1,0 +1,15 @@
+package org.ole.planet.myplanet.lite.util
+
+import androidx.recyclerview.widget.DiffUtil
+
+object DiffUtils {
+    inline fun <T : Any> itemCallback(
+        crossinline areItemsTheSame: (oldItem: T, newItem: T) -> Boolean,
+        crossinline areContentsTheSame: (oldItem: T, newItem: T) -> Boolean = { oldItem, newItem -> oldItem == newItem }
+    ): DiffUtil.ItemCallback<T> {
+        return object : DiffUtil.ItemCallback<T>() {
+            override fun areItemsTheSame(oldItem: T, newItem: T): Boolean = areItemsTheSame(oldItem, newItem)
+            override fun areContentsTheSame(oldItem: T, newItem: T): Boolean = areContentsTheSame(oldItem, newItem)
+        }
+    }
+}


### PR DESCRIPTION
- Added `org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback` inline function.
- Updated `DashboardVoicesFragment.DashboardNewsAdapter` to use the helper.
- Updated `DashboardPostDetailActivity.PostDetailAdapter` to use the helper.

---
*PR created automatically by Jules for task [4260243126625302709](https://jules.google.com/task/4260243126625302709) started by @dogi*