### PR TITLE
Reduce minimum password length requirement to 1 character

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 152
-        versionName = "0.1.52"
+        versionCode = 153
+        versionName = "0.1.53"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -1158,7 +1158,7 @@ class MyPlanetLite : AppCompatActivity() {
     }
 
     companion object {
-        private const val MIN_PASSWORD_LENGTH = 4
+        private const val MIN_PASSWORD_LENGTH = 1
         const val SECURE_PREFS_NAME = "secure_server_prefs"
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_SERVER_PARENT_CODE = "server_parent_code"

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
@@ -1194,7 +1194,7 @@ class SignupActivity : AppCompatActivity() {
     private fun validatePasswords(): Boolean {
         val password = passwordInput.text?.toString().orEmpty()
         val passwordsMatch = updatePasswordErrorState(showEmptyError = true)
-        return if (password.length < 6) {
+        return if (password.length < 1) {
             passwordLayout.error = getString(R.string.signup_password_error_length)
             if (confirmPasswordLayout.error == getString(R.string.signup_password_error_mismatch)) {
                 confirmPasswordLayout.error = null

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">كلمة المرور</string>
     <string name="login_action">تسجيل الدخول</string>
     <string name="login_username_error">أدخل اسم المستخدم الخاص بك</string>
-    <string name="login_password_error">يجب أن تتكون كلمة المرور من 4 أحرف على الأقل</string>
+    <string name="login_password_error">أدخل كلمة المرور الخاصة بك</string>
     <string name="login_invalid_credentials">اسم المستخدم أو كلمة المرور غير صحيح</string>
     <string name="login_generic_error">تعذّر تسجيل الدخول. حاول مرة أخرى.</string>
     <string name="logo">الشعار</string>
@@ -68,7 +68,7 @@
     <string name="signup_email_label">البريد الإلكتروني</string>
     <string name="signup_email_error_invalid">أدخل بريدًا إلكترونيًا صالحًا</string>
     <string name="signup_password_error_mismatch">يجب أن تتطابق كلمات المرور</string>
-    <string name="signup_password_error_length">يجب أن تتكون كلمة المرور من 6 أحرف على الأقل</string>
+    <string name="signup_password_error_length">أدخل كلمة مرور</string>
     <string name="signup_username_error_invalid">أدخل اسم مستخدم يبدأ بحرف ويستخدم الأحرف والأرقام فقط</string>
     <string name="signup_first_name_error_required">أدخل اسمك الأول</string>
     <string name="signup_last_name_error_required">أدخل اسم عائلتك</string>
@@ -137,7 +137,7 @@
     <string name="signup_step_contact_title">كيف نتواصل معك؟</string>
     <string name="signup_step_contact_subtitle">قدّم بريدك الإلكتروني ورقم جوالك.</string>
     <string name="signup_step_password_title">أنشئ كلمة مرور</string>
-    <string name="signup_step_password_subtitle">استخدم ستة أحرف أو أرقام على الأقل.</string>
+    <string name="signup_step_password_subtitle">استخدم حرفًا واحدًا أو رقمًا واحدًا على الأقل.</string>
     <string name="signup_step_language_title">اللغة والمستوى</string>
     <string name="signup_step_language_subtitle">اختر اللغة والمستوى الذي تفضله.</string>
     <string name="signup_step_license_title">اقبل الترخيص</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">Contraseña</string>
     <string name="login_action">Iniciar sesión</string>
     <string name="login_username_error">Ingresa tu usuario</string>
-    <string name="login_password_error">La contraseña debe tener al menos 4 caracteres</string>
+    <string name="login_password_error">Ingresa tu contraseña</string>
     <string name="login_invalid_credentials">Usuario o contraseña incorrectos</string>
     <string name="login_generic_error">No se pudo iniciar sesión. Intenta nuevamente.</string>
     <string name="login_success_title">Inicio de sesión exitoso</string>
@@ -70,7 +70,7 @@
     <string name="signup_email_label">Correo</string>
     <string name="signup_email_error_invalid">Ingresa un correo válido</string>
     <string name="signup_password_error_mismatch">Las contraseñas deben coincidir</string>
-    <string name="signup_password_error_length">La contraseña debe tener al menos 6 caracteres</string>
+    <string name="signup_password_error_length">Ingresa una contraseña</string>
     <string name="signup_username_error_invalid">Ingresa un usuario que empiece con una letra y use solo letras y números</string>
     <string name="signup_first_name_error_required">Ingresa tu nombre</string>
     <string name="signup_last_name_error_required">Ingresa tu apellido</string>
@@ -139,7 +139,7 @@
     <string name="signup_step_contact_title">¿Cómo te contactamos?</string>
     <string name="signup_step_contact_subtitle">Comparte tu correo y número de celular.</string>
     <string name="signup_step_password_title">Crea una contraseña</string>
-    <string name="signup_step_password_subtitle">Usa al menos seis letras o números.</string>
+    <string name="signup_step_password_subtitle">Usa al menos una letra o número.</string>
     <string name="signup_step_language_title">Idioma y nivel</string>
     <string name="signup_step_language_subtitle">Selecciona el idioma y nivel que prefieres.</string>
     <string name="signup_step_license_title">Acepta la licencia</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">Mot de passe</string>
     <string name="login_action">Se connecter</string>
     <string name="login_username_error">Saisissez votre nom d\'utilisateur</string>
-    <string name="login_password_error">Le mot de passe doit contenir au moins 4 caractères</string>
+    <string name="login_password_error">Saisissez votre mot de passe</string>
     <string name="login_invalid_credentials">Nom d\'utilisateur ou mot de passe incorrect</string>
     <string name="login_generic_error">Impossible de se connecter. Veuillez réessayer.</string>
     <string name="logo">Logo</string>
@@ -68,7 +68,7 @@
     <string name="signup_email_label">Courriel</string>
     <string name="signup_email_error_invalid">Saisissez un courriel valide</string>
     <string name="signup_password_error_mismatch">Les mots de passe doivent correspondre</string>
-    <string name="signup_password_error_length">Le mot de passe doit contenir au moins 6 caractères</string>
+    <string name="signup_password_error_length">Saisissez un mot de passe</string>
     <string name="signup_username_error_invalid">Saisissez un nom d\'utilisateur qui commence par une lettre et utilise uniquement des lettres et des chiffres</string>
     <string name="signup_first_name_error_required">Saisissez votre prénom</string>
     <string name="signup_last_name_error_required">Saisissez votre nom de famille</string>
@@ -137,7 +137,7 @@
     <string name="signup_step_contact_title">Comment vous joindre ?</string>
     <string name="signup_step_contact_subtitle">Indiquez votre courriel et votre numéro de mobile.</string>
     <string name="signup_step_password_title">Créez un mot de passe</string>
-    <string name="signup_step_password_subtitle">Utilisez au moins six lettres ou chiffres.</string>
+    <string name="signup_step_password_subtitle">Utilisez au moins une lettre ou un chiffre.</string>
     <string name="signup_step_language_title">Langue et niveau</string>
     <string name="signup_step_language_subtitle">Choisissez la langue et le niveau que vous préférez.</string>
     <string name="signup_step_license_title">Acceptez la licence</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">पासवर्ड</string>
     <string name="login_action">साइन इन</string>
     <string name="login_username_error">अपना उपयोगकर्ता नाम दर्ज करें</string>
-    <string name="login_password_error">पासवर्ड कम से कम 4 अक्षरों का होना चाहिए</string>
+    <string name="login_password_error">अपना पासवर्ड दर्ज करें</string>
     <string name="login_invalid_credentials">गलत उपयोगकर्ता नाम या पासवर्ड</string>
     <string name="login_generic_error">साइन इन नहीं हो सका। कृपया पुनः प्रयास करें।</string>
     <string name="logo">लोगो</string>
@@ -68,7 +68,7 @@
     <string name="signup_email_label">ईमेल</string>
     <string name="signup_email_error_invalid">मान्य ईमेल पता दर्ज करें</string>
     <string name="signup_password_error_mismatch">पासवर्ड मेल खाने चाहिए</string>
-    <string name="signup_password_error_length">पासवर्ड कम से कम 6 अक्षरों का होना चाहिए</string>
+    <string name="signup_password_error_length">एक पासवर्ड दर्ज करें</string>
     <string name="signup_username_error_invalid">ऐसा उपयोगकर्ता नाम दर्ज करें जो अक्षर से शुरू हो और केवल अक्षर व संख्या उपयोग करे</string>
     <string name="signup_first_name_error_required">अपना पहला नाम दर्ज करें</string>
     <string name="signup_last_name_error_required">अपना अंतिम नाम दर्ज करें</string>
@@ -137,7 +137,7 @@
     <string name="signup_step_contact_title">हम आपसे कैसे संपर्क करें?</string>
     <string name="signup_step_contact_subtitle">अपना ईमेल और मोबाइल नंबर साझा करें।</string>
     <string name="signup_step_password_title">पासवर्ड बनाएं</string>
-    <string name="signup_step_password_subtitle">कम से कम छह अक्षर या संख्या उपयोग करें।</string>
+    <string name="signup_step_password_subtitle">कम से कम एक अक्षर या संख्या उपयोग करें।</string>
     <string name="signup_step_language_title">भाषा और स्तर</string>
     <string name="signup_step_language_subtitle">वह भाषा और स्तर चुनें जिसे आप पसंद करते हैं।</string>
     <string name="signup_step_license_title">लाइसेंस स्वीकार करें</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">पासवर्ड</string>
     <string name="login_action">साइन इन गर्नुहोस्</string>
     <string name="login_username_error">तपाईंको प्रयोगकर्तानाम लेख्नुहोस्</string>
-    <string name="login_password_error">पासवर्ड कम्तीमा ४ वर्णको हुनुपर्छ</string>
+    <string name="login_password_error">तपाईंको पासवर्ड लेख्नुहोस्</string>
     <string name="login_invalid_credentials">प्रयोगकर्तानाम वा पासवर्ड मेल खान्दैन</string>
     <string name="login_generic_error">साइन इन गर्न सकेन। कृपया फेरि प्रयास गर्नुहोस्।</string>
     <string name="logo">लोगो</string>
@@ -68,7 +68,7 @@
     <string name="signup_email_label">इमेल</string>
     <string name="signup_email_error_invalid">वैध इमेल लेख्नुहोस्</string>
     <string name="signup_password_error_mismatch">पासवर्डहरू मिल्नुपर्छ</string>
-    <string name="signup_password_error_length">पासवर्ड कम्तीमा ६ अक्षरको हुनुपर्छ</string>
+    <string name="signup_password_error_length">पासवर्ड लेख्नुहोस्</string>
     <string name="signup_username_error_invalid">कृपया अक्षरबाट सुरु हुने र केवल अक्षर तथा अंक प्रयोग गर्ने प्रयोगकर्तानाम लेख्नुहोस्</string>
     <string name="signup_first_name_error_required">आफ्नो नाम लेख्नुहोस्</string>
     <string name="signup_last_name_error_required">आफ्नो थर लेख्नुहोस्</string>
@@ -99,7 +99,7 @@
     <string name="signup_step_contact_title">हामी तपाईंलाई कसरी सम्पर्क गर्ने?</string>
     <string name="signup_step_contact_subtitle">आफ्नो इमेल र मोबाइल नम्बर दिनुहोस्।</string>
     <string name="signup_step_password_title">पासवर्ड बनाउनुहोस्</string>
-    <string name="signup_step_password_subtitle">कम्तीमा छ वटा अक्षर वा अंक प्रयोग गर्नुहोस्।</string>
+    <string name="signup_step_password_subtitle">कम्तीमा एउटा अक्षर वा अंक प्रयोग गर्नुहोस्।</string>
     <string name="signup_step_language_title">भाषा र स्तर</string>
     <string name="signup_step_language_subtitle">आफ्नो मनपर्ने भाषा र स्तर छान्नुहोस्।</string>
     <string name="signup_step_license_title">लाइसेन्स स्वीकार गर्नुहोस्</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">Senha</string>
     <string name="login_action">Entrar</string>
     <string name="login_username_error">Digite seu nome de usuário</string>
-    <string name="login_password_error">A senha deve ter pelo menos 4 caracteres</string>
+    <string name="login_password_error">Digite sua senha</string>
     <string name="login_invalid_credentials">Nome de usuário ou senha incorretos</string>
     <string name="login_generic_error">Não foi possível entrar. Tente novamente.</string>
     <string name="logo">Logotipo</string>
@@ -68,7 +68,7 @@
     <string name="signup_email_label">E-mail</string>
     <string name="signup_email_error_invalid">Digite um endereço de e-mail válido</string>
     <string name="signup_password_error_mismatch">As senhas devem coincidir</string>
-    <string name="signup_password_error_length">A senha deve ter pelo menos 6 caracteres</string>
+    <string name="signup_password_error_length">Digite uma senha</string>
     <string name="signup_username_error_invalid">Digite um nome de usuário que comece com uma letra e use apenas letras e números</string>
     <string name="signup_first_name_error_required">Digite seu nome</string>
     <string name="signup_last_name_error_required">Digite seu sobrenome</string>
@@ -137,7 +137,7 @@
     <string name="signup_step_contact_title">Como podemos falar com você?</string>
     <string name="signup_step_contact_subtitle">Informe seu e-mail e número de celular.</string>
     <string name="signup_step_password_title">Crie uma senha</string>
-    <string name="signup_step_password_subtitle">Use pelo menos seis letras ou números.</string>
+    <string name="signup_step_password_subtitle">Use pelo menos uma letra ou número.</string>
     <string name="signup_step_language_title">Idioma e nível</string>
     <string name="signup_step_language_subtitle">Escolha o idioma e o nível de sua preferência.</string>
     <string name="signup_step_license_title">Aceite a licença</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">Furaha sirta ah</string>
     <string name="login_action">Soo gal</string>
     <string name="login_username_error">Geli magacaaga isticmaale</string>
-    <string name="login_password_error">Furaha sirta ah waa inuu lahaadaa ugu yaraan 4 xaraf</string>
+    <string name="login_password_error">Geli furahaaga sirta ah</string>
     <string name="login_invalid_credentials">Magaca isticmaale ama eray sir ah khaldan</string>
     <string name="login_generic_error">Lama suurtagelin in la galo. Fadlan isku day mar kale.</string>
     <string name="logo">Logo</string>
@@ -68,7 +68,7 @@
     <string name="signup_email_label">Iimayl</string>
     <string name="signup_email_error_invalid">Geli iimayl sax ah</string>
     <string name="signup_password_error_mismatch">Furaha sirta waa in ay is waafaqaan</string>
-    <string name="signup_password_error_length">Furaha sirta waa inuu lahaadaa ugu yaraan 6 xaraf ama tiro</string>
+    <string name="signup_password_error_length">Geli furaha sirta ah</string>
     <string name="signup_username_error_invalid">Geli magac isticmaale oo ka bilaabma xaraf oo isticmaala keliya xarfo iyo tirooyin</string>
     <string name="signup_first_name_error_required">Geli magacaaga koowaad</string>
     <string name="signup_last_name_error_required">Geli magaca qoyskaaga</string>
@@ -99,7 +99,7 @@
     <string name="signup_step_contact_title">Sideen kuu gaarnaa?</string>
     <string name="signup_step_contact_subtitle">La wadaag iimaylkaaga iyo lambarka taleefanka.</string>
     <string name="signup_step_password_title">Abuur furaha sirta ah</string>
-    <string name="signup_step_password_subtitle">Isticmaal ugu yaraan lix xaraf ama tiro.</string>
+    <string name="signup_step_password_subtitle">Isticmaal ugu yaraan hal xaraf ama tiro.</string>
     <string name="signup_step_language_title">Luqad iyo heer</string>
     <string name="signup_step_language_subtitle">Dooro luqadda iyo heerka aad doorbidayso.</string>
     <string name="signup_step_license_title">Aqbal shatiga</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="login_password_label">Password</string>
     <string name="login_action">Login</string>
     <string name="login_username_error">Enter your username</string>
-    <string name="login_password_error">The password must be at least 4 characters long</string>
+    <string name="login_password_error">Enter your password</string>
     <string name="login_invalid_credentials">Incorrect username or password</string>
     <string name="login_generic_error">Couldn\'t sign in. Please try again.</string>
     <string name="login_success_title">Login Successful</string>
@@ -70,7 +70,7 @@
     <string name="signup_email_label">Email</string>
     <string name="signup_email_error_invalid">Enter a valid email address</string>
     <string name="signup_password_error_mismatch">Passwords must match</string>
-    <string name="signup_password_error_length">Password must be at least 6 characters long</string>
+    <string name="signup_password_error_length">Enter a password</string>
     <string name="signup_username_error_invalid">Enter a username that starts with a letter and uses only letters and numbers</string>
     <string name="signup_first_name_error_required">Enter your first name</string>
     <string name="signup_last_name_error_required">Enter your last name</string>
@@ -139,7 +139,7 @@
     <string name="signup_step_contact_title">How can we reach you?</string>
     <string name="signup_step_contact_subtitle">Share your email and mobile number.</string>
     <string name="signup_step_password_title">Create a password</string>
-    <string name="signup_step_password_subtitle">Use at least six letters or numbers.</string>
+    <string name="signup_step_password_subtitle">Use at least one letter or number.</string>
     <string name="signup_step_language_title">Language and level</string>
     <string name="signup_step_language_subtitle">Choose the language and level you prefer.</string>
     <string name="signup_step_license_title">Accept the license</string>


### PR DESCRIPTION
The minimum password length requirement has been reduced to 1 character for both login and registration. The validation logic in MyPlanetLite.kt and SignupActivity.kt has been updated. Additionally, all relevant string resources, including localized versions, have been updated to reflect the new requirement.

---
*PR created automatically by Jules for task [12679720583937025521](https://jules.google.com/task/12679720583937025521) started by @PlataformasInformaticas*