### PR TITLE
🔒 Fix plaintext Basic Auth credential leak in Markdown image resources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 174
-        versionName = "0.1.74"
+        versionCode = 176
+        versionName = "0.1.76"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -44,6 +44,7 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferences
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.ole.planet.myplanet.lite.util.AuthUtils
+import org.ole.planet.myplanet.lite.util.NetworkUtils
 
 class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses_page) {
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -44,6 +44,7 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyD
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferences
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.ole.planet.myplanet.lite.util.AuthUtils
 
 class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses_page) {
 
@@ -759,7 +760,11 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val request = Request.Builder()
                 .url(url)
                 .head()
-                .header("Authorization", Credentials.basic(creds.username, creds.password))
+                .apply {
+                    if (AuthUtils.isSecureAndTrustedUrl(url, base)) {
+                        header("Authorization", Credentials.basic(creds.username, creds.password))
+                    }
+                }
                 .build()
             runCatching {
                 httpClient.newCall(request).execute().use { response ->
@@ -792,7 +797,11 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             target.parentFile?.mkdirs()
             val request = Request.Builder()
                 .url(url)
-                .header("Authorization", authHeader)
+                .apply {
+                    if (AuthUtils.isSecureAndTrustedUrl(url, base)) {
+                        header("Authorization", authHeader)
+                    }
+                }
                 .build()
             val success = runCatching {
                 httpClient.newCall(request).execute().use { response ->
@@ -816,7 +825,11 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             target.parentFile?.mkdirs()
             val request = Request.Builder()
                 .url(resolvedUrl)
-                .header("Authorization", authHeader)
+                .apply {
+                    if (AuthUtils.isSecureAndTrustedUrl(resolvedUrl, base)) {
+                        header("Authorization", authHeader)
+                    }
+                }
                 .build()
             runCatching {
                 httpClient.newCall(request).execute().use { response ->
@@ -847,7 +860,11 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val request = Request.Builder()
                 .url(url)
                 .head()
-                .header("Authorization", authHeader)
+                .apply {
+                    if (AuthUtils.isSecureAndTrustedUrl(url, base)) {
+                        header("Authorization", authHeader)
+                    }
+                }
                 .build()
             runCatching {
                 httpClient.newCall(request).execute().use { response ->

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/AuthUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/AuthUtils.kt
@@ -1,0 +1,58 @@
+package org.ole.planet.myplanet.lite.util
+
+import java.net.URI
+
+object AuthUtils {
+
+    /**
+     * Checks if a URL is secure (HTTPS) or a trusted local/private network address,
+     * and ensures it matches the expected base host.
+     * This prevents credential leakage when requesting external or unencrypted resources (e.g. Markdown images).
+     */
+    fun isSecureAndTrustedUrl(url: String, base: String): Boolean {
+        return try {
+            val uri = URI.create(url)
+            val scheme = uri.scheme?.lowercase()
+            val host = uri.host ?: return false
+
+            val baseUri = URI.create(base)
+            val baseHost = baseUri.host
+
+            if (host != baseHost) {
+                return false
+            }
+
+            if (scheme == "https") {
+                return true
+            }
+
+            isLocalOrPrivateIp(host)
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun isLocalOrPrivateIp(host: String): Boolean {
+        if (host == "localhost" || host == "127.0.0.1") {
+            return true
+        }
+
+        // Check for private IPv4 ranges:
+        // 10.0.0.0 - 10.255.255.255
+        if (host.matches(Regex("^10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"))) {
+            return true
+        }
+
+        // 192.168.0.0 - 192.168.255.255
+        if (host.matches(Regex("^192\\.168\\.\\d{1,3}\\.\\d{1,3}$"))) {
+            return true
+        }
+
+        // 172.16.0.0 - 172.31.255.255
+        if (host.matches(Regex("^172\\.(1[6-9]|2[0-9]|3[0-1])\\.\\d{1,3}\\.\\d{1,3}$"))) {
+            return true
+        }
+
+        return false
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/AuthUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/AuthUtilsTest.kt
@@ -1,0 +1,85 @@
+package org.ole.planet.myplanet.lite.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AuthUtilsTest {
+
+    @Test
+    fun isSecureAndTrustedUrl_httpsHostMatch_returnsTrue() {
+        val base = "https://example.com"
+        val url = "https://example.com/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpsHostMismatch_returnsFalse() {
+        val base = "https://example.com"
+        val url = "https://attacker.com/image.png"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpLocalhost_returnsTrue() {
+        val base = "http://localhost:3000"
+        val url = "http://localhost:3000/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_http127_0_0_1_returnsTrue() {
+        val base = "http://127.0.0.1:3000"
+        val url = "http://127.0.0.1:3000/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpPrivateClassA_returnsTrue() {
+        val base = "http://10.0.2.2:5984"
+        val url = "http://10.0.2.2:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpPrivateClassC_returnsTrue() {
+        val base = "http://192.168.1.100:5984"
+        val url = "http://192.168.1.100:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpPrivateClassB_returnsTrue() {
+        val base = "http://172.16.5.5:5984"
+        val url = "http://172.16.5.5:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpPublicIp_returnsFalse() {
+        val base = "http://8.8.8.8"
+        val url = "http://8.8.8.8/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_httpExternalDomain_returnsFalse() {
+        val base = "http://example.com"
+        val url = "http://example.com/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_spoofedIpDomain_returnsFalse() {
+        val base = "http://10.attacker.com"
+        val url = "http://10.attacker.com/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_malformedUrl_returnsFalse() {
+        val base = "https://example.com"
+        val url = "not_a_valid_url"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+}


### PR DESCRIPTION
### 🎯 What
Fixes a security vulnerability where CouchDB Basic Authentication credentials could be leaked to external or unencrypted endpoints when downloading Markdown image resources in the dashboard.

### ⚠️ Risk
If left unfixed, an attacker could inject a malicious Markdown image URL (e.g., `http://attacker.com/image.png`) into a course or step description. When a user navigates to the course page, the app would automatically attempt to download the image, sending the user's CouchDB username and password in plaintext in the `Authorization` header to the attacker's server. This is a severe credential disclosure vulnerability.

### 🛡️ Solution
- Introduced `AuthUtils.isSecureAndTrustedUrl` to validate that the target URL matches the application's expected base host.
- Enforced that credentials are only sent over secure HTTPS connections, unless the base host is a trusted local or private IP address (e.g., `localhost`, `10.x.x.x`, `192.168.x.x`), which is necessary for offline MyPlanet deployments.
- Applied this validation conditionally before attaching the `Authorization` header to OkHttp requests in `estimateResourcesSize`, `downloadCourseResources`, and `estimateMarkdownImagesSize`.
- Implemented robust regex-based IP validation to prevent domain spoofing bypasses (e.g., `10.attacker.com`).
- Added comprehensive unit tests (`AuthUtilsTest`) to verify the validation logic.

---
*PR created automatically by Jules for task [8802757199841355480](https://jules.google.com/task/8802757199841355480) started by @dogi*