### PR TITLE
🔒 Fix DoS vulnerability with opaque URIs in exported SplashScreen Activity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 125
-        versionName = "0.1.25"
+        versionCode = 145
+        versionName = "0.1.45"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
@@ -10,6 +10,7 @@ object IntentUtils {
             return null
         }
         val data = intent.data ?: return null
+        if (data.isOpaque) return null
         val queryPostId = data.getQueryParameter("postId")
         if (!queryPostId.isNullOrBlank() && queryPostId.matches(ID_PATTERN)) {
             return queryPostId

--- a/app/src/test/java/org/ole/planet/myplanet/lite/IntentSecurityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/IntentSecurityTest.kt
@@ -1,0 +1,36 @@
+package org.ole.planet.myplanet.lite
+
+import android.content.Intent
+import android.net.Uri
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.ole.planet.myplanet.lite.util.IntentUtils
+
+@RunWith(RobolectricTestRunner::class)
+class IntentSecurityTest {
+
+    @Test
+    fun extractDeepLinkPostId_withOpaqueUri_returnsNull() {
+        // An opaque URI like mailto: or tel: will cause UnsupportedOperationException
+        // if we try to call getQueryParameter on it.
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:test@test.com"))
+        val result = IntentUtils.extractDeepLinkPostId(intent)
+        assertNull("Opaque URIs should safely return null", result)
+    }
+
+    @Test
+    fun extractDeepLinkPostId_withValidHierarchicalUri_returnsPostId() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://midominio.com/post?postId=12345"))
+        val result = IntentUtils.extractDeepLinkPostId(intent)
+        assertEquals("12345", result)
+    }
+
+    @Test
+    fun extractDeepLinkPostId_withValidPathUri_returnsPostId() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("myplanetlite://post/67890"))
+        val result = IntentUtils.extractDeepLinkPostId(intent)
+        assertEquals("67890", result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `SplashScreen` Activity, which is exported and handles intent deep links, could crash when provided with an opaque URI (e.g., `mailto:`, `tel:`).
⚠️ **Risk:** An attacker could craft a malicious intent containing an opaque URI and invoke the exported `SplashScreen` activity. This would trigger an `UnsupportedOperationException` in `IntentUtils` and crash the application on launch, leading to a Denial of Service (DoS) vulnerability.
🛡️ **Solution:** Updated `IntentUtils.extractDeepLinkPostId` to explicitly check `if (data.isOpaque)` and return `null` before attempting to access hierarchical URI properties like `getQueryParameter` or `pathSegments`. Additionally, created `IntentSecurityTest` to ensure opaque URIs are handled safely without crashing.

---
*PR created automatically by Jules for task [15535440123606858180](https://jules.google.com/task/15535440123606858180) started by @dogi*