### PR TITLE
Fix ActivityScenario lifecycle flakiness in MyPlanetLiteAuthTest

### DIFF
--- a/app/src/androidTest/java/org/ole/planet/myplanet/lite/MyPlanetLiteAuthTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/lite/MyPlanetLiteAuthTest.kt
@@ -19,7 +19,6 @@ import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.lifecycle.Lifecycle
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import org.hamcrest.Description
@@ -52,7 +51,7 @@ class MyPlanetLiteAuthTest {
     @After
     fun tearDown() {
         AuthDependencies.overrideAuthService(null)
-        SecurePreferencesProvider.injectedPreferences = null
+        SecurePreferencesProvider.resetForTesting()
     }
 
     @Test
@@ -60,7 +59,6 @@ class MyPlanetLiteAuthTest {
         AuthDependencies.overrideAuthService(FakeService(AuthResult.Success(LoginResponse(ok = true))))
 
         ActivityScenario.launch(MyPlanetLite::class.java).use { scenario ->
-            scenario.moveToState(Lifecycle.State.RESUMED)
             scenario.onActivity { activity ->
                 activity.findViewById<Button>(R.id.loginButton).apply {
                     isEnabled = true
@@ -83,7 +81,6 @@ class MyPlanetLiteAuthTest {
         AuthDependencies.overrideAuthService(FakeService(AuthResult.Error(code = 401, message = "")))
 
         ActivityScenario.launch(MyPlanetLite::class.java).use { scenario ->
-            scenario.moveToState(Lifecycle.State.RESUMED)
             scenario.onActivity { activity ->
                 activity.findViewById<TextInputEditText>(R.id.usernameInput).setText("user@planet.com")
                 activity.findViewById<TextInputEditText>(R.id.passwordInput).setText("badpass")


### PR DESCRIPTION
The instrumented tests in `MyPlanetLiteAuthTest` were failing with an `AssertionError` because they explicitly requested the `RESUMED` state immediately after launching the activity. This caused race conditions and failures when the activity was already transitioning or recreating (e.g., due to locale or orientation setup in `onCreate`). Since `ActivityScenario.launch` already brings the activity to the `RESUMED` state by default, these calls were redundant and problematic.

Changes:
- Removed `scenario.moveToState(Lifecycle.State.RESUMED)` from `login_shows_validation_errors_for_empty_fields` and `login_invalid_credentials_shows_error_message`.
- Updated `tearDown` to call `SecurePreferencesProvider.resetForTesting()`, ensuring a cleaner state between tests.
- Removed the unused `androidx.lifecycle.Lifecycle` import.

---
*PR created automatically by Jules for task [17658688059578866535](https://jules.google.com/task/17658688059578866535) started by @PlataformasInformaticas*