### PR TITLE
🧹 Refactor renderLanguageLevelStep in SurveyWizardFragment to reduce complexity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 152
-        versionName = "0.1.52"
+        versionCode = 161
+        versionName = "0.1.61"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
@@ -1149,6 +1149,38 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         return container to collector
     }
 
+    private fun createDropdownLayout(context: android.content.Context, hintText: String): Pair<TextInputLayout, AutoCompleteTextView> {
+        val layout = TextInputLayout(context).apply {
+            hint = hintText
+            layoutParams = LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        }
+        val input = AutoCompleteTextView(context).apply {
+            inputType = InputType.TYPE_NULL
+            keyListener = null
+            setOnClickListener { showDropDown() }
+            setOnFocusChangeListener { _, hasFocus -> if (hasFocus) showDropDown() }
+        }
+        layout.addView(input)
+        return layout to input
+    }
+
+    private fun levelArrayForLanguage(languageLabel: String?): Int {
+        val normalized = languageLabel?.trim()?.lowercase(Locale.ROOT)
+        return when (normalized) {
+            getString(R.string.language_name_spanish).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_es
+            getString(R.string.language_name_french).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_fr
+            getString(R.string.language_name_portuguese).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_pt
+            getString(R.string.language_name_arabic).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_ar
+            getString(R.string.language_name_somali).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_so
+            getString(R.string.language_name_nepali).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_ne
+            getString(R.string.language_name_hindi).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_hi
+            else -> R.array.signup_level_options_language_en
+        }
+    }
+
     private fun renderLanguageLevelStep(): Pair<View, () -> Boolean> {
         val context = requireContext()
         val container = LinearLayout(context).apply {
@@ -1159,53 +1191,19 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
             )
         }
 
-        val languageLayout = TextInputLayout(context).apply {
-            hint = getString(R.string.dashboard_survey_wizard_language_label)
-            layoutParams = LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-            )
-        }
-        val languageInput = AutoCompleteTextView(context).apply {
-            inputType = InputType.TYPE_NULL
-            keyListener = null
-            setOnClickListener { showDropDown() }
-            setOnFocusChangeListener { _, hasFocus -> if (hasFocus) showDropDown() }
-        }
+        val (languageLayout, languageInput) = createDropdownLayout(
+            context,
+            getString(R.string.dashboard_survey_wizard_language_label)
+        )
+        val (levelLayout, levelInput) = createDropdownLayout(
+            context,
+            getString(R.string.dashboard_survey_wizard_level_label)
+        )
+
         val languages = resources.getStringArray(R.array.signup_language_options).toList()
         val languageAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, languages)
         languageInput.setAdapter(languageAdapter)
         respondent.language?.let { languageInput.setText(it, false) }
-        languageLayout.addView(languageInput)
-
-        val levelLayout = TextInputLayout(context).apply {
-            hint = getString(R.string.dashboard_survey_wizard_level_label)
-            layoutParams = LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-            )
-        }
-        val levelInput = AutoCompleteTextView(context).apply {
-            inputType = InputType.TYPE_NULL
-            keyListener = null
-            setOnClickListener { showDropDown() }
-            setOnFocusChangeListener { _, hasFocus -> if (hasFocus) showDropDown() }
-        }
-        levelLayout.addView(levelInput)
-
-        fun levelArrayForLanguage(languageLabel: String?): Int {
-            val normalized = languageLabel?.trim()?.lowercase(Locale.ROOT)
-            return when (normalized) {
-                getString(R.string.language_name_spanish).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_es
-                getString(R.string.language_name_french).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_fr
-                getString(R.string.language_name_portuguese).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_pt
-                getString(R.string.language_name_arabic).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_ar
-                getString(R.string.language_name_somali).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_so
-                getString(R.string.language_name_nepali).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_ne
-                getString(R.string.language_name_hindi).lowercase(Locale.ROOT) -> R.array.signup_level_options_language_hi
-                else -> R.array.signup_level_options_language_en
-            }
-        }
 
         var currentLevelOptions: List<String> = emptyList()
 

--- a/patch_file.py
+++ b/patch_file.py
@@ -1,0 +1,6 @@
+import sys
+
+with open("app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt", "r") as f:
+    content = f.read()
+
+# I will use replace_with_git_merge_diff tool.

--- a/patch_file.py
+++ b/patch_file.py
@@ -1,6 +1,0 @@
-import sys
-
-with open("app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt", "r") as f:
-    content = f.read()
-
-# I will use replace_with_git_merge_diff tool.


### PR DESCRIPTION
🎯 **What:** Extracted repetitive view generation and inline string mapping logic out of `renderLanguageLevelStep` in `SurveyWizardFragment.kt`.
💡 **Why:** The original function was over 100 lines long with duplicated view building patterns and a large inline `when` expression for language mapping. This makes it much easier to read and maintain.
✅ **Verification:** Ran `./gradlew compileDebugKotlin` to verify compilation, and `./gradlew lint app:testDebugUnitTest` to ensure no regressions were introduced.
✨ **Result:** A cleaner, modular `SurveyWizardFragment` with reusable helper methods for dropdowns.

---
*PR created automatically by Jules for task [9479761567816387237](https://jules.google.com/task/9479761567816387237) started by @dogi*