### PR TITLE
🧹 Refactor deprecated window.statusBarColor to SystemBarStyle in MyPlanetLite

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 173
+        versionName = "0.1.73"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -26,6 +26,7 @@ import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.SystemBarStyle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -153,10 +154,14 @@ class MyPlanetLite : AppCompatActivity() {
         LanguagePreferences.applySavedLocale(this)
         super.onCreate(savedInstanceState)
         applyDeviceOrientationLock()
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(
+                ContextCompat.getColor(this, R.color.white),
+                ContextCompat.getColor(this, R.color.white)
+            )
+        )
         setContentView(R.layout.activity_main)
 
-        setupWindowState()
         initializeState(savedInstanceState)
 
         val logoImageView: ImageView = findViewById(R.id.logoImageView)
@@ -169,12 +174,6 @@ class MyPlanetLite : AppCompatActivity() {
         World.init(applicationContext)
 
         configureLogin()
-    }
-
-    private fun setupWindowState() {
-        @Suppress("DEPRECATION")
-        window.statusBarColor = ContextCompat.getColor(this, R.color.white)
-        WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
     }
 
     private fun initializeState(savedInstanceState: Bundle?) {


### PR DESCRIPTION
🎯 **What:** The deprecated `window.statusBarColor` and related window inset configurations in `MyPlanetLite.kt` were removed and replaced with Android's modern `enableEdgeToEdge()` API using `SystemBarStyle.light()`.

💡 **Why:** `window.statusBarColor` has been deprecated in modern Android versions (API 35+). The standard practice is to use `enableEdgeToEdge()` combined with `SystemBarStyle` to handle system bars appearance. This consolidates the window configuration, improves maintainability, and removes obsolete code (`setupWindowState()`).

✅ **Verification:**
- Ran `./gradlew compileDebugKotlin` to verify syntax.
- Ran `./gradlew testDebugUnitTest` to ensure tests continue to pass.
- Ran `./gradlew lint app:testDebugUnitTest` to ensure no lint regressions.
- Verified `enableEdgeToEdge()` is positioned correctly before `setContentView()`.

✨ **Result:** Improved code health by removing deprecated APIs and standardizing window edge-to-edge configurations according to modern Android practices without changing visual behavior.

---
*PR created automatically by Jules for task [7909543254650221400](https://jules.google.com/task/7909543254650221400) started by @dogi*