### PR TITLE
🔒 [security fix] Obscure database name and disable backups

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 152
-        versionName = "0.1.52"
+        versionCode = 156
+        versionName = "0.1.56"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:enableOnBackInvokedCallback="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabase.kt
@@ -14,7 +14,8 @@ import android.database.sqlite.SQLiteOpenHelper
 import org.ole.planet.myplanet.lite.util.getBlobOrNull
 import org.ole.planet.myplanet.lite.util.getStringOrNull
 
-private const val DATABASE_NAME = "user_profile.db"
+private const val DATABASE_NAME = ".user_profile_data.db"
+private const val LEGACY_DATABASE_NAME = "user_profile.db"
 private const val DATABASE_VERSION = 4
 private const val TABLE_PROFILE = "user_profile"
 private const val COLUMN_ID = "id"
@@ -157,7 +158,18 @@ class UserProfileDatabase private constructor(context: Context) :
 
         fun getInstance(context: Context): UserProfileDatabase {
             return instance ?: synchronized(this) {
+                if (instance == null) {
+                    migrateLegacyDatabase(context)
+                }
                 instance ?: UserProfileDatabase(context).also { instance = it }
+            }
+        }
+
+        private fun migrateLegacyDatabase(context: Context) {
+            val legacyDbFile = context.getDatabasePath(LEGACY_DATABASE_NAME)
+            if (legacyDbFile.exists()) {
+                val newDbFile = context.getDatabasePath(DATABASE_NAME)
+                legacyDbFile.renameTo(newDbFile)
             }
         }
     }


### PR DESCRIPTION
### 🎯 **What:** The vulnerability fixed
Hardcoded, predictable SQLite database name (`user_profile.db`) and enabled application backups (`android:allowBackup="true"`).

### ⚠️ **Risk:** The potential impact if left unfixed
A predictable database name combined with enabled backups allows an attacker with physical access (via ADB) or access to a user's cloud backup to easily extract and read sensitive profile data, including emails, phone numbers, and derived keys.

### 🛡️ **Solution:** How the fix addresses the vulnerability
- **Obscurity:** Changed the database name to a hidden file format (`.user_profile_data.db`).
- **Data Integrity:** Added a migration step that renames the old database file to the new name on the first run, ensuring no data loss for existing users.
- **Hardening:** Disabled application backups globally in the manifest to ensure that local sensitive data remains confined to the device's protected internal storage.

---
*PR created automatically by Jules for task [7525581983197999523](https://jules.google.com/task/7525581983197999523) started by @dogi*