### PR TITLE
Use no_image icon as fallback for course covers

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -1336,26 +1336,12 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
                 itemView.findViewById(R.id.dashboardCourseDownloadProgressIndicator)
             private val progressIndicator: com.google.android.material.progressindicator.LinearProgressIndicator =
                 itemView.findViewById(R.id.dashboardCourseProgressIndicator)
-            private val defaultPadding = intArrayOf(
-                imageView.paddingLeft,
-                imageView.paddingTop,
-                imageView.paddingRight,
-                imageView.paddingBottom
-            )
-            private val defaultScaleType = imageView.scaleType
-
             private fun showDefaultIcon() {
                 imageView.visibility = View.VISIBLE
-                imageView.setImageResource(R.drawable.ic_courses_24)
-                val primary = MaterialColors.getColor(itemView, androidx.appcompat.R.attr.colorPrimary)
-                imageView.imageTintList = android.content.res.ColorStateList.valueOf(primary)
-                imageView.setPadding(
-                    defaultPadding[0],
-                    defaultPadding[1],
-                    defaultPadding[2],
-                    defaultPadding[3]
-                )
-                imageView.scaleType = defaultScaleType
+                imageView.setImageResource(R.drawable.no_image)
+                imageView.imageTintList = null
+                imageView.setPadding(0, 0, 0, 0)
+                imageView.scaleType = ImageView.ScaleType.CENTER_INSIDE
             }
 
             fun bind(course: CourseItem) {

--- a/app/src/main/res/layout/item_dashboard_course_card.xml
+++ b/app/src/main/res/layout/item_dashboard_course_card.xml
@@ -24,9 +24,8 @@
                 android:layout_height="160dp"
                 android:background="@drawable/dashboard_course_image_background"
                 android:contentDescription="@string/dashboard_courses_content_description_icon"
-                android:padding="24dp"
                 android:scaleType="centerInside"
-                app:srcCompat="@drawable/ic_courses_24" />
+                app:srcCompat="@drawable/no_image" />
 
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/dashboardCourseDownloadButton"


### PR DESCRIPTION
The changes update the course listing to use a specific 'no_image' icon instead of the generic course icon when no cover image is provided by the server or when loading fails. 

Key changes:
- In `DashboardCoursePageFragment.kt`: Updated `showDefaultIcon()` to load `R.drawable.no_image`, cleared `imageTintList`, removed padding, and set scale type to `CENTER_INSIDE`.
- In `item_dashboard_course_card.xml`: Changed the default `app:srcCompat` to `@drawable/no_image` and removed the fixed `24dp` padding.

---
*PR created automatically by Jules for task [12539712914086140921](https://jules.google.com/task/12539712914086140921) started by @PlataformasInformaticas*