### PR TITLE
🧪 Add Robolectric testing suite for CreateVoiceActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 142
+        versionName = "0.1.42"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 142
-        versionName = "0.1.42"
+        versionCode = 144
+        versionName = "0.1.44"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/androidTest/java/org/ole/planet/myplanet/lite/MyPlanetLiteAuthTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/lite/MyPlanetLiteAuthTest.kt
@@ -19,7 +19,6 @@ import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.lifecycle.Lifecycle
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import org.hamcrest.Description
@@ -52,7 +51,7 @@ class MyPlanetLiteAuthTest {
     @After
     fun tearDown() {
         AuthDependencies.overrideAuthService(null)
-        SecurePreferencesProvider.injectedPreferences = null
+        SecurePreferencesProvider.resetForTesting()
     }
 
     @Test
@@ -60,7 +59,6 @@ class MyPlanetLiteAuthTest {
         AuthDependencies.overrideAuthService(FakeService(AuthResult.Success(LoginResponse(ok = true))))
 
         ActivityScenario.launch(MyPlanetLite::class.java).use { scenario ->
-            scenario.moveToState(Lifecycle.State.RESUMED)
             scenario.onActivity { activity ->
                 activity.findViewById<Button>(R.id.loginButton).apply {
                     isEnabled = true
@@ -83,7 +81,6 @@ class MyPlanetLiteAuthTest {
         AuthDependencies.overrideAuthService(FakeService(AuthResult.Error(code = 401, message = "")))
 
         ActivityScenario.launch(MyPlanetLite::class.java).use { scenario ->
-            scenario.moveToState(Lifecycle.State.RESUMED)
             scenario.onActivity { activity ->
                 activity.findViewById<TextInputEditText>(R.id.usernameInput).setText("user@planet.com")
                 activity.findViewById<TextInputEditText>(R.id.passwordInput).setText("badpass")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivityRobolectricTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivityRobolectricTest.kt
@@ -1,0 +1,139 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.lite.R
+import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
+import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowToast
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CreateVoiceActivityRobolectricTest {
+
+    @Test
+    fun `test activity launches successfully`() {
+        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val activity = controller.get()
+        assertNotNull(activity)
+    }
+
+    @Test
+    fun `test initial UI state`() {
+        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val activity = controller.get()
+
+        val createVoiceInput: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
+        val createVoiceSubmitButton: MaterialButton = activity.findViewById(R.id.createVoiceSubmitButton)
+
+        assertNotNull(createVoiceInput)
+        assertNotNull(createVoiceSubmitButton)
+        assertEquals("", createVoiceInput.text.toString())
+    }
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        ProfileCredentialsStore.setSessionCredentials(StoredCredentials("test", "testpass"))
+        org.ole.planet.myplanet.lite.util.SecurePreferencesProvider.injectedPreferences = org.mockito.Mockito.mock(android.content.SharedPreferences::class.java)
+    }
+
+    @Test
+    fun `attemptPost shows empty error toast when message is blank`() {
+        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val activity = controller.get()
+
+        val submitButton: MaterialButton = activity.findViewById(R.id.createVoiceSubmitButton)
+        submitButton.performClick()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        val latestToast = ShadowToast.getTextOfLatestToast()
+        assertNotNull("Expected a Toast to be shown", latestToast)
+        assertEquals(context.getString(R.string.create_voice_empty_error), latestToast)
+    }
+
+
+    @Test
+    fun `attemptPost shows missing server toast when base url is blank`() {
+        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val activity = controller.get()
+
+        val input: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
+        input.setText("Some test voice message")
+
+        val submitButton: MaterialButton = activity.findViewById(R.id.createVoiceSubmitButton)
+        submitButton.performClick()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        val latestToast = ShadowToast.getTextOfLatestToast()
+        assertNotNull("Expected a Toast to be shown", latestToast)
+        assertEquals(context.getString(R.string.create_voice_missing_server), latestToast)
+    }
+
+    @Test
+    fun `attemptPost shows missing credentials toast when credentials are null`() {
+        // Mocking or circumventing the secure preferences exception for now
+        ProfileCredentialsStore.setSessionCredentials(null)
+        org.ole.planet.myplanet.lite.util.SecurePreferencesProvider.injectedPreferences = org.mockito.Mockito.mock(android.content.SharedPreferences::class.java)
+        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val activity = controller.get()
+
+        val input: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
+        input.setText("Some test voice message")
+
+        // Use reflection to set baseUrl
+        val field = CreateVoiceActivity::class.java.getDeclaredField("baseUrl")
+        field.isAccessible = true
+        field.set(activity, "http://test.com")
+
+        val submitButton: MaterialButton = activity.findViewById(R.id.createVoiceSubmitButton)
+        submitButton.performClick()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        val latestToast = ShadowToast.getTextOfLatestToast()
+        assertNotNull("Expected a Toast to be shown", latestToast)
+        assertEquals(context.getString(R.string.create_voice_missing_credentials), latestToast)
+    }
+
+
+    @Test
+    fun `attemptPost shows confirmation dialog when valid`() {
+        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val activity = controller.get()
+
+        val input: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
+        input.setText("Some test voice message")
+
+        // Use reflection to set baseUrl
+        val field = CreateVoiceActivity::class.java.getDeclaredField("baseUrl")
+        field.isAccessible = true
+        field.set(activity, "http://test.com")
+
+        val submitButton: MaterialButton = activity.findViewById(R.id.createVoiceSubmitButton)
+        submitButton.performClick()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        val dialog = org.robolectric.shadows.ShadowAlertDialog.getLatestAlertDialog()
+        // A MaterialAlertDialog is used, which might not register exactly as AlertDialog in Robolectric sometimes depending on version or it uses a generic dialog
+        val dialog2 = org.robolectric.shadows.ShadowDialog.getLatestDialog()
+        assertNotNull("Expected confirmation dialog", dialog2)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `CreateVoiceActivity` addressed. Missing explicit Robolectric unit tests for complex UI edge cases.
📊 **Coverage:** Adds automated tests covering initial UI states, error handling when trying to submit an empty form, missing server base URL errors, credential failure errors, and successful validation dialog prompts. Resolves a regression in the full test suite triggered by a missing exception handler inside `DashboardOfflineSurveyStoreTest` when running headless tests.
✨ **Result:** Test coverage for the `CreateVoiceActivity` was significantly increased, securing UI validations from possible future regressions and standardizing test behavior when cryptographic stores are initialized in Activities during testing.

---
*PR created automatically by Jules for task [1952781789352924714](https://jules.google.com/task/1952781789352924714) started by @dogi*