### PR TITLE
🧪 [AuthService] Complete testing for NetworkAuthService logic branches

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 174
+        versionName = "0.1.74"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -77,6 +77,54 @@ class NetworkAuthServiceTest {
     }
 
     @Test
+    fun `login success without cookie clears token`() = runTest {
+        tokenStorage.saveToken("old_token")
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals(null, tokenStorage.token)
+        assertEquals(null, success.response.sessionCookie)
+    }
+
+    @Test
+    fun `login success with null body returns invalid response error`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(204)
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(204, error.code)
+        assertEquals("Respuesta inválida del servidor", error.message)
+    }
+
+    @Test
+    fun `login success with ok false returns server rejected error`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"ok":false,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(200, error.code)
+        assertEquals("El servidor rechazó el inicio de sesión", error.message)
+    }
+
+    @Test
     fun `login invalid credentials returns error`() = runTest {
         mockWebServer.enqueue(
             MockResponse()
@@ -123,6 +171,22 @@ class NetworkAuthServiceTest {
     }
 
     @Test
+    fun `login error with empty error body returns default error message`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(500, error.code)
+        assertEquals("Error 500", error.message)
+    }
+
+    @Test
     fun `login returns raw body when error JSON has unknown keys`() = runTest {
         val unknownKeysJson = """{"unknown_key":"bad"}"""
         mockWebServer.enqueue(
@@ -137,6 +201,38 @@ class NetworkAuthServiceTest {
         val error = result as AuthResult.Error
         assertEquals(400, error.code)
         assertEquals(unknownKeysJson, error.message)
+    }
+
+    @Test
+    fun `login error parses message key`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"message":"Invalid request message"}""")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(400, error.code)
+        assertEquals("Invalid request message", error.message)
+    }
+
+    @Test
+    fun `login error parses detail key`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(400)
+                .setBody("""{"detail":"Detailed error"}""")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(400, error.code)
+        assertEquals("Detailed error", error.message)
     }
 
     private class FakeTokenStorage : TokenStorage {


### PR DESCRIPTION
🎯 **What:** The `NetworkAuthService` implementation of `AuthService` had multiple conditional edge cases missing from test coverage (e.g., successful network response with null `Set-Cookie`, unsuccessful server responses containing custom JSON error keys like `message` or `detail`, etc.).

📊 **Coverage:** The test suite now explicitly handles:
- `login success without cookie clears token`
- `login success with null body returns invalid response error`
- `login success with ok false returns server rejected error`
- `login error with empty error body returns default error message`
- `login error parses message key`
- `login error parses detail key`

✨ **Result:** Substantially improved test coverage of `NetworkAuthServiceTest` making the authentication layer less prone to unhandled network/API quirks.

---
*PR created automatically by Jules for task [6762653625904686363](https://jules.google.com/task/6762653625904686363) started by @dogi*