### PR TITLE
Refactor team member adapters to properly use ListAdapter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 148
-        versionName = "0.1.48"
+        versionCode = 152
+        versionName = "0.1.52"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -81,6 +81,7 @@ class DashboardTeamMembersFragment : Fragment() {
     private var currentTeamPlanetCode: String? = null
     private var currentTeamType: String? = null
     private var isCurrentUserTeamLeader: Boolean = false
+    private var currentUsername: String? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -255,7 +256,7 @@ class DashboardTeamMembersFragment : Fragment() {
                         username.equals(normalizedCurrentUsername, ignoreCase = true)
                     )
             }
-            adapter.currentUsername = normalizedCurrentUsername
+            currentUsername = normalizedCurrentUsername
             updateLeaderActionsVisibility()
             searchQuery = binding.dashboardTeamMembersSearchInput.text?.toString().orEmpty()
             applySearchFilter()
@@ -275,13 +276,13 @@ class DashboardTeamMembersFragment : Fragment() {
     private fun applySearchFilter() {
         val query = searchQuery.trim().lowercase()
         if (currentMembers.isEmpty()) {
-            adapter.submitList(emptyList())
+            updateTeamMembersAdapterList(emptyList())
             binding.dashboardTeamMembersSearchEmptyView.isVisible = false
             binding.dashboardTeamMembersList.isVisible = false
             return
         }
         if (query.isEmpty()) {
-            adapter.submitList(currentMembers)
+            updateTeamMembersAdapterList(currentMembers)
             binding.dashboardTeamMembersSearchEmptyView.isVisible = false
             binding.dashboardTeamMembersList.isVisible = true
             return
@@ -291,7 +292,7 @@ class DashboardTeamMembersFragment : Fragment() {
             val username = member.username?.lowercase().orEmpty()
             name.contains(query) || username.contains(query)
         }
-        adapter.submitList(filtered)
+        updateTeamMembersAdapterList(filtered)
         val hasResults = filtered.isNotEmpty()
         binding.dashboardTeamMembersSearchEmptyView.isVisible = !hasResults
         binding.dashboardTeamMembersList.isVisible = hasResults
@@ -305,14 +306,18 @@ class DashboardTeamMembersFragment : Fragment() {
         currentMembers = emptyList()
         currentTeamPlanetCode = null
         currentTeamType = null
-        adapter.submitList(emptyList())
+        updateTeamMembersAdapterList(emptyList())
         isCurrentUserTeamLeader = false
         updateLeaderActionsVisibility()
     }
 
     private fun updateLeaderActionsVisibility() {
         binding.fabAddMember.isVisible = isCurrentUserTeamLeader
-        adapter.showRemoveAction = isCurrentUserTeamLeader
+    }
+
+    private fun updateTeamMembersAdapterList(list: List<TeamMemberDetails>) {
+        val uiModels = list.map { TeamMemberUiModel(it, isCurrentUserTeamLeader, currentUsername) }
+        adapter.submitList(uiModels)
     }
 
     private fun confirmMemberRemoval(member: TeamMemberDetails) {
@@ -421,6 +426,13 @@ class DashboardTeamMembersFragment : Fragment() {
         private var pendingReset = false
         private var pagingDialog: AlertDialog? = null
         private lateinit var inviteAdapter: InviteMembersAdapter
+        private val currentCandidates = mutableListOf<InviteCandidate>()
+        private val disabledCandidates = mutableSetOf<String>()
+
+        private fun submitCandidates() {
+            val uiModels = currentCandidates.map { InviteCandidateUiModel(it, disabledCandidates.contains(it.username)) }
+            inviteAdapter.submitList(uiModels)
+        }
 
         fun show() {
             inviteAdapter = InviteMembersAdapter(avatarLoader) { candidate ->
@@ -475,7 +487,8 @@ class DashboardTeamMembersFragment : Fragment() {
                 ).show()
                 return
             }
-            inviteAdapter.disableCandidate(candidate.username)
+            disabledCandidates.add(candidate.username)
+            submitCandidates()
             viewLifecycleOwner.lifecycleScope.launch {
                 val result = repository.addTeamMember(
                     baseUrl = base,
@@ -497,7 +510,8 @@ class DashboardTeamMembersFragment : Fragment() {
                         Toast.LENGTH_SHORT
                     ).show()
                 }.onFailure {
-                    inviteAdapter.enableCandidate(candidate.username)
+                    disabledCandidates.remove(candidate.username)
+                    submitCandidates()
                     Toast.makeText(
                         requireContext(),
                         getString(
@@ -542,7 +556,9 @@ class DashboardTeamMembersFragment : Fragment() {
                 nextSkip = 0
                 hasMorePages = true
                 pendingReset = false
-                inviteAdapter.replaceCandidates(emptyList())
+                currentCandidates.clear()
+                disabledCandidates.clear()
+                submitCandidates()
             }
             if (nextSkip == 0) {
                 dialogBinding.inviteMembersLoading.isVisible = true
@@ -569,10 +585,13 @@ class DashboardTeamMembersFragment : Fragment() {
                 toInviteCandidate(user)
             }
             if (reset) {
-                inviteAdapter.replaceCandidates(candidates)
+                currentCandidates.clear()
+                disabledCandidates.clear()
+                currentCandidates.addAll(candidates)
             } else {
-                inviteAdapter.appendCandidates(candidates)
+                currentCandidates.addAll(candidates)
             }
+            submitCandidates()
             if (candidates.size < INVITE_PAGE_SIZE) {
                 hasMorePages = false
             } else {
@@ -655,33 +674,20 @@ class DashboardTeamMembersFragment : Fragment() {
     }
 }
 
-private class TeamMemberDiffCallback : DiffUtil.ItemCallback<TeamMemberDetails>() {
-    override fun areItemsTheSame(oldItem: TeamMemberDetails, newItem: TeamMemberDetails): Boolean {
-        return oldItem.username == newItem.username
-    }
 
-    override fun areContentsTheSame(oldItem: TeamMemberDetails, newItem: TeamMemberDetails): Boolean {
-        return oldItem == newItem
-    }
-}
+private data class TeamMemberUiModel(
+    val member: TeamMemberDetails,
+    val showRemoveAction: Boolean,
+    val currentUsername: String?
+)
 
 private class TeamMembersAdapter(
     private val avatarBinder: (ImageView, String?, Boolean) -> Unit,
     private val onMemberClicked: (TeamMemberDetails) -> Unit,
     private val onRemoveMemberClicked: (TeamMemberDetails) -> Unit
-) : ListAdapter<TeamMemberDetails, TeamMemberViewHolder>(TeamMemberDiffCallback()) {
-
-    var showRemoveAction: Boolean = false
-        set(value) {
-            field = value
-            submitList(currentList.toList())
-        }
-
-    var currentUsername: String? = null
-        set(value) {
-            field = value
-            submitList(currentList.toList())
-        }
+) : ListAdapter<TeamMemberUiModel, TeamMemberViewHolder>(
+    org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback({ oldItem, newItem -> oldItem.member.username == newItem.member.username })
+) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamMemberViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -690,7 +696,8 @@ private class TeamMembersAdapter(
     }
 
     override fun onBindViewHolder(holder: TeamMemberViewHolder, position: Int) {
-        holder.bind(getItem(position), showRemoveAction, currentUsername)
+        val uiModel = getItem(position)
+        holder.bind(uiModel.member, uiModel.showRemoveAction, uiModel.currentUsername)
     }
 }
 
@@ -756,22 +763,21 @@ private data class InviteCandidate(
     val colorRes: Int,
 )
 
-private class InviteCandidateDiffCallback : DiffUtil.ItemCallback<InviteCandidate>() {
-    override fun areItemsTheSame(oldItem: InviteCandidate, newItem: InviteCandidate): Boolean {
-        return oldItem.username == newItem.username
-    }
 
-    override fun areContentsTheSame(oldItem: InviteCandidate, newItem: InviteCandidate): Boolean {
-        return oldItem == newItem
-    }
-}
+private data class InviteCandidateUiModel(
+    val candidate: InviteCandidate,
+    val isDisabled: Boolean
+)
 
 private class InviteMembersAdapter(
     private val avatarLoader: DashboardAvatarLoader?,
     private val onAddClicked: (InviteCandidate) -> Unit
-) : ListAdapter<InviteCandidate, InviteMemberViewHolder>(InviteCandidateDiffCallback()) {
-
-    private val disabledUsernames: MutableSet<String> = mutableSetOf()
+) : ListAdapter<InviteCandidateUiModel, InviteMemberViewHolder>(
+    org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback(
+        areItemsTheSame = { oldItem, newItem -> oldItem.candidate.username == newItem.candidate.username },
+        getChangePayload = { oldItem, newItem -> if (oldItem.isDisabled != newItem.isDisabled) true else null }
+    )
+) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): InviteMemberViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -780,35 +786,18 @@ private class InviteMembersAdapter(
     }
 
     override fun onBindViewHolder(holder: InviteMemberViewHolder, position: Int) {
-        val candidate = getItem(position)
-        holder.bind(candidate, disabledUsernames.contains(candidate.username))
+        val uiModel = getItem(position)
+        holder.bind(uiModel.candidate, uiModel.isDisabled)
     }
 
-    fun replaceCandidates(candidates: List<InviteCandidate>) {
-        disabledUsernames.clear()
-        submitList(candidates)
-    }
-
-    fun appendCandidates(candidates: List<InviteCandidate>) {
-        submitList(currentList + candidates)
-    }
-
-    fun disableCandidate(username: String) {
-        disabledUsernames.add(username)
-        val index = currentList.indexOfFirst { it.username.equals(username, ignoreCase = true) }
-        if (index >= 0) {
-            notifyItemChanged(index)
+    override fun onBindViewHolder(holder: InviteMemberViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isNotEmpty()) {
+            val uiModel = getItem(position)
+            holder.bindPayload(uiModel.isDisabled)
+        } else {
+            super.onBindViewHolder(holder, position, payloads)
         }
     }
-
-    fun enableCandidate(username: String) {
-        disabledUsernames.removeIf { it.equals(username, ignoreCase = true) }
-        val index = currentList.indexOfFirst { it.username.equals(username, ignoreCase = true) }
-        if (index >= 0) {
-            notifyItemChanged(index)
-        }
-    }
-
 }
 
 private class InviteMemberViewHolder(
@@ -827,12 +816,16 @@ private class InviteMemberViewHolder(
         )
         val shouldAttemptLoad = candidate.hasAvatar || candidate.username.isNotBlank()
         avatarLoader?.bind(binding.inviteMemberAvatar, candidate.username, shouldAttemptLoad)
-        binding.inviteMemberAdd.isEnabled = !isDisabled
-        binding.inviteMemberAdd.alpha = if (isDisabled) 0.5f else 1f
+        bindPayload(isDisabled)
         binding.inviteMemberAdd.setOnClickListener {
             if (binding.inviteMemberAdd.isEnabled) {
                 onAddClicked(candidate)
             }
         }
+    }
+
+    fun bindPayload(isDisabled: Boolean) {
+        binding.inviteMemberAdd.isEnabled = !isDisabled
+        binding.inviteMemberAdd.alpha = if (isDisabled) 0.5f else 1f
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/DiffUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/DiffUtils.kt
@@ -5,11 +5,13 @@ import androidx.recyclerview.widget.DiffUtil
 object DiffUtils {
     inline fun <T : Any> itemCallback(
         crossinline areItemsTheSame: (oldItem: T, newItem: T) -> Boolean,
-        crossinline areContentsTheSame: (oldItem: T, newItem: T) -> Boolean = { oldItem, newItem -> oldItem == newItem }
+        crossinline areContentsTheSame: (oldItem: T, newItem: T) -> Boolean = { oldItem, newItem -> oldItem == newItem },
+        crossinline getChangePayload: (oldItem: T, newItem: T) -> Any? = { _, _ -> null }
     ): DiffUtil.ItemCallback<T> {
         return object : DiffUtil.ItemCallback<T>() {
             override fun areItemsTheSame(oldItem: T, newItem: T): Boolean = areItemsTheSame(oldItem, newItem)
             override fun areContentsTheSame(oldItem: T, newItem: T): Boolean = areContentsTheSame(oldItem, newItem)
+            override fun getChangePayload(oldItem: T, newItem: T): Any? = getChangePayload(oldItem, newItem)
         }
     }
 }


### PR DESCRIPTION
Converted adapter logic to rely on `ListAdapter` and view state models (`UiModel`). Fixed unnecessary full-list refreshes caused by implicit internal state modifications in both `TeamMembersAdapter` and `InviteMembersAdapter`. Limits manual updates to one-off payload deliveries.

---
*PR created automatically by Jules for task [6119631857473018970](https://jules.google.com/task/6119631857473018970) started by @dogi*