### PR TITLE
🔒 Explicit HTTPS enforcement for Basic Auth headers in FullscreenPdfActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 181
+        versionName = "0.1.81"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/FullscreenPdfActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/FullscreenPdfActivity.kt
@@ -148,7 +148,7 @@ class FullscreenPdfActivity : AppCompatActivity() {
                 val request = Request.Builder()
                     .url(url)
                     .apply {
-                        if (!authHeader.isNullOrBlank()) {
+                        if (!authHeader.isNullOrBlank() && url.startsWith("https://", ignoreCase = true)) {
                             addHeader("Authorization", authHeader)
                         }
                     }
@@ -164,7 +164,7 @@ class FullscreenPdfActivity : AppCompatActivity() {
     private fun resolveAuthHeader(): String? {
         val credentials = ProfileCredentialsStore.getStoredCredentials(applicationContext)
         val baseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
-        return if (credentials != null && !baseUrl.isNullOrBlank()) {
+        return if (credentials != null && !baseUrl.isNullOrBlank() && baseUrl.startsWith("https://", ignoreCase = true)) {
             Credentials.basic(credentials.username, credentials.password)
         } else {
             null


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was sending stored plaintext Basic Authentication credentials over HTTP.
⚠️ **Risk:** Stored profile credentials could be intercepted by attackers listening on the network, leading to unauthorized access.
🛡️ **Solution:** Added a strict verification step ensuring both the base server URL and the specific download URL start with `https://` (ignoring case) before generating the credentials string and injecting the `Authorization` header. This prevents the application from sending credentials over insecure plaintext channels.

---
*PR created automatically by Jules for task [15129887718371343376](https://jules.google.com/task/15129887718371343376) started by @dogi*