### PR TITLE
🧪 [Test] Add specific interaction test for NetworkAuthService.getStoredToken()

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 196
+        versionName = "0.1.96"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -22,6 +22,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import retrofit2.HttpException
 import retrofit2.Response
@@ -362,6 +363,19 @@ class NetworkAuthServiceTest {
         val token = service.getStoredToken()
 
         assertEquals(null, token)
+    }
+
+    @Test
+    fun `getStoredToken invokes getToken on mocked TokenStorage`() = runTest {
+        val mockTokenStorage = mock<TokenStorage>()
+        whenever(mockTokenStorage.getToken()).thenReturn("mock_token")
+        val mockApi = mock<AuthApi>()
+        val serviceWithMock = NetworkAuthService(mockApi, mockTokenStorage, Dispatchers.Unconfined)
+
+        val token = serviceWithMock.getStoredToken()
+
+        verify(mockTokenStorage).getToken()
+        assertEquals("mock_token", token)
     }
 
 


### PR DESCRIPTION
🎯 **What:** The testing gap in `NetworkAuthService.getStoredToken()` was addressed by explicitly testing interaction with the underlying dependency (`TokenStorage.getToken()`).

📊 **Coverage:** The new test covers the specific scenario where invoking the public suspend function `getStoredToken` correctly routes and calls the nested mock.

✨ **Result:** Enhanced determinism in `NetworkAuthServiceTest.kt`. Now, not only the result is checked, but the strict interaction with the internal abstraction layer (`TokenStorage`) is guaranteed.

---
*PR created automatically by Jules for task [15090868693118371833](https://jules.google.com/task/15090868693118371833) started by @dogi*