### PR TITLE
🧪 Add missing edge case tests for NetworkAuthService

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 194
+        versionName = "0.1.94"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -94,6 +94,42 @@ class NetworkAuthServiceTest {
     }
 
     @Test
+    fun `login success with empty cookie clears token`() = runTest {
+        tokenStorage.saveToken("old_token")
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "")
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals(null, tokenStorage.token)
+        assertEquals("", success.response.sessionCookie)
+    }
+
+    @Test
+    fun `login success with blank cookie clears token`() = runTest {
+        tokenStorage.saveToken("old_token")
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "   ")
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.login("user@planet.com", "secret")
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals(null, tokenStorage.token)
+        assertEquals("", success.response.sessionCookie)
+    }
+
+    @Test
     fun `login success with null body returns invalid response error`() = runTest {
         mockWebServer.enqueue(
             MockResponse()
@@ -443,5 +479,81 @@ class NetworkAuthServiceTest {
         assertTrue(result is AuthResult.Error)
         val error = result as AuthResult.Error
         assertEquals(401, error.code)
+    }
+
+    @Test
+    fun `authenticate success stores token`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "AuthSession=xyz789; Path=/")
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.authenticate(mockWebServer.url("/").toString(), UserCredentials("user@planet.com", "secret"))
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals("AuthSession=xyz789; Path=/", tokenStorage.token)
+        assertEquals("AuthSession=xyz789; Path=/", success.response.sessionCookie)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/db/_session", request.path)
+        val body = request.body.readUtf8()
+        assertTrue(body.contains("\"name\":\"user@planet.com\""))
+        assertTrue(body.contains("\"password\":\"secret\""))
+    }
+
+    @Test
+    fun `authenticate success without cookie clears token`() = runTest {
+        tokenStorage.saveToken("old_token")
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.authenticate(mockWebServer.url("/").toString(), UserCredentials("user@planet.com", "secret"))
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals(null, tokenStorage.token)
+        assertEquals(null, success.response.sessionCookie)
+    }
+
+    @Test
+    fun `authenticate success with empty cookie clears token`() = runTest {
+        tokenStorage.saveToken("old_token")
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "")
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.authenticate(mockWebServer.url("/").toString(), UserCredentials("user@planet.com", "secret"))
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals(null, tokenStorage.token)
+        assertEquals("", success.response.sessionCookie)
+    }
+
+    @Test
+    fun `authenticate success with blank cookie clears token`() = runTest {
+        tokenStorage.saveToken("old_token")
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "   ")
+                .setBody("""{"ok":true,"name":"user@planet.com","roles":["learner"]}""")
+        )
+
+        val result = service.authenticate(mockWebServer.url("/").toString(), UserCredentials("user@planet.com", "secret"))
+
+        assertTrue(result is AuthResult.Success)
+        val success = result as AuthResult.Success
+        assertEquals(null, tokenStorage.token)
+        assertEquals("", success.response.sessionCookie)
     }
 }


### PR DESCRIPTION
🎯 **What:** This PR addresses the testing gap in `NetworkAuthService.login` by adding edge case tests to verify the behavior when the response lacks a valid `Set-Cookie` header (specifically, handling empty and blank header strings). It additionally adds the entirely missing success path tests for the `authenticate` method.

📊 **Coverage:**
- `NetworkAuthService.login` now has tests asserting the token is cleared when the `Set-Cookie` header is `""` (empty) or `"   "` (blank).
- `NetworkAuthService.authenticate` now has tests for successful authentication storing the token, and clearing the token when the header is missing (`null`), empty (`""`), or blank (`"   "`).

✨ **Result:** Test coverage for `NetworkAuthService` logic handles the edge cases for session cookies, significantly improving confidence in the token storage clearing logic for both `login` and `authenticate` paths.

---
*PR created automatically by Jules for task [13905075992016097416](https://jules.google.com/task/13905075992016097416) started by @dogi*