### PR TITLE
🔒 Enforce HTTPS for basic authentication in course downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ gradle/gradle-daemon-jvm.properties
 
 # Local benchmarking scratch file
 benchmark.kt
+
+app/baseline_time.txt

--- a/app/baseline_time.txt
+++ b/app/baseline_time.txt
@@ -1,1 +1,0 @@
-fetchCoursesProgress baseline took 18 ms

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 178
+        versionName = "0.1.78"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -756,11 +756,13 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         var total = 0L
         resources.forEach { resource ->
             val url = buildServerResourceUrl(base, resource) ?: return@forEach
-            val request = Request.Builder()
+            val requestBuilder = Request.Builder()
                 .url(url)
                 .head()
-                .header("Authorization", Credentials.basic(creds.username, creds.password))
-                .build()
+            if (url.startsWith("https://", ignoreCase = true)) {
+                requestBuilder.header("Authorization", Credentials.basic(creds.username, creds.password))
+            }
+            val request = requestBuilder.build()
             runCatching {
                 httpClient.newCall(request).execute().use { response ->
                     val size = response.header("Content-Length")?.toLongOrNull() ?: 0L
@@ -790,10 +792,12 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val url = buildServerResourceUrl(base, resource) ?: return false
             val target = OfflineCourseStorage.resourceFile(requireContext(), course.id, resource.id, resource.filename)
             target.parentFile?.mkdirs()
-            val request = Request.Builder()
+            val requestBuilder = Request.Builder()
                 .url(url)
-                .header("Authorization", authHeader)
-                .build()
+            if (url.startsWith("https://", ignoreCase = true)) {
+                requestBuilder.header("Authorization", authHeader)
+            }
+            val request = requestBuilder.build()
             val success = runCatching {
                 httpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) return@use false
@@ -814,10 +818,12 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val resolvedUrl = MarkdownUtils.resolveMarkdownSourceUrl(base, source) ?: return@forEach
             val target = OfflineCourseStorage.markdownImageFile(requireContext(), course.id, source)
             target.parentFile?.mkdirs()
-            val request = Request.Builder()
+            val requestBuilder = Request.Builder()
                 .url(resolvedUrl)
-                .header("Authorization", authHeader)
-                .build()
+            if (resolvedUrl.startsWith("https://", ignoreCase = true)) {
+                requestBuilder.header("Authorization", authHeader)
+            }
+            val request = requestBuilder.build()
             runCatching {
                 httpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) return@use false
@@ -844,11 +850,13 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         val authHeader = Credentials.basic(creds.username, creds.password)
         sources.forEach { source ->
             val url = MarkdownUtils.resolveMarkdownSourceUrl(base, source) ?: return@forEach
-            val request = Request.Builder()
+            val requestBuilder = Request.Builder()
                 .url(url)
                 .head()
-                .header("Authorization", authHeader)
-                .build()
+            if (url.startsWith("https://", ignoreCase = true)) {
+                requestBuilder.header("Authorization", authHeader)
+            }
+            val request = requestBuilder.build()
             runCatching {
                 httpClient.newCall(request).execute().use { response ->
                     val size = response.header("Content-Length")?.toLongOrNull() ?: 0L


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the unconditional transmission of Basic Authentication credentials in the `Authorization` header when fetching course resources and markdown images, regardless of whether the transport was secure.
⚠️ **Risk:** If the course server or markdown contained standard HTTP links, the user's CouchDB credentials would be sent in plaintext over the network. This could lead to credential theft by anyone monitoring the network traffic or by third-party servers targeted by embedded markdown images.
🛡️ **Solution:** The `Request.Builder` logic in `DashboardCoursePageFragment.kt` was modified across all resource-fetching functions (`estimateResourcesSize`, `downloadCourseResources`, and `estimateMarkdownImagesSize`). The `Authorization` header is now conditionally appended only if the target URL begins with `https://`.

---
*PR created automatically by Jules for task [4377222586757820151](https://jules.google.com/task/4377222586757820151) started by @dogi*