### PR TITLE
🧹 Remove unused import in TeamsFragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 141
+        versionName = "0.1.41"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/TeamsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/TeamsFragment.kt
@@ -26,7 +26,6 @@ import com.google.android.material.card.MaterialCardView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext


### PR DESCRIPTION
Removed the unused import kotlinx.coroutines.awaitAll from TeamsFragment.kt to improve code health and maintainability.

---
*PR created automatically by Jules for task [11333315619308292294](https://jules.google.com/task/11333315619308292294) started by @dogi*