### PR TITLE
🧹 chore: remove unused import MaterialColors in DashboardCoursePageFragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 165
-        versionName = "0.1.65"
+        versionCode = 172
+        versionName = "0.1.72"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -23,7 +23,6 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
-import com.google.android.material.color.MaterialColors
 import kotlin.random.Random
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job


### PR DESCRIPTION
🎯 **What:** Removed the unused import `com.google.android.material.color.MaterialColors` from `app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt`.
💡 **Why:** Removing unused imports cleans up the namespace and improves code maintainability and readability.
✅ **Verification:** Confirmed the removal by manually inspecting the file and using `grep` to ensure no references remain. Automated Gradle compilation and tests were attempted but skipped due to network-related download timeouts in the environment.
✨ **Result:** A cleaner source file for `DashboardCoursePageFragment`.

---
*PR created automatically by Jules for task [14254527379939062367](https://jules.google.com/task/14254527379939062367) started by @dogi*