### PR TITLE
🧹 [Code Health] Extract markdown image resolution logic into a shared utility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 152
-        versionName = "0.1.52"
+        versionCode = 159
+        versionName = "0.1.59"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import android.view.View
 import android.widget.ImageButton
 import android.widget.LinearLayout
@@ -859,56 +860,7 @@ class CourseWizardActivity : AppCompatActivity() {
     }
 
     private fun resolveOfflineMarkdownImages(markdown: String): String {
-        val safeCourseId = courseId?.takeIf { it.isNotBlank() } ?: return markdown
-        var resolved = markdown
-        val markdownPattern = Regex("""!\[([^]]*)]\(([^)\s]+)(?:\s+"[^"]*")?\)""")
-        resolved = markdownPattern.replace(resolved) { match ->
-            val alt = match.groupValues[1]
-            val source = normalizeMarkdownImageSource(match.groupValues[2])
-            val local = OfflineCourseStorage.localMarkdownImageUri(this, safeCourseId, source)
-            val selected = local ?: resolveMarkdownSourceUrl(source) ?: source
-            "![$alt]($selected)"
-        }
-        val htmlPattern = Regex("""<img\b[^>]*>""", RegexOption.IGNORE_CASE)
-        val srcAttributePattern = Regex("""\bsrc\s*=\s*["']([^"']+)["']""", RegexOption.IGNORE_CASE)
-        val altAttributePattern = Regex("""\balt\s*=\s*["']([^"']*)["']""", RegexOption.IGNORE_CASE)
-        resolved = htmlPattern.replace(resolved) { match ->
-            val imageTag = match.value
-            val source = normalizeMarkdownImageSource(
-                srcAttributePattern.find(imageTag)?.groupValues?.get(1).orEmpty()
-            )
-            if (source.isBlank()) {
-                return@replace imageTag
-            }
-            val alt = altAttributePattern.find(imageTag)?.groupValues?.get(1).orEmpty()
-            val local = OfflineCourseStorage.localMarkdownImageUri(this, safeCourseId, source)
-            val selected = local ?: resolveMarkdownSourceUrl(source) ?: source
-            "![$alt]($selected)"
-        }
-        return resolved
-    }
-
-    private fun resolveMarkdownSourceUrl(source: String): String? {
-        val trimmed = source.trim()
-        if (trimmed.isBlank()) return null
-        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed
-        if (trimmed.startsWith("file://")) return trimmed
-        val normalizedBase = baseUrl?.trim()?.trimEnd('/').orEmpty()
-        if (normalizedBase.isBlank()) return null
-        val normalizedPath = trimmed.trimStart('/')
-        val finalPath = if (normalizedPath.startsWith("db/")) normalizedPath else "db/$normalizedPath"
-        return "$normalizedBase/$finalPath"
-    }
-
-    private fun normalizeMarkdownImageSource(rawSource: String): String {
-        var value = rawSource.trim()
-        if (value.startsWith("<") && value.endsWith(">")) {
-            value = value.removePrefix("<").removeSuffix(">")
-        }
-        if (value.contains(" ")) {
-            value = value.substringBefore(" ")
-        }
-        return value.trim()
+        return MarkdownUtils.resolveOfflineMarkdownImages(this, markdown, courseId, baseUrl)
     }
 
     data class StepDisplay(

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -9,6 +9,7 @@ package org.ole.planet.myplanet.lite
 import android.content.Intent
 import android.graphics.Rect
 import android.os.Bundle
+import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
@@ -810,7 +811,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             onProgress(downloaded to totalItems)
         }
         markdownImageSources.forEach { source ->
-            val resolvedUrl = resolveMarkdownSourceUrl(base, source) ?: return@forEach
+            val resolvedUrl = MarkdownUtils.resolveMarkdownSourceUrl(base, source) ?: return@forEach
             val target = OfflineCourseStorage.markdownImageFile(requireContext(), course.id, source)
             target.parentFile?.mkdirs()
             val request = Request.Builder()
@@ -842,7 +843,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         var total = 0L
         val authHeader = Credentials.basic(creds.username, creds.password)
         sources.forEach { source ->
-            val url = resolveMarkdownSourceUrl(base, source) ?: return@forEach
+            val url = MarkdownUtils.resolveMarkdownSourceUrl(base, source) ?: return@forEach
             val request = Request.Builder()
                 .url(url)
                 .head()
@@ -859,42 +860,9 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
     }
 
     private fun extractMarkdownImageSources(course: CourseItem): List<String> {
-        val markdownPattern = Regex("""!\[[^\]]*]\(([^)]+)\)""")
-        val htmlPattern = Regex("""<img[^>]+src=["']([^"']+)["']""", RegexOption.IGNORE_CASE)
-        fun extractFromText(text: String): List<String> {
-            val fromMarkdown = markdownPattern.findAll(text)
-                .map { normalizeMarkdownImageSource(it.groupValues[1]) }
-                .toList()
-            val fromHtml = htmlPattern.findAll(text)
-                .map { normalizeMarkdownImageSource(it.groupValues[1]) }
-                .toList()
-            return (fromMarkdown + fromHtml).filter { it.isNotBlank() }
-        }
-        val fromCourseDescription = extractFromText(course.description)
-        val fromSteps = course.steps.flatMap { step -> extractFromText(step.description) }
+        val fromCourseDescription = MarkdownUtils.extractImageSourcesFromText(course.description)
+        val fromSteps = course.steps.flatMap { step -> MarkdownUtils.extractImageSourcesFromText(step.description) }
         return (fromCourseDescription + fromSteps).distinct()
-    }
-
-    private fun normalizeMarkdownImageSource(rawSource: String): String {
-        var value = rawSource.trim()
-        if (value.startsWith("<") && value.endsWith(">")) {
-            value = value.removePrefix("<").removeSuffix(">")
-        }
-        if (value.contains(" ")) {
-            value = value.substringBefore(" ")
-        }
-        return value.trim()
-    }
-
-    private fun resolveMarkdownSourceUrl(base: String, source: String): String? {
-        val trimmed = source.trim()
-        if (trimmed.isBlank()) return null
-        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed
-        val normalizedBase = base.trim().trimEnd('/')
-        if (normalizedBase.isBlank()) return null
-        val normalizedPath = trimmed.trimStart('/')
-        val finalPath = if (normalizedPath.startsWith("db/")) normalizedPath else "db/$normalizedPath"
-        return "$normalizedBase/$finalPath"
     }
 
     private fun buildServerResourceUrl(base: String, resource: CourseItem.LessonResource): String? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/MarkdownUtils.kt
@@ -1,0 +1,77 @@
+package org.ole.planet.myplanet.lite.util
+
+import android.content.Context
+import org.ole.planet.myplanet.lite.OfflineCourseStorage
+
+object MarkdownUtils {
+
+    fun normalizeMarkdownImageSource(rawSource: String): String {
+        var value = rawSource.trim()
+        if (value.startsWith("<") && value.endsWith(">")) {
+            value = value.removePrefix("<").removeSuffix(">")
+        }
+        if (value.contains(" ")) {
+            value = value.substringBefore(" ")
+        }
+        return value.trim()
+    }
+
+    fun resolveMarkdownSourceUrl(base: String?, source: String): String? {
+        val trimmed = source.trim()
+        if (trimmed.isBlank()) return null
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed
+        if (trimmed.startsWith("file://")) return trimmed
+        val normalizedBase = base?.trim()?.trimEnd('/').orEmpty()
+        if (normalizedBase.isBlank()) return null
+        val normalizedPath = trimmed.trimStart('/')
+        val finalPath = if (normalizedPath.startsWith("db/")) normalizedPath else "db/$normalizedPath"
+        return "$normalizedBase/$finalPath"
+    }
+
+    fun extractImageSourcesFromText(text: String): List<String> {
+        val markdownPattern = Regex("""!\[[^\]]*]\(([^)]+)\)""")
+        val htmlPattern = Regex("""<img[^>]+src=["']([^"']+)["']""", RegexOption.IGNORE_CASE)
+        val fromMarkdown = markdownPattern.findAll(text)
+            .map { normalizeMarkdownImageSource(it.groupValues[1]) }
+            .toList()
+        val fromHtml = htmlPattern.findAll(text)
+            .map { normalizeMarkdownImageSource(it.groupValues[1]) }
+            .toList()
+        return (fromMarkdown + fromHtml).filter { it.isNotBlank() }
+    }
+
+    fun resolveOfflineMarkdownImages(
+        context: Context,
+        markdown: String,
+        courseId: String?,
+        baseUrl: String?
+    ): String {
+        val safeCourseId = courseId?.takeIf { it.isNotBlank() } ?: return markdown
+        var resolved = markdown
+        val markdownPattern = Regex("""!\[([^]]*)]\(([^)\s]+)(?:\s+"[^"]*")?\)""")
+        resolved = markdownPattern.replace(resolved) { match ->
+            val alt = match.groupValues[1]
+            val source = normalizeMarkdownImageSource(match.groupValues[2])
+            val local = OfflineCourseStorage.localMarkdownImageUri(context, safeCourseId, source)
+            val selected = local ?: resolveMarkdownSourceUrl(baseUrl, source) ?: source
+            "![$alt]($selected)"
+        }
+        val htmlPattern = Regex("""<img\b[^>]*>""", RegexOption.IGNORE_CASE)
+        val srcAttributePattern = Regex("""\bsrc\s*=\s*["']([^"']+)["']""", RegexOption.IGNORE_CASE)
+        val altAttributePattern = Regex("""\balt\s*=\s*["']([^"']*)["']""", RegexOption.IGNORE_CASE)
+        resolved = htmlPattern.replace(resolved) { match ->
+            val imageTag = match.value
+            val source = normalizeMarkdownImageSource(
+                srcAttributePattern.find(imageTag)?.groupValues?.get(1).orEmpty()
+            )
+            if (source.isBlank()) {
+                return@replace imageTag
+            }
+            val alt = altAttributePattern.find(imageTag)?.groupValues?.get(1).orEmpty()
+            val local = OfflineCourseStorage.localMarkdownImageUri(context, safeCourseId, source)
+            val selected = local ?: resolveMarkdownSourceUrl(baseUrl, source) ?: source
+            "![$alt]($selected)"
+        }
+        return resolved
+    }
+}

--- a/test_script.kt
+++ b/test_script.kt
@@ -1,0 +1,5 @@
+import java.io.File
+
+fun main() {
+    println("Test script")
+}

--- a/test_script.kt
+++ b/test_script.kt
@@ -1,5 +1,0 @@
-import java.io.File
-
-fun main() {
-    println("Test script")
-}


### PR DESCRIPTION
🎯 **What:** Extracted duplicated logic for resolving markdown/images into a shared `MarkdownUtils` utility object. Removed the private duplicates in `CourseWizardActivity.kt` and `DashboardCoursePageFragment.kt`. Cleaned up stray test files.

💡 **Why:** Reduces code duplication, centralizes image resolution logic, and improves maintainability across the application.

✅ **Verification:** Ran `./gradlew compileDebugKotlin` and `./gradlew testDebugUnitTest` to ensure the project compiles and no regressions were introduced.

✨ **Result:** Improved code health and readability by reusing a centralized utility object.

---
*PR created automatically by Jules for task [15788075357520630686](https://jules.google.com/task/15788075357520630686) started by @dogi*