### PR TITLE
⚡ Optimize legacy preference migration to be asynchronous

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 184
+        versionName = "0.1.84"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
@@ -7,8 +7,14 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import java.security.KeyStore
 import javax.crypto.AEADBadTagException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 object SecurePreferencesProvider {
+    private val migrationScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     @androidx.annotation.VisibleForTesting
     var injectedPreferences: SharedPreferences? = null
 
@@ -25,15 +31,23 @@ object SecurePreferencesProvider {
         injectedPreferences?.let { return it }
 
         return synchronized(this) {
-            instance ?: getEncryptedPreferences(
-                context = context,
-                prefsName = ENCRYPTED_PREFS_NAME,
-                onCreated = { appContext, encryptedPrefs ->
-                    migrateLegacyPreferences(appContext, encryptedPrefs)
+            instance ?: run {
+                val encryptedPrefs = getEncryptedPreferences(
+                    context = context,
+                    prefsName = ENCRYPTED_PREFS_NAME
+                )
+                val legacyFile = java.io.File(context.applicationInfo.dataDir, "shared_prefs/$LEGACY_PREFS_NAME.xml")
+                val created = if (legacyFile.exists()) {
+                    val legacyPrefs = context.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE)
+                    val job = migrateLegacyPreferences(context, encryptedPrefs, legacyPrefs)
+                    MigrationAwarePreferences(encryptedPrefs, legacyPrefs, job)
+                } else {
+                    encryptedPrefs
                 }
-            ).also { created ->
-                instance = created
-                cachedInstances[ENCRYPTED_PREFS_NAME] = created
+                created.also {
+                    instance = it
+                    cachedInstances[ENCRYPTED_PREFS_NAME] = it
+                }
             }
         }
     }
@@ -132,23 +146,122 @@ object SecurePreferencesProvider {
         }
     }
 
-    private fun migrateLegacyPreferences(context: Context, encryptedPrefs: SharedPreferences) {
-        val legacyPrefs = context.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE)
-        val allLegacy = legacyPrefs.all
-        if (allLegacy.isNotEmpty()) {
-            val editor = encryptedPrefs.edit()
-            for ((key, value) in allLegacy) {
-                when (value) {
-                    is String -> editor.putString(key, value)
-                    is Int -> editor.putInt(key, value)
-                    is Boolean -> editor.putBoolean(key, value)
-                    is Float -> editor.putFloat(key, value)
-                    is Long -> editor.putLong(key, value)
-                    is Set<*> -> @Suppress("UNCHECKED_CAST") editor.putStringSet(key, value as Set<String>)
+    private fun migrateLegacyPreferences(
+        context: Context,
+        encryptedPrefs: SharedPreferences,
+        legacyPrefs: SharedPreferences
+    ): Job {
+        return migrationScope.launch {
+            val allLegacy = legacyPrefs.all
+            if (allLegacy.isNotEmpty()) {
+                val editor = encryptedPrefs.edit()
+                for ((key, value) in allLegacy) {
+                    if (encryptedPrefs.contains(key)) continue
+                    when (value) {
+                        is String -> editor.putString(key, value)
+                        is Int -> editor.putInt(key, value)
+                        is Boolean -> editor.putBoolean(key, value)
+                        is Float -> editor.putFloat(key, value)
+                        is Long -> editor.putLong(key, value)
+                        is Set<*> -> @Suppress("UNCHECKED_CAST") editor.putStringSet(key, value as Set<String>)
+                    }
                 }
+                if (editor.commit()) {
+                    context.deleteSharedPreferences(LEGACY_PREFS_NAME)
+                }
+            } else {
+                context.deleteSharedPreferences(LEGACY_PREFS_NAME)
             }
-            editor.apply()
-            context.deleteSharedPreferences(LEGACY_PREFS_NAME)
+        }
+    }
+
+    private class MigrationAwarePreferences(
+        private val encryptedPrefs: SharedPreferences,
+        private val legacyPrefs: SharedPreferences,
+        private val migrationJob: Job
+    ) : SharedPreferences {
+        override fun getAll(): Map<String, *> {
+            return if (migrationJob.isActive) {
+                val combined = legacyPrefs.all.toMutableMap()
+                combined.putAll(encryptedPrefs.all)
+                combined
+            } else {
+                encryptedPrefs.all
+            }
+        }
+
+        override fun getString(key: String?, defValue: String?): String? {
+            return if (encryptedPrefs.contains(key)) {
+                encryptedPrefs.getString(key, defValue)
+            } else if (migrationJob.isActive) {
+                legacyPrefs.getString(key, defValue)
+            } else {
+                defValue
+            }
+        }
+
+        override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? {
+            return if (encryptedPrefs.contains(key)) {
+                encryptedPrefs.getStringSet(key, defValues)
+            } else if (migrationJob.isActive) {
+                legacyPrefs.getStringSet(key, defValues)
+            } else {
+                defValues
+            }
+        }
+
+        override fun getInt(key: String?, defValue: Int): Int {
+            return if (encryptedPrefs.contains(key)) {
+                encryptedPrefs.getInt(key, defValue)
+            } else if (migrationJob.isActive) {
+                legacyPrefs.getInt(key, defValue)
+            } else {
+                defValue
+            }
+        }
+
+        override fun getLong(key: String?, defValue: Long): Long {
+            return if (encryptedPrefs.contains(key)) {
+                encryptedPrefs.getLong(key, defValue)
+            } else if (migrationJob.isActive) {
+                legacyPrefs.getLong(key, defValue)
+            } else {
+                defValue
+            }
+        }
+
+        override fun getFloat(key: String?, defValue: Float): Float {
+            return if (encryptedPrefs.contains(key)) {
+                encryptedPrefs.getFloat(key, defValue)
+            } else if (migrationJob.isActive) {
+                legacyPrefs.getFloat(key, defValue)
+            } else {
+                defValue
+            }
+        }
+
+        override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+            return if (encryptedPrefs.contains(key)) {
+                encryptedPrefs.getBoolean(key, defValue)
+            } else if (migrationJob.isActive) {
+                legacyPrefs.getBoolean(key, defValue)
+            } else {
+                defValue
+            }
+        }
+
+        override fun contains(key: String?): Boolean {
+            return encryptedPrefs.contains(key) || (migrationJob.isActive && legacyPrefs.contains(key))
+        }
+
+        override fun edit(): SharedPreferences.Editor = encryptedPrefs.edit()
+
+        override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+            encryptedPrefs.registerOnSharedPreferenceChangeListener(listener)
+        }
+
+        override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+            encryptedPrefs.unregisterOnSharedPreferenceChangeListener(listener)
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -136,7 +136,7 @@ class SecurePreferencesProviderTest {
     }
 
     @Test
-    fun `migrateLegacyPreferences does nothing when legacy prefs are empty`() {
+    fun `migrateLegacyPreferences deletes legacy prefs when they are empty`() {
         runBlocking {
             val mockLegacyPrefs = mock(SharedPreferences::class.java)
             val mockEncryptedPrefs = mock(SharedPreferences::class.java)
@@ -158,7 +158,7 @@ class SecurePreferencesProviderTest {
 
             verify(mockEncryptedPrefs, never()).edit()
             verify(mockLegacyPrefs, never()).edit()
-            verify(mockContext, never()).deleteSharedPreferences(any())
+            verify(mockContext).deleteSharedPreferences("server_preferences")
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.lite.util
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.pm.ApplicationInfo
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import org.junit.After
@@ -11,6 +12,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockConstruction
@@ -27,6 +30,9 @@ class SecurePreferencesProviderTest {
     fun setup() {
         mockContext = mock(Context::class.java)
         `when`(mockContext.applicationContext).thenReturn(mockContext)
+        val mockAppInfo = mock(ApplicationInfo::class.java)
+        mockAppInfo.dataDir = "/tmp"
+        `when`(mockContext.applicationInfo).thenReturn(mockAppInfo)
         mockPrefs = mock(SharedPreferences::class.java)
         SecurePreferencesProvider.resetForTesting()
     }
@@ -85,7 +91,7 @@ class SecurePreferencesProviderTest {
     }
 
     @Test
-    fun `migrateLegacyPreferences migrates data and deletes legacy prefs`() {
+    fun `migrateLegacyPreferences migrates data and deletes legacy prefs`() = runBlocking {
         val mockLegacyPrefs = mock(SharedPreferences::class.java)
         val mockEncryptedPrefs = mock(SharedPreferences::class.java)
         val mockEncryptedEditor = mock(SharedPreferences.Editor::class.java)
@@ -104,10 +110,17 @@ class SecurePreferencesProviderTest {
 
         `when`(mockLegacyPrefs.all).thenReturn(legacyData)
         `when`(mockEncryptedPrefs.edit()).thenReturn(mockEncryptedEditor)
+        `when`(mockEncryptedEditor.commit()).thenReturn(true)
 
-        val method = SecurePreferencesProvider::class.java.getDeclaredMethod("migrateLegacyPreferences", Context::class.java, SharedPreferences::class.java)
+        val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
+            "migrateLegacyPreferences",
+            Context::class.java,
+            SharedPreferences::class.java,
+            SharedPreferences::class.java
+        )
         method.isAccessible = true
-        method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs)
+        val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
+        job.join()
 
         verify(mockEncryptedEditor).putString("string_key", "value")
         verify(mockEncryptedEditor).putInt("int_key", 42)
@@ -115,13 +128,13 @@ class SecurePreferencesProviderTest {
         verify(mockEncryptedEditor).putFloat("float_key", 3.14f)
         verify(mockEncryptedEditor).putLong("long_key", 100L)
         verify(mockEncryptedEditor).putStringSet("set_key", setOf("a", "b"))
-        verify(mockEncryptedEditor).apply()
+        verify(mockEncryptedEditor).commit()
 
         verify(mockContext).deleteSharedPreferences("server_preferences")
     }
 
     @Test
-    fun `migrateLegacyPreferences does nothing when legacy prefs are empty`() {
+    fun `migrateLegacyPreferences does nothing when legacy prefs are empty`() = runBlocking {
         val mockLegacyPrefs = mock(SharedPreferences::class.java)
         val mockEncryptedPrefs = mock(SharedPreferences::class.java)
 
@@ -130,9 +143,15 @@ class SecurePreferencesProviderTest {
 
         `when`(mockLegacyPrefs.all).thenReturn(emptyMap<String, Any?>())
 
-        val method = SecurePreferencesProvider::class.java.getDeclaredMethod("migrateLegacyPreferences", Context::class.java, SharedPreferences::class.java)
+        val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
+            "migrateLegacyPreferences",
+            Context::class.java,
+            SharedPreferences::class.java,
+            SharedPreferences::class.java
+        )
         method.isAccessible = true
-        method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs)
+        val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
+        job.join()
 
         verify(mockEncryptedPrefs, never()).edit()
         verify(mockLegacyPrefs, never()).edit()

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -91,70 +91,74 @@ class SecurePreferencesProviderTest {
     }
 
     @Test
-    fun `migrateLegacyPreferences migrates data and deletes legacy prefs`() = runBlocking {
-        val mockLegacyPrefs = mock(SharedPreferences::class.java)
-        val mockEncryptedPrefs = mock(SharedPreferences::class.java)
-        val mockEncryptedEditor = mock(SharedPreferences.Editor::class.java)
+    fun `migrateLegacyPreferences migrates data and deletes legacy prefs`() {
+        runBlocking {
+            val mockLegacyPrefs = mock(SharedPreferences::class.java)
+            val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+            val mockEncryptedEditor = mock(SharedPreferences.Editor::class.java)
 
-        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
-            .thenReturn(mockLegacyPrefs)
+            `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
+                .thenReturn(mockLegacyPrefs)
 
-        val legacyData = mapOf<String, Any?>(
-            "string_key" to "value",
-            "int_key" to 42,
-            "bool_key" to true,
-            "float_key" to 3.14f,
-            "long_key" to 100L,
-            "set_key" to setOf("a", "b")
-        )
+            val legacyData = mapOf<String, Any?>(
+                "string_key" to "value",
+                "int_key" to 42,
+                "bool_key" to true,
+                "float_key" to 3.14f,
+                "long_key" to 100L,
+                "set_key" to setOf("a", "b")
+            )
 
-        `when`(mockLegacyPrefs.all).thenReturn(legacyData)
-        `when`(mockEncryptedPrefs.edit()).thenReturn(mockEncryptedEditor)
-        `when`(mockEncryptedEditor.commit()).thenReturn(true)
+            `when`(mockLegacyPrefs.all).thenReturn(legacyData)
+            `when`(mockEncryptedPrefs.edit()).thenReturn(mockEncryptedEditor)
+            `when`(mockEncryptedEditor.commit()).thenReturn(true)
 
-        val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
-            "migrateLegacyPreferences",
-            Context::class.java,
-            SharedPreferences::class.java,
-            SharedPreferences::class.java
-        )
-        method.isAccessible = true
-        val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
-        job.join()
+            val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
+                "migrateLegacyPreferences",
+                Context::class.java,
+                SharedPreferences::class.java,
+                SharedPreferences::class.java
+            )
+            method.isAccessible = true
+            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
+            job.join()
 
-        verify(mockEncryptedEditor).putString("string_key", "value")
-        verify(mockEncryptedEditor).putInt("int_key", 42)
-        verify(mockEncryptedEditor).putBoolean("bool_key", true)
-        verify(mockEncryptedEditor).putFloat("float_key", 3.14f)
-        verify(mockEncryptedEditor).putLong("long_key", 100L)
-        verify(mockEncryptedEditor).putStringSet("set_key", setOf("a", "b"))
-        verify(mockEncryptedEditor).commit()
+            verify(mockEncryptedEditor).putString("string_key", "value")
+            verify(mockEncryptedEditor).putInt("int_key", 42)
+            verify(mockEncryptedEditor).putBoolean("bool_key", true)
+            verify(mockEncryptedEditor).putFloat("float_key", 3.14f)
+            verify(mockEncryptedEditor).putLong("long_key", 100L)
+            verify(mockEncryptedEditor).putStringSet("set_key", setOf("a", "b"))
+            verify(mockEncryptedEditor).commit()
 
-        verify(mockContext).deleteSharedPreferences("server_preferences")
+            verify(mockContext).deleteSharedPreferences("server_preferences")
+        }
     }
 
     @Test
-    fun `migrateLegacyPreferences does nothing when legacy prefs are empty`() = runBlocking {
-        val mockLegacyPrefs = mock(SharedPreferences::class.java)
-        val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+    fun `migrateLegacyPreferences does nothing when legacy prefs are empty`() {
+        runBlocking {
+            val mockLegacyPrefs = mock(SharedPreferences::class.java)
+            val mockEncryptedPrefs = mock(SharedPreferences::class.java)
 
-        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
-            .thenReturn(mockLegacyPrefs)
+            `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
+                .thenReturn(mockLegacyPrefs)
 
-        `when`(mockLegacyPrefs.all).thenReturn(emptyMap<String, Any?>())
+            `when`(mockLegacyPrefs.all).thenReturn(emptyMap<String, Any?>())
 
-        val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
-            "migrateLegacyPreferences",
-            Context::class.java,
-            SharedPreferences::class.java,
-            SharedPreferences::class.java
-        )
-        method.isAccessible = true
-        val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
-        job.join()
+            val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
+                "migrateLegacyPreferences",
+                Context::class.java,
+                SharedPreferences::class.java,
+                SharedPreferences::class.java
+            )
+            method.isAccessible = true
+            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
+            job.join()
 
-        verify(mockEncryptedPrefs, never()).edit()
-        verify(mockLegacyPrefs, never()).edit()
-        verify(mockContext, never()).deleteSharedPreferences(any())
+            verify(mockEncryptedPrefs, never()).edit()
+            verify(mockLegacyPrefs, never()).edit()
+            verify(mockContext, never()).deleteSharedPreferences(any())
+        }
     }
 }


### PR DESCRIPTION
This PR optimizes the application's initialization process by moving the legacy SharedPreferences migration to a background thread. Previously, the migration performed a blocking iteration and encryption of all legacy values on the main thread, which could cause visible delays or ANRs during the first launch after an update.

The optimization introduces a `MigrationAwarePreferences` wrapper that delegates reads to the new encrypted store but falls back to the legacy store only while the migration job is active. This ensures that preferences are immediately available to the rest of the application without blocking initialization.

Key improvements:
- **Asynchronous Migration:** Iteration and encryption now happen on `Dispatchers.IO`.
- **Race Condition Prevention:** The migration task checks if a key already exists in the new store before copying, preventing it from overwriting fresher data.
- **Main Thread I/O Reduction:** Replaced the blocking `SharedPreferences.all` call with a direct `File.exists()` check to determine if migration is needed, avoiding a synchronous XML load on the main thread.
- **Robust Testing:** Updated the unit test suite to mock the necessary Android environment, handle asynchronous tasks, and ensure compatibility with JUnit 4.

---
*PR created automatically by Jules for task [2694002340418774797](https://jules.google.com/task/2694002340418774797) started by @dogi*