### PR TITLE
🧪 Add error path tests for UserProfileDatabase

### DIFF
--- a/app/baseline_time.txt
+++ b/app/baseline_time.txt
@@ -1,1 +1,0 @@
-fetchCoursesProgress baseline took 16 ms

--- a/app/baseline_time.txt
+++ b/app/baseline_time.txt
@@ -1,0 +1,1 @@
+fetchCoursesProgress baseline took 16 ms

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 166
-        versionName = "0.1.66"
+        versionCode = 185
+        versionName = "0.1.85"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseErrorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseErrorTest.kt
@@ -1,0 +1,88 @@
+package org.ole.planet.myplanet.lite.profile
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.junit.Assert.assertThrows
+import android.database.sqlite.SQLiteException
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.doThrow
+import android.database.sqlite.SQLiteDatabase
+import org.mockito.ArgumentMatchers.any
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class UserProfileDatabaseErrorTest {
+
+    private lateinit var database: UserProfileDatabase
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        database = UserProfileDatabase.getInstance(context)
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+        val instanceField = UserProfileDatabase::class.java.getDeclaredField("instance")
+        instanceField.isAccessible = true
+        instanceField.set(null, null)
+    }
+
+    @Test
+    fun testSaveProfileError() {
+        val spyDatabase = spy(database)
+        // In Kotlin, the property 'writableDatabase' generates a call to 'getWritableDatabase()'
+        doThrow(SQLiteException("Mocked Exception")).`when`(spyDatabase).writableDatabase
+
+        val profile = UserProfile(
+            username = "test",
+            firstName = "test",
+            middleName = "test",
+            lastName = "test",
+            email = "test",
+            language = "test",
+            phoneNumber = "test",
+            birthDate = "test",
+            gender = "test",
+            level = "test",
+            avatarImage = byteArrayOf(),
+            revision = "test",
+            derivedKey = "test",
+            rawDocument = "test",
+            isUserAdmin = false
+        )
+
+        assertThrows(SQLiteException::class.java) {
+            spyDatabase.saveProfile(profile)
+        }
+    }
+
+    @Test
+    fun testGetProfileError() {
+        val spyDatabase = spy(database)
+        doThrow(SQLiteException("Mocked DB Exception")).`when`(spyDatabase).readableDatabase
+
+        assertThrows(SQLiteException::class.java) {
+            spyDatabase.getProfile()
+        }
+    }
+
+    @Test
+    fun testClearProfileError() {
+        val spyDatabase = spy(database)
+        doThrow(SQLiteException("Mocked DB Exception")).`when`(spyDatabase).writableDatabase
+
+        assertThrows(SQLiteException::class.java) {
+            spyDatabase.clearProfile()
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `UserProfileDatabase` had a testing gap where database failures (e.g. `SQLiteException` thrown when accessing `writableDatabase` or `readableDatabase`) were not covered.
📊 **Coverage:** Added a new test class `UserProfileDatabaseErrorTest.kt` that uses Mockito to `spy` the `UserProfileDatabase` instance and mock the `writableDatabase` / `readableDatabase` properties to throw `SQLiteException`. The tests verify that the exceptions bubble up correctly as they are not caught internally. Covered `saveProfile`, `getProfile`, and `clearProfile`.
✨ **Result:** Improved test coverage and ensured correct exception propagation is tested for database interaction errors.

---
*PR created automatically by Jules for task [17978042096077988902](https://jules.google.com/task/17978042096077988902) started by @dogi*