### PR TITLE
🧪 [testing improvement] Add test for JSONException in parseErrorMessage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 197
+        versionName = "0.1.97"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,13 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-<<<<<<< test-parse-error-message-13351406347152029566
         versionCode = 197
         versionName = "0.1.97"
-=======
-        versionCode = 196
-        versionName = "0.1.96"
->>>>>>> main
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -444,4 +444,12 @@ class NetworkAuthServiceTest {
         val error = result as AuthResult.Error
         assertEquals(401, error.code)
     }
+
+    @Test
+    fun `parseErrorMessage returns raw body on JSONException`() {
+        val method = NetworkAuthService::class.java.getDeclaredMethod("parseErrorMessage", String::class.java)
+        method.isAccessible = true
+        val result = method.invoke(service, "invalid json {") as String
+        assertEquals("invalid json {", result)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `JSONException` in `NetworkAuthService.parseErrorMessage`.
📊 **Coverage:** The scenario where a raw error response fails to parse as valid JSON (thus throwing a `JSONException` in the inner try-catch) is now perfectly covered.
✨ **Result:** Test coverage for `NetworkAuthService` is improved by validating the fallback behavior of the pure function returning the raw unparsed string safely.

---
*PR created automatically by Jules for task [13351406347152029566](https://jules.google.com/task/13351406347152029566) started by @dogi*