### PR TITLE
🧪 Improve test coverage for SecureTokenStorage.saveToken

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 190
+        versionName = "0.1.90"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/SecureTokenStorageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/SecureTokenStorageTest.kt
@@ -132,4 +132,47 @@ class SecureTokenStorageTest {
         Mockito.verify(mockEditor).remove("planet_token")
         Mockito.verify(mockEditor, Mockito.times(2)).apply()
     }
+
+    @Test
+    fun `saveToken specifically verifies string put and apply on mock editor`() = runTest {
+        val mockSharedPreferences = Mockito.mock(SharedPreferences::class.java)
+        val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+        Mockito.`when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
+        Mockito.`when`(mockEditor.putString(Mockito.anyString(), Mockito.anyString())).thenReturn(mockEditor)
+
+        SecurePreferencesProvider.resetForTesting()
+        SecurePreferencesProvider.injectedPreferences = mockSharedPreferences
+
+        val storage = SecureTokenStorage(context, Dispatchers.Unconfined)
+        val token = "explicit_save_token"
+        storage.saveToken(token)
+
+        Mockito.verify(mockEditor).putString("planet_token", token)
+        Mockito.verify(mockEditor).apply()
+    }
+
+    @Test
+    fun `saveToken handles exception during putString gracefully or propagates`() = runTest {
+        val mockSharedPreferences = Mockito.mock(SharedPreferences::class.java)
+        val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+        Mockito.`when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
+        Mockito.`when`(mockEditor.putString(Mockito.anyString(), Mockito.anyString())).thenThrow(RuntimeException("Storage failed"))
+
+        SecurePreferencesProvider.resetForTesting()
+        SecurePreferencesProvider.injectedPreferences = mockSharedPreferences
+
+        val storage = SecureTokenStorage(context, Dispatchers.Unconfined)
+        val token = "error_token"
+
+        var exceptionThrown = false
+        try {
+            storage.saveToken(token)
+        } catch (e: Exception) {
+            exceptionThrown = true
+            assertEquals("Storage failed", e.message)
+        }
+
+        org.junit.Assert.assertTrue("Exception should be thrown", exceptionThrown)
+        Mockito.verify(mockEditor, Mockito.never()).apply()
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for public suspend function saveToken in SecureTokenStorage.
📊 **Coverage:** Added mock tests that verify the interaction with SharedPreferences.Editor and exception handling.
✨ **Result:** Improved test coverage for TokenStorage.

---
*PR created automatically by Jules for task [5654306324364916170](https://jules.google.com/task/5654306324364916170) started by @dogi*