### PR TITLE
🧹 Refactor renderSingleChoiceQuestion to improve maintainability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 195
+        versionName = "0.1.95"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
@@ -1298,6 +1298,32 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
                 ViewGroup.LayoutParams.WRAP_CONTENT,
             )
         }
+
+        val otherInputLayout = buildSingleChoiceOptions(
+            context = context,
+            question = question,
+            translation = translation,
+            radioGroup = radioGroup,
+            container = container,
+        )
+        container.addView(radioGroup, 0)
+
+        val savedSelection = (answers[index] as? SurveyAnswer.SingleChoice)?.choice
+        restoreSingleChoiceSelection(radioGroup, otherInputLayout, savedSelection)
+
+        val collector = {
+            collectSingleChoiceAnswer(radioGroup, otherInputLayout, question, index)
+        }
+        return container to collector
+    }
+
+    private fun buildSingleChoiceOptions(
+        context: android.content.Context,
+        question: SurveyQuestion,
+        translation: TranslatedQuestion?,
+        radioGroup: RadioGroup,
+        container: LinearLayout,
+    ): TextInputLayout? {
         val choices = question.choices.orEmpty()
         choices.forEachIndexed { index, choice ->
             val button = RadioButton(context)
@@ -1306,7 +1332,7 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
             button.tag = choice
             radioGroup.addView(button)
         }
-        val otherInputLayout: TextInputLayout?
+        var otherInputLayout: TextInputLayout? = null
         if (question.hasOtherOption) {
             val otherButton = RadioButton(context)
             otherButton.text = getString(R.string.dashboard_survey_wizard_other_option)
@@ -1320,12 +1346,15 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
                 val isOther = selectedButton?.tag == OTHER_CHOICE_TAG
                 otherInputLayout.isVisible = isOther
             }
-        } else {
-            otherInputLayout = null
         }
-        container.addView(radioGroup, 0)
+        return otherInputLayout
+    }
 
-        val savedSelection = (answers[index] as? SurveyAnswer.SingleChoice)?.choice
+    private fun restoreSingleChoiceSelection(
+        radioGroup: RadioGroup,
+        otherInputLayout: TextInputLayout?,
+        savedSelection: SelectedOption?,
+    ) {
         if (savedSelection != null) {
             val matchedButton = (0 until radioGroup.childCount)
                 .mapNotNull { childIndex -> radioGroup.getChildAt(childIndex) as? RadioButton }
@@ -1345,50 +1374,51 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
                 otherInputLayout?.editText?.setSelection(savedSelection.text.length)
             }
         }
+    }
 
-        val collector = {
-            val selectedId = radioGroup.checkedRadioButtonId
-            if (selectedId == -1) {
-                showValidationMessage(R.string.dashboard_survey_wizard_choice_required)
-                false
-            } else {
-                val selectedButton = radioGroup.findViewById<RadioButton>(selectedId)
-                val isOther = selectedButton.tag == OTHER_CHOICE_TAG
-                val otherValue = otherInputLayout?.editText?.text?.toString()?.trim().orEmpty()
-                if (isOther && otherValue.isBlank()) {
-                    showValidationMessage(R.string.dashboard_survey_wizard_input_required)
-                    false
-                } else {
-                    val choice = if (isOther) {
-                        SelectedOption(
-                            id = GENDER_OTHER,
-                            text = otherValue,
-                            isOther = true,
-                        )
-                    } else {
-                        val originalChoice = selectedButton.tag as? SurveyChoice
-                        val label = originalChoice?.text?.takeIf { it.isNotBlank() }
-                            ?: selectedButton.text?.toString()?.takeIf { it.isNotBlank() }
-                            ?: originalChoice?.id
-                            ?: ""
-                        SelectedOption(
-                            id = originalChoice?.id ?: label,
-                            text = label,
-                            isOther = false,
-                        )
-                    }
-                    val answer = SurveyAnswer.SingleChoice(choice = choice)
-                    if (isExam && !isAnswerCorrect(question, answer)) {
-                        showValidationMessage(R.string.dashboard_exam_incorrect_answers)
-                        false
-                    } else {
-                        answers[index] = answer
-                        true
-                    }
-                }
-            }
+    private fun collectSingleChoiceAnswer(
+        radioGroup: RadioGroup,
+        otherInputLayout: TextInputLayout?,
+        question: SurveyQuestion,
+        index: Int,
+    ): Boolean {
+        val selectedId = radioGroup.checkedRadioButtonId
+        if (selectedId == -1) {
+            showValidationMessage(R.string.dashboard_survey_wizard_choice_required)
+            return false
         }
-        return container to collector
+        val selectedButton = radioGroup.findViewById<RadioButton>(selectedId)
+        val isOther = selectedButton.tag == OTHER_CHOICE_TAG
+        val otherValue = otherInputLayout?.editText?.text?.toString()?.trim().orEmpty()
+        if (isOther && otherValue.isBlank()) {
+            showValidationMessage(R.string.dashboard_survey_wizard_input_required)
+            return false
+        }
+        val choice = if (isOther) {
+            SelectedOption(
+                id = GENDER_OTHER,
+                text = otherValue,
+                isOther = true,
+            )
+        } else {
+            val originalChoice = selectedButton.tag as? SurveyChoice
+            val label = originalChoice?.text?.takeIf { it.isNotBlank() }
+                ?: selectedButton.text?.toString()?.takeIf { it.isNotBlank() }
+                ?: originalChoice?.id
+                ?: ""
+            SelectedOption(
+                id = originalChoice?.id ?: label,
+                text = label,
+                isOther = false,
+            )
+        }
+        val answer = SurveyAnswer.SingleChoice(choice = choice)
+        if (isExam && !isAnswerCorrect(question, answer)) {
+            showValidationMessage(R.string.dashboard_exam_incorrect_answers)
+            return false
+        }
+        answers[index] = answer
+        return true
     }
 
     private fun renderMultiChoiceQuestion(


### PR DESCRIPTION
🎯 **What:** Simplified the `renderSingleChoiceQuestion` method in `SurveyWizardFragment.kt` by extracting its complex logic into three specialized helper methods.
💡 **Why:** The original method was overly long and mixed view instantiation, UI layout manipulation, state restoration, and form validation/collection logic. This made it difficult to read and maintain. By extracting the responsibilities into focused functions (`buildSingleChoiceOptions`, `restoreSingleChoiceSelection`, and `collectSingleChoiceAnswer`), the main function acts purely as an orchestrator, drastically improving the code health.
✅ **Verification:** Ran `./gradlew compileDebugKotlin` to verify compilation, `./gradlew lint app:compileDebugKotlin` to verify static analysis, and `./gradlew testDebugUnitTest` to ensure no existing logic or tests were broken. All checks passed.
✨ **Result:** A more modular, maintainable, and readable implementation of single-choice question rendering in the Survey Wizard.

---
*PR created automatically by Jules for task [1327036465418198812](https://jules.google.com/task/1327036465418198812) started by @dogi*