### PR TITLE
🧹 Code Health: Reduce complexity of bindAttachments in CourseWizardActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 175
+        versionName = "0.1.75"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -578,142 +578,167 @@ class CourseWizardActivity : AppCompatActivity() {
                 .show()
             return
         }
-        if (hasSurvey) {
-            val itemView = inflater.inflate(
-                R.layout.item_course_wizard_attachment,
-                listContainer,
-                false
-            )
-            val titleText: TextView = itemView.findViewById(R.id.courseWizardAttachmentTitle)
-            val subtitle: TextView = itemView.findViewById(R.id.courseWizardAttachmentSubtitle)
-            val iconView: android.widget.ImageView =
-                itemView.findViewById(R.id.courseWizardAttachmentIcon)
-            val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
-            titleText.text = survey.name.orEmpty().ifBlank {
-                getString(R.string.dashboard_surveys_title)
-            }
-            subtitle.text = getString(R.string.dashboard_surveys_title)
-            iconView.setImageResource(R.drawable.ic_surveys_24)
-            iconView.contentDescription = getString(R.string.dashboard_surveys_title)
-            playButton.contentDescription = getString(R.string.course_wizard_open_survey)
-            val openSurvey = {
-                SurveyWizardActivity.newIntent(
-                    this,
-                    survey,
-                    survey.teamId,
-                    null,
-                    courseId
-                ).also { startActivity(it) }
-            }
-            itemView.setOnClickListener { openSurvey() }
-            playButton.setOnClickListener { openSurvey() }
-            listContainer.addView(itemView)
+        if (survey != null && hasSurvey) {
+            bindSurveyAttachment(survey, inflater, listContainer)
         }
-        if (hasExam) {
-            val itemView = inflater.inflate(
-                R.layout.item_course_wizard_attachment,
-                listContainer,
-                false
-            )
-            val titleText: TextView = itemView.findViewById(R.id.courseWizardAttachmentTitle)
-            val subtitle: TextView = itemView.findViewById(R.id.courseWizardAttachmentSubtitle)
-            val iconView: android.widget.ImageView =
-                itemView.findViewById(R.id.courseWizardAttachmentIcon)
-            val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
-            titleText.text = exam.name.orEmpty().ifBlank {
-                getString(R.string.dashboard_exam_title)
-            }
-            subtitle.text = getString(R.string.dashboard_exam_title)
-            iconView.setImageResource(R.drawable.ic_course_step_exam_24)
-            iconView.contentDescription = getString(R.string.dashboard_exam_title)
-            playButton.contentDescription = getString(R.string.course_wizard_open_exam)
-            val openExam = openExam@{
-                pendingExamStepIndex = currentIndex
-                SurveyWizardActivity.newIntent(
-                    this,
-                    exam,
-                    exam.teamId,
-                    null,
-                    courseId,
-                    isExam = true
-                ).also { examLauncher.launch(it) }
-            }
-            itemView.setOnClickListener { openExam() }
-            playButton.setOnClickListener { openExam() }
-            listContainer.addView(itemView)
+        if (exam != null && hasExam) {
+            bindExamAttachment(exam, inflater, listContainer)
         }
         displayResources.forEach { resource ->
-            val isAudio = resource.mediaType.lowercase(Locale.ROOT).contains("audio")
-            val itemView = if (isAudio) {
-                inflater.inflate(
-                    R.layout.item_course_wizard_audio_attachment,
-                    listContainer,
-                    false
-                )
-            } else {
-                inflater.inflate(
-                    R.layout.item_course_wizard_attachment,
-                    listContainer,
-                    false
-                )
-            }
-            val titleText: TextView = itemView.findViewById(R.id.courseWizardAttachmentTitle)
-            val subtitle: TextView = itemView.findViewById(R.id.courseWizardAttachmentSubtitle)
-            val iconView: android.widget.ImageView =
-                itemView.findViewById(R.id.courseWizardAttachmentIcon)
-            titleText.text = resource.filename
-            subtitle.text = resource.mediaType
-            val isVideo = resource.mediaType.lowercase(Locale.ROOT).contains("video")
-            val isImage = resource.mediaType.lowercase(Locale.ROOT).contains("image")
-            when {
-                isVideo -> {
-                    val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
-                    iconView.setImageResource(R.drawable.ic_course_resource_video_24)
-                    iconView.contentDescription = getString(R.string.course_wizard_attachment_video)
-                    playButton.contentDescription = getString(R.string.course_wizard_play_video)
-                }
-                isImage -> {
-                    val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
-                    iconView.setImageResource(R.drawable.ic_course_step_image_24)
-                    iconView.contentDescription = getString(R.string.course_wizard_attachment_image)
-                    playButton.contentDescription = getString(R.string.course_wizard_open_image)
-                }
-                isAudio -> {
-                    iconView.setImageResource(R.drawable.ic_course_step_audio_24)
-                    iconView.contentDescription = getString(R.string.course_wizard_attachment_audio)
-                    bindAudioPlayer(itemView, resource)
-                }
-                else -> {
-                    val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
-                    iconView.setImageResource(R.drawable.ic_course_step_pdf_24)
-                    iconView.contentDescription = getString(R.string.course_wizard_attachment_pdf)
-                    playButton.contentDescription = getString(R.string.course_wizard_open_pdf)
-                }
-            }
-            val openResource = {
-                if (isVideo) {
-                    if (playlistIndexByResourceId.containsKey(resource.id)) {
-                        selectResource(resource)
-                    } else {
-                        Toast.makeText(
-                            this,
-                            getString(R.string.course_wizard_play_error),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                } else if (isImage) {
-                    openImageResource(resource, imageResources)
-                } else {
-                    openPdfResource(resource)
-                }
-            }
-            if (!isAudio) {
-                val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
-                itemView.setOnClickListener { openResource() }
-                playButton.setOnClickListener { openResource() }
-            }
-            listContainer.addView(itemView)
+            bindResourceAttachment(resource, imageResources, inflater, listContainer)
         }
+    }
+
+    private fun bindSurveyAttachment(
+        survey: SurveyDocument,
+        inflater: android.view.LayoutInflater,
+        listContainer: LinearLayout
+    ) {
+        val itemView = inflater.inflate(
+            R.layout.item_course_wizard_attachment,
+            listContainer,
+            false
+        )
+        val titleText: TextView = itemView.findViewById(R.id.courseWizardAttachmentTitle)
+        val subtitle: TextView = itemView.findViewById(R.id.courseWizardAttachmentSubtitle)
+        val iconView: android.widget.ImageView =
+            itemView.findViewById(R.id.courseWizardAttachmentIcon)
+        val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
+        titleText.text = survey.name.orEmpty().ifBlank {
+            getString(R.string.dashboard_surveys_title)
+        }
+        subtitle.text = getString(R.string.dashboard_surveys_title)
+        iconView.setImageResource(R.drawable.ic_surveys_24)
+        iconView.contentDescription = getString(R.string.dashboard_surveys_title)
+        playButton.contentDescription = getString(R.string.course_wizard_open_survey)
+        val openSurvey = {
+            SurveyWizardActivity.newIntent(
+                this,
+                survey,
+                survey.teamId,
+                null,
+                courseId
+            ).also { startActivity(it) }
+        }
+        itemView.setOnClickListener { openSurvey() }
+        playButton.setOnClickListener { openSurvey() }
+        listContainer.addView(itemView)
+    }
+
+    private fun bindExamAttachment(
+        exam: SurveyDocument,
+        inflater: android.view.LayoutInflater,
+        listContainer: LinearLayout
+    ) {
+        val itemView = inflater.inflate(
+            R.layout.item_course_wizard_attachment,
+            listContainer,
+            false
+        )
+        val titleText: TextView = itemView.findViewById(R.id.courseWizardAttachmentTitle)
+        val subtitle: TextView = itemView.findViewById(R.id.courseWizardAttachmentSubtitle)
+        val iconView: android.widget.ImageView =
+            itemView.findViewById(R.id.courseWizardAttachmentIcon)
+        val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
+        titleText.text = exam.name.orEmpty().ifBlank {
+            getString(R.string.dashboard_exam_title)
+        }
+        subtitle.text = getString(R.string.dashboard_exam_title)
+        iconView.setImageResource(R.drawable.ic_course_step_exam_24)
+        iconView.contentDescription = getString(R.string.dashboard_exam_title)
+        playButton.contentDescription = getString(R.string.course_wizard_open_exam)
+        val openExam = {
+            pendingExamStepIndex = currentIndex
+            SurveyWizardActivity.newIntent(
+                this,
+                exam,
+                exam.teamId,
+                null,
+                courseId,
+                isExam = true
+            ).also { examLauncher.launch(it) }
+        }
+        itemView.setOnClickListener { openExam() }
+        playButton.setOnClickListener { openExam() }
+        listContainer.addView(itemView)
+    }
+
+    private fun bindResourceAttachment(
+        resource: DashboardCoursePageFragment.CourseItem.LessonResource,
+        imageResources: List<DashboardCoursePageFragment.CourseItem.LessonResource>,
+        inflater: android.view.LayoutInflater,
+        listContainer: LinearLayout
+    ) {
+        val isAudio = resource.mediaType.lowercase(Locale.ROOT).contains("audio")
+        val itemView = if (isAudio) {
+            inflater.inflate(
+                R.layout.item_course_wizard_audio_attachment,
+                listContainer,
+                false
+            )
+        } else {
+            inflater.inflate(
+                R.layout.item_course_wizard_attachment,
+                listContainer,
+                false
+            )
+        }
+        val titleText: TextView = itemView.findViewById(R.id.courseWizardAttachmentTitle)
+        val subtitle: TextView = itemView.findViewById(R.id.courseWizardAttachmentSubtitle)
+        val iconView: android.widget.ImageView =
+            itemView.findViewById(R.id.courseWizardAttachmentIcon)
+        titleText.text = resource.filename
+        subtitle.text = resource.mediaType
+        val isVideo = resource.mediaType.lowercase(Locale.ROOT).contains("video")
+        val isImage = resource.mediaType.lowercase(Locale.ROOT).contains("image")
+        when {
+            isVideo -> {
+                val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
+                iconView.setImageResource(R.drawable.ic_course_resource_video_24)
+                iconView.contentDescription = getString(R.string.course_wizard_attachment_video)
+                playButton.contentDescription = getString(R.string.course_wizard_play_video)
+            }
+            isImage -> {
+                val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
+                iconView.setImageResource(R.drawable.ic_course_step_image_24)
+                iconView.contentDescription = getString(R.string.course_wizard_attachment_image)
+                playButton.contentDescription = getString(R.string.course_wizard_open_image)
+            }
+            isAudio -> {
+                iconView.setImageResource(R.drawable.ic_course_step_audio_24)
+                iconView.contentDescription = getString(R.string.course_wizard_attachment_audio)
+                bindAudioPlayer(itemView, resource)
+            }
+            else -> {
+                val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
+                iconView.setImageResource(R.drawable.ic_course_step_pdf_24)
+                iconView.contentDescription = getString(R.string.course_wizard_attachment_pdf)
+                playButton.contentDescription = getString(R.string.course_wizard_open_pdf)
+            }
+        }
+        val openResource = {
+            if (isVideo) {
+                if (playlistIndexByResourceId.containsKey(resource.id)) {
+                    selectResource(resource)
+                } else {
+                    Toast.makeText(
+                        this,
+                        getString(R.string.course_wizard_play_error),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            } else if (isImage) {
+                openImageResource(resource, imageResources)
+            } else {
+                openPdfResource(resource)
+            }
+        }
+        if (!isAudio) {
+            val playButton: ImageButton = itemView.findViewById(R.id.courseWizardAttachmentPlay)
+            itemView.setOnClickListener { openResource() }
+            playButton.setOnClickListener { openResource() }
+        }
+        listContainer.addView(itemView)
     }
 
     private fun bindAudioPlayer(


### PR DESCRIPTION
🎯 **What:** Extracted the logic for handling surveys, exams, and generic resources from the `bindAttachments` method in `CourseWizardActivity.kt` into their own private helper methods.

💡 **Why:** The `bindAttachments` method was overly complex, long, and handled too many responsibilities (inflating layouts, setting up listeners, and binding data for multiple different resource types). By extracting these responsibilities into smaller, focused methods, the code is significantly easier to read, maintain, and test.

✅ **Verification:**
- Ran `./gradlew compileDebugKotlin` to verify syntax and structure were correct after extraction.
- Ran `./gradlew testDebugUnitTest` to confirm no unit tests were broken.
- Ran `./gradlew lint app:testDebugUnitTest` to ensure no linting regressions were introduced.
- Passed AI code review successfully.

✨ **Result:** The `bindAttachments` function is now much shorter and easier to reason about, delegating specific binding tasks to clearly named helper functions (`bindSurveyAttachment`, `bindExamAttachment`, and `bindResourceAttachment`). No behavior was altered.

---
*PR created automatically by Jules for task [2600244860113209768](https://jules.google.com/task/2600244860113209768) started by @dogi*