### PR TITLE
🧪 Add tests for DashboardImagePreviewAdapter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 152
-        versionName = "0.1.52"
+        versionCode = 158
+        versionName = "0.1.58"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 158
-        versionName = "0.1.58"
+        versionCode = 164
+        versionName = "0.1.64"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/android/util/Log.java
+++ b/app/src/test/java/android/util/Log.java
@@ -8,59 +8,18 @@ public class Log {
     public static final int ERROR = 6;
     public static final int ASSERT = 7;
 
-    public static int v(String tag, String msg) {
-        return 0;
-    }
-
-    public static int v(String tag, String msg, Throwable tr) {
-        return 0;
-    }
-
-    public static int d(String tag, String msg) {
-        return 0;
-    }
-
-    public static int d(String tag, String msg, Throwable tr) {
-        return 0;
-    }
-
-    public static int i(String tag, String msg) {
-        return 0;
-    }
-
-    public static int i(String tag, String msg, Throwable tr) {
-        return 0;
-    }
-
-    public static int w(String tag, String msg) {
-        return 0;
-    }
-
-    public static int w(String tag, String msg, Throwable tr) {
-        return 0;
-    }
-
-    public static int w(String tag, Throwable tr) {
-        return 0;
-    }
-
-    public static int e(String tag, String msg) {
-        return 0;
-    }
-
-    public static int e(String tag, String msg, Throwable tr) {
-        return 0;
-    }
-
-    public static int println(int priority, String tag, String msg) {
-        return 0;
-    }
-
-    public static boolean isLoggable(String tag, int level) {
-        return false;
-    }
-
-    public static String getStackTraceString(Throwable tr) {
-        return "";
-    }
+    public static int v(String tag, String msg) { return 0; }
+    public static int v(String tag, String msg, Throwable tr) { return 0; }
+    public static int d(String tag, String msg) { return 0; }
+    public static int d(String tag, String msg, Throwable tr) { return 0; }
+    public static int i(String tag, String msg) { return 0; }
+    public static int i(String tag, String msg, Throwable tr) { return 0; }
+    public static int w(String tag, String msg) { return 0; }
+    public static int w(String tag, String msg, Throwable tr) { return 0; }
+    public static int w(String tag, Throwable tr) { return 0; }
+    public static int e(String tag, String msg) { return 0; }
+    public static int e(String tag, String msg, Throwable tr) { return 0; }
+    public static int println(int priority, String tag, String msg) { return 0; }
+    public static boolean isLoggable(String tag, int level) { return false; }
+    public static String getStackTraceString(Throwable tr) { return ""; }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivityRobolectricTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivityRobolectricTest.kt
@@ -17,22 +17,29 @@ import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowToast
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class CreateVoiceActivityRobolectricTest {
 
+    private fun buildActivityController(): ActivityController<CreateVoiceActivity> {
+        return Robolectric.buildActivity(CreateVoiceActivity::class.java).also {
+            it.get().setTheme(R.style.Theme_MyPlanetLite)
+        }.create().start().resume()
+    }
+
     @Test
     fun `test activity launches successfully`() {
-        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val controller = buildActivityController()
         val activity = controller.get()
         assertNotNull(activity)
     }
 
     @Test
     fun `test initial UI state`() {
-        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val controller = buildActivityController()
         val activity = controller.get()
 
         val createVoiceInput: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
@@ -55,7 +62,7 @@ class CreateVoiceActivityRobolectricTest {
 
     @Test
     fun `attemptPost shows empty error toast when message is blank`() {
-        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val controller = buildActivityController()
         val activity = controller.get()
 
         val submitButton: MaterialButton = activity.findViewById(R.id.createVoiceSubmitButton)
@@ -71,7 +78,7 @@ class CreateVoiceActivityRobolectricTest {
 
     @Test
     fun `attemptPost shows missing server toast when base url is blank`() {
-        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val controller = buildActivityController()
         val activity = controller.get()
 
         val input: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
@@ -92,7 +99,7 @@ class CreateVoiceActivityRobolectricTest {
         // Mocking or circumventing the secure preferences exception for now
         ProfileCredentialsStore.setSessionCredentials(null)
         org.ole.planet.myplanet.lite.util.SecurePreferencesProvider.injectedPreferences = org.mockito.Mockito.mock(android.content.SharedPreferences::class.java)
-        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val controller = buildActivityController()
         val activity = controller.get()
 
         val input: TextInputEditText = activity.findViewById(R.id.createVoiceInput)
@@ -116,7 +123,7 @@ class CreateVoiceActivityRobolectricTest {
 
     @Test
     fun `attemptPost shows confirmation dialog when valid`() {
-        val controller = Robolectric.buildActivity(CreateVoiceActivity::class.java).create().start().resume()
+        val controller = buildActivityController()
         val activity = controller.get()
 
         val input: TextInputEditText = activity.findViewById(R.id.createVoiceInput)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardImagePreviewAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardImagePreviewAdapterTest.kt
@@ -1,0 +1,102 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import androidx.core.view.isVisible
+import androidx.test.core.app.ApplicationProvider
+import com.github.chrisbanes.photoview.PhotoView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.ole.planet.myplanet.lite.R
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DashboardImagePreviewAdapterTest {
+
+    private lateinit var adapter: DashboardImagePreviewAdapter
+    private lateinit var imageLoader: DashboardPostImageLoader
+    private var dismissCount = 0
+
+    @Before
+    fun setup() {
+        dismissCount = 0
+        imageLoader = mock()
+        val imagePaths = listOf("path1", "path2")
+        adapter = DashboardImagePreviewAdapter(imagePaths, imageLoader) {
+            dismissCount++
+        }
+    }
+
+    @Test
+    fun `getItemCount returns correct size`() {
+        assertEquals(2, adapter.itemCount)
+    }
+
+    @Test
+    fun `onCreateViewHolder inflates layout`() {
+        val parent = FrameLayout(ApplicationProvider.getApplicationContext())
+        val viewHolder = adapter.onCreateViewHolder(parent, 0)
+
+        val photoView = viewHolder.itemView.findViewById<PhotoView>(R.id.previewPhotoView)
+        assertEquals(5f, photoView.maximumScale)
+        assertEquals(2.5f, photoView.mediumScale)
+        assertEquals(0.6f, photoView.minimumScale)
+    }
+
+    @Test
+    fun `onBindViewHolder binds image successfully`() {
+        val parent = FrameLayout(ApplicationProvider.getApplicationContext())
+        val viewHolder = adapter.onCreateViewHolder(parent, 0)
+        val photoView = viewHolder.itemView.findViewById<PhotoView>(R.id.previewPhotoView)
+        val progressBar = viewHolder.itemView.findViewById<ProgressBar>(R.id.previewPageLoading)
+
+        // Mock image loader to invoke the callback with success = true
+        doAnswer { invocation ->
+            val callback = invocation.getArgument<((Boolean) -> Unit)?>(2)
+            callback?.invoke(true)
+            null
+        }.`when`(imageLoader).bind(any(), eq("path1"), anyOrNull())
+
+        adapter.onBindViewHolder(viewHolder, 0)
+
+        verify(imageLoader).bind(eq(photoView), eq("path1"), anyOrNull())
+
+        assertFalse(progressBar.isVisible)
+        assertTrue(photoView.isVisible)
+        assertEquals(0, dismissCount)
+    }
+
+    @Test
+    fun `onBindViewHolder dismisses on image load failure`() {
+        val parent = FrameLayout(ApplicationProvider.getApplicationContext())
+        val viewHolder = adapter.onCreateViewHolder(parent, 0)
+        val photoView = viewHolder.itemView.findViewById<PhotoView>(R.id.previewPhotoView)
+        val progressBar = viewHolder.itemView.findViewById<ProgressBar>(R.id.previewPageLoading)
+
+        // Mock image loader to invoke the callback with success = false
+        doAnswer { invocation ->
+            val callback = invocation.getArgument<((Boolean) -> Unit)?>(2)
+            callback?.invoke(false)
+            null
+        }.`when`(imageLoader).bind(any(), eq("path2"), anyOrNull())
+
+        adapter.onBindViewHolder(viewHolder, 1)
+
+        verify(imageLoader).bind(eq(photoView), eq("path2"), anyOrNull())
+
+        assertFalse(progressBar.isVisible)
+        assertFalse(photoView.isVisible)
+        assertEquals(1, dismissCount)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `DashboardImagePreviewAdapter` was addressed by adding missing test coverage.
📊 **Coverage:** The new test covers `getItemCount`, layout inflation (`onCreateViewHolder`) asserting correct `PhotoView` scale settings, and binding logic (`onBindViewHolder`). Specifically, it tests both the successful image load path (asserting visibility and correct loader behavior) and the failed load path (asserting UI state and that the `onDismissRequested` callback is triggered).
✨ **Result:** Increased unit test coverage and reliability for the dashboard image preview feature, ensuring visual components behave as expected during runtime network states.

---
*PR created automatically by Jules for task [8458042803234782551](https://jules.google.com/task/8458042803234782551) started by @dogi*