### PR TITLE
🧹 Refactor bindAttachments to extract helper methods

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 192
+        versionName = "0.1.92"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -538,12 +538,7 @@ class CourseWizardActivity : BaseActivity() {
         titleView: TextView,
         listContainer: LinearLayout
     ) {
-        listContainer.removeAllViews()
-        playlistIndexByResourceId.clear()
-        currentPlaylistUrls.clear()
-        lastPlaybackIndex = 0
-        lastPlaybackPositionMs = 0L
-        releaseAudioPlayers()
+        resetAttachmentState(listContainer)
         val videoResources = resources.filter { it.mediaType.lowercase(Locale.ROOT).contains("video") }
         val imageResources = resources.filter { it.mediaType.lowercase(Locale.ROOT).contains("image") }
         val displayResources = resources.filter { resource ->
@@ -560,6 +555,35 @@ class CourseWizardActivity : BaseActivity() {
         container.visibility = View.VISIBLE
         titleView.visibility = View.VISIBLE
         val inflater = layoutInflater
+        prepareVideoPlaylist(videoResources)
+        if (videoResources.isNotEmpty() && currentPlaylistUrls.isEmpty()) {
+            container.visibility = View.GONE
+            Toast.makeText(this, getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT)
+                .show()
+            return
+        }
+        populateAttachmentList(
+            survey,
+            hasSurvey,
+            exam,
+            hasExam,
+            displayResources,
+            imageResources,
+            inflater,
+            listContainer
+        )
+    }
+
+    private fun resetAttachmentState(listContainer: LinearLayout) {
+        listContainer.removeAllViews()
+        playlistIndexByResourceId.clear()
+        currentPlaylistUrls.clear()
+        lastPlaybackIndex = 0
+        lastPlaybackPositionMs = 0L
+        releaseAudioPlayers()
+    }
+
+    private fun prepareVideoPlaylist(videoResources: List<DashboardCoursePageFragment.CourseItem.LessonResource>) {
         videoResources.forEachIndexed { index, resource ->
             val resolvedUrl = buildResourceUrl(resource)
             if (resolvedUrl != null) {
@@ -567,12 +591,18 @@ class CourseWizardActivity : BaseActivity() {
                 currentPlaylistUrls.add(resolvedUrl)
             }
         }
-        if (videoResources.isNotEmpty() && currentPlaylistUrls.isEmpty()) {
-            container.visibility = View.GONE
-            Toast.makeText(this, getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT)
-                .show()
-            return
-        }
+    }
+
+    private fun populateAttachmentList(
+        survey: SurveyDocument?,
+        hasSurvey: Boolean,
+        exam: SurveyDocument?,
+        hasExam: Boolean,
+        displayResources: List<DashboardCoursePageFragment.CourseItem.LessonResource>,
+        imageResources: List<DashboardCoursePageFragment.CourseItem.LessonResource>,
+        inflater: android.view.LayoutInflater,
+        listContainer: LinearLayout
+    ) {
         if (survey != null && hasSurvey) {
             bindSurveyAttachment(survey, inflater, listContainer)
         }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `bindAttachments` function in `CourseWizardActivity.kt` was a lengthy, complex method responsible for resetting state, filtering resources, constructing video playlists, and binding various attachments (surveys, exams, files) to the UI. This was broken down into three private helper methods.

💡 **Why:** How this improves maintainability
Breaking this large method into `resetAttachmentState`, `prepareVideoPlaylist`, and `populateAttachmentList` clearly separates concerns. It makes the main `bindAttachments` function much easier to read at a glance, reduces its cognitive complexity, and creates specific functional blocks that can be updated independently if requirements change.

✅ **Verification:** How you confirmed the change is safe
- Compiled the codebase (`./gradlew compileDebugKotlin`) successfully.
- Ran the unit test suite (`./gradlew testDebugUnitTest`) and confirmed all tests passed.
- Ran lint checks (`./gradlew lint app:compileDebugKotlin`) to ensure no syntax/structural rules were violated.
- Requested a code review which scored the refactor `#Correct#`, confirming that early return checks and control flow matched the original logic perfectly.

✨ **Result:** The improvement achieved
A cleaner, more cohesive UI rendering function in `CourseWizardActivity` with smaller logical components, preserving the original behavior while drastically improving the readability of the class.

---
*PR created automatically by Jules for task [4510516221548121625](https://jules.google.com/task/4510516221548121625) started by @dogi*