### PR TITLE
Refactor DashboardNewsRepository for dependency injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 148
-        versionName = "0.1.48"
+        versionCode = 151
+        versionName = "0.1.51"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -34,6 +34,9 @@ import kotlin.math.max
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.dashboard.CreateVoiceActivity
 import org.ole.planet.myplanet.lite.dashboard.DashboardAvatarLoader
@@ -88,7 +91,10 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
         }
     }
 
-    private val repository = DashboardNewsRepository()
+    private val repository = DashboardNewsRepository(
+        client = OkHttpClient.Builder().build(),
+        moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+    )
     private val actionsRepository = DashboardNewsActionsRepository()
     private val items = mutableListOf<DashboardNewsItem>()
     private val commentCounts = mutableMapOf<String, Int>()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepository.kt
@@ -21,10 +21,8 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
 class DashboardNewsRepository(
-    private val client: OkHttpClient = OkHttpClient.Builder().build(),
-    private val moshi: Moshi = Moshi.Builder()
-        .addLast(KotlinJsonAdapterFactory())
-        .build(),
+    private val client: OkHttpClient,
+    private val moshi: Moshi,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -91,7 +91,10 @@ class DashboardPostDetailActivity : AppCompatActivity() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var loadingView: View
 
-    private val repository = DashboardNewsRepository()
+    private val repository = DashboardNewsRepository(
+        client = OkHttpClient.Builder().build(),
+        moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+    )
     private val actionsRepository = DashboardNewsActionsRepository()
     private val composerRepository = VoicesComposerRepository(
         client = OkHttpClient.Builder().build(),

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardNewsRepositoryTest.kt
@@ -9,6 +9,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import okhttp3.OkHttpClient
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.junit.Before
 import org.junit.Test
 
@@ -21,7 +24,11 @@ class DashboardNewsRepositoryTest {
     fun setup() {
         mockWebServer = MockWebServer()
         mockWebServer.start()
-        repository = DashboardNewsRepository()
+        repository = DashboardNewsRepository(
+            client = OkHttpClient.Builder().build(),
+            moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
+            /* using default dispatcher */
+        )
     }
 
     @After


### PR DESCRIPTION
This commit updates the `DashboardNewsRepository` to receive its `OkHttpClient` and `Moshi` dependencies via its constructor, removing the hardcoded `.Builder().build()` default instances. This makes the class more testable and flexible for future DI updates. Relevant call sites have been updated to explicitly provide these dependencies.

---
*PR created automatically by Jules for task [9896364457041666411](https://jules.google.com/task/9896364457041666411) started by @dogi*