### PR TITLE
🧪 [testing improvement] Add tests for DiffUtils.itemCallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 152
-        versionName = "0.1.52"
+        versionCode = 154
+        versionName = "0.1.54"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DiffUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DiffUtilsTest.kt
@@ -1,0 +1,82 @@
+package org.ole.planet.myplanet.lite.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiffUtilsTest {
+
+    data class TestItem(val id: Int, val content: String)
+
+    @Test
+    fun `itemCallback uses areItemsTheSame lambda correctly`() {
+        val callback = DiffUtils.itemCallback<TestItem>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id }
+        )
+
+        val item1 = TestItem(1, "A")
+        val item2 = TestItem(1, "B")
+        val item3 = TestItem(2, "A")
+
+        assertTrue(callback.areItemsTheSame(item1, item2))
+        assertFalse(callback.areItemsTheSame(item1, item3))
+    }
+
+    @Test
+    fun `itemCallback uses default areContentsTheSame lambda correctly`() {
+        val callback = DiffUtils.itemCallback<TestItem>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id }
+        )
+
+        val item1 = TestItem(1, "A")
+        val item2 = TestItem(1, "A")
+        val item3 = TestItem(1, "B")
+
+        assertTrue(callback.areContentsTheSame(item1, item2))
+        assertFalse(callback.areContentsTheSame(item1, item3))
+    }
+
+    @Test
+    fun `itemCallback uses custom areContentsTheSame lambda correctly`() {
+        val callback = DiffUtils.itemCallback<TestItem>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
+            areContentsTheSame = { oldItem, newItem -> oldItem.content == newItem.content }
+        )
+
+        val item1 = TestItem(1, "A")
+        val item2 = TestItem(2, "A")
+        val item3 = TestItem(1, "B")
+
+        assertTrue(callback.areContentsTheSame(item1, item2))
+        assertFalse(callback.areContentsTheSame(item1, item3))
+    }
+
+    @Test
+    fun `itemCallback uses default getChangePayload lambda correctly`() {
+        val callback = DiffUtils.itemCallback<TestItem>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id }
+        )
+
+        val item1 = TestItem(1, "A")
+        val item2 = TestItem(1, "B")
+
+        assertNull(callback.getChangePayload(item1, item2))
+    }
+
+    @Test
+    fun `itemCallback uses custom getChangePayload lambda correctly`() {
+        val callback = DiffUtils.itemCallback<TestItem>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
+            getChangePayload = { oldItem, newItem -> if (oldItem.content != newItem.content) "ContentChanged" else null }
+        )
+
+        val item1 = TestItem(1, "A")
+        val item2 = TestItem(1, "B")
+        val item3 = TestItem(1, "A")
+
+        assertEquals("ContentChanged", callback.getChangePayload(item1, item2))
+        assertNull(callback.getChangePayload(item1, item3))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `DiffUtils.itemCallback` was addressed by creating a new test file `DiffUtilsTest.kt`.
📊 **Coverage:** The tests now cover custom and default lambda behaviors for `areItemsTheSame`, `areContentsTheSame`, and `getChangePayload`.
✨ **Result:** The improvement in test coverage ensures the reliability of the `DiffUtils` object.

---
*PR created automatically by Jules for task [6897300188486173395](https://jules.google.com/task/6897300188486173395) started by @dogi*