### PR TITLE
🧪 [Testing] Add tests for clearToken in SecureTokenStorage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 193
+        versionName = "0.1.93"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/SecureTokenStorageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/SecureTokenStorageTest.kt
@@ -67,6 +67,34 @@ class SecureTokenStorageTest {
     }
 
     @Test
+    fun `clearToken_removesExistingToken_successfully`() = runTest {
+        val testToken = "test_token_123"
+        secureTokenStorage.saveToken(testToken)
+
+        // Verify token is saved
+        assertEquals(testToken, secureTokenStorage.getToken())
+
+        // Call clearToken to remove it
+        secureTokenStorage.clearToken()
+
+        // Assert token was successfully removed
+        assertNull(secureTokenStorage.getToken())
+    }
+
+    @Test
+    fun `clearToken when no token exists does not throw`() = runTest {
+        // Ensure it starts empty
+        assertNull(fakeSharedPreferences.getString("planet_token", null))
+
+        // Clearing empty storage shouldn't throw an exception
+        secureTokenStorage.clearToken()
+
+        // Should remain empty
+        assertNull(fakeSharedPreferences.getString("planet_token", null))
+        assertNull(secureTokenStorage.getToken())
+    }
+
+    @Test
     fun `saveToken overwrites previous token`() = runTest {
         val testToken1 = "test_token_123"
         val testToken2 = "test_token_456"


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested public suspend function `clearToken` in `SecureTokenStorage`.
📊 **Coverage:** Now tests the "happy path" of successfully clearing an existing token and the "edge case" of calling `clearToken` when no token currently exists in the `SharedPreferences`. 
✨ **Result:** Increased testing coverage and robustness for the auth storage component, verifying that clearing the token securely interacts with the underlying preferences editor.

---
*PR created automatically by Jules for task [6136384609709533859](https://jules.google.com/task/6136384609709533859) started by @dogi*