### PR TITLE
🧹 Extract duplicated replaceImagePlaceholder to MarkdownUtils

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         minSdk = 28
         targetSdk = 36
         versionCode = 204
-        versionName = "0.2.04"
+        versionName = "0.2.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 204
+        versionName = "0.2.04"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -64,6 +64,7 @@ import okhttp3.OkHttpClient
 import org.json.JSONObject
 import org.ole.planet.myplanet.lite.BaseActivity
 import org.ole.planet.myplanet.lite.R
+import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsActionsRepository
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository
@@ -1225,7 +1226,7 @@ class CreateVoiceActivity : BaseActivity() {
 
         for ((pending, markdown) in uploadResults) {
             val normalizedPath = normalizeImagePath(markdown)
-            val replaced = replaceImagePlaceholder(updatedMessage, pending.fileName, markdown)
+            val replaced = MarkdownUtils.replaceImagePlaceholder(updatedMessage, pending.fileName, markdown)
             if (!normalizedMessageImages.contains(normalizedPath)) {
                 updatedMessage = ensureMarkdownPresent(replaced, markdown)
                 normalizedMessageImages += normalizedPath
@@ -1421,50 +1422,6 @@ class CreateVoiceActivity : BaseActivity() {
             val parentCode = json.optString("parentCode").takeIf { it.isNotBlank() }
             ProfileCodes(planetCode, parentCode)
         }.getOrNull()
-    }
-
-    private fun replaceImagePlaceholder(source: String, fileName: String, replacement: String): String {
-        val escapedName = Regex.escape(fileName)
-        val pattern = Regex("!\\[([^\\]]*)\\]\\($escapedName\\)")
-        var matched = false
-        val updated = pattern.replace(source) { matchResult ->
-            matched = true
-            val altText = matchResult.groupValues.getOrNull(1).orEmpty()
-            if (altText.isBlank()) {
-                replacement
-            } else {
-                applyAltTextToMarkdown(replacement, altText)
-            }
-        }
-        if (matched) {
-            return updated
-        }
-        val builder = StringBuilder(source)
-        if (builder.isNotEmpty()) {
-            if (builder[builder.length - 1] != '\n') {
-                builder.append('\n')
-            }
-            builder.append('\n')
-        }
-        builder.append(replacement)
-        return builder.toString()
-    }
-
-    private fun applyAltTextToMarkdown(markdown: String, altText: String): String {
-        val trimmedAlt = altText.trim()
-        if (trimmedAlt.isEmpty()) {
-            return markdown
-        }
-        val openBracket = markdown.indexOf('[')
-        val closeBracket = markdown.indexOf(']')
-        if (openBracket == -1 || closeBracket <= openBracket) {
-            return markdown
-        }
-        return buildString {
-            append(markdown.substring(0, openBracket + 1))
-            append(trimmedAlt)
-            append(markdown.substring(closeBracket))
-        }
     }
 
     private suspend fun loadCachedProfile(): UserProfile? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
+import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository.NewsDocument
 import org.ole.planet.myplanet.lite.profile.AvatarUpdateNotifier
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
@@ -1089,7 +1090,7 @@ class DashboardPostDetailActivity : AppCompatActivity() {
         val preparedImages = mutableListOf<VoicesComposerRepository.ImagePayload>()
 
         for ((pending, markdown) in uploadResults) {
-            val replaced = replaceImagePlaceholder(updatedMessage, pending.fileName, markdown)
+            val replaced = MarkdownUtils.replaceImagePlaceholder(updatedMessage, pending.fileName, markdown)
             updatedMessage = ensureMarkdownPresent(replaced, markdown)
             val resourceId = pending.resourceId
             if (resourceId != null) {
@@ -1247,50 +1248,6 @@ class DashboardPostDetailActivity : AppCompatActivity() {
             val parentCode = json.optString("parentCode").takeIf { it.isNotBlank() }
             ProfileCodes(planetCode, parentCode)
         }.getOrNull()
-    }
-
-    private fun replaceImagePlaceholder(source: String, fileName: String, replacement: String): String {
-        val escapedName = Regex.escape(fileName)
-        val pattern = Regex("!\\[([^\\]]*)\\]\\($escapedName\\)")
-        var matched = false
-        val updated = pattern.replace(source) { matchResult ->
-            matched = true
-            val altText = matchResult.groupValues.getOrNull(1).orEmpty()
-            if (altText.isBlank()) {
-                replacement
-            } else {
-                applyAltTextToMarkdown(replacement, altText)
-            }
-        }
-        if (matched) {
-            return updated
-        }
-        val builder = StringBuilder(source)
-        if (builder.isNotEmpty()) {
-            if (builder[builder.length - 1] != '\n') {
-                builder.append('\n')
-            }
-            builder.append('\n')
-        }
-        builder.append(replacement)
-        return builder.toString()
-    }
-
-    private fun applyAltTextToMarkdown(markdown: String, altText: String): String {
-        val trimmedAlt = altText.trim()
-        if (trimmedAlt.isEmpty()) {
-            return markdown
-        }
-        val openBracket = markdown.indexOf('[')
-        val closeBracket = markdown.indexOf(']')
-        if (openBracket == -1 || closeBracket <= openBracket) {
-            return markdown
-        }
-        return buildString {
-            append(markdown.substring(0, openBracket + 1))
-            append(trimmedAlt)
-            append(markdown.substring(closeBracket))
-        }
     }
 
     private suspend fun loadCachedProfile(): UserProfile? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/MarkdownUtils.kt
@@ -40,6 +40,50 @@ object MarkdownUtils {
         return (fromMarkdown + fromHtml).filter { it.isNotBlank() }
     }
 
+    fun replaceImagePlaceholder(source: String, fileName: String, replacement: String): String {
+        val escapedName = Regex.escape(fileName)
+        val pattern = Regex("!\\[([^\\]]*)\\]\\($escapedName\\)")
+        var matched = false
+        val updated = pattern.replace(source) { matchResult ->
+            matched = true
+            val altText = matchResult.groupValues.getOrNull(1).orEmpty()
+            if (altText.isBlank()) {
+                replacement
+            } else {
+                applyAltTextToMarkdown(replacement, altText)
+            }
+        }
+        if (matched) {
+            return updated
+        }
+        val builder = StringBuilder(source)
+        if (builder.isNotEmpty()) {
+            if (builder[builder.length - 1] != '\n') {
+                builder.append('\n')
+            }
+            builder.append('\n')
+        }
+        builder.append(replacement)
+        return builder.toString()
+    }
+
+    private fun applyAltTextToMarkdown(markdown: String, altText: String): String {
+        val trimmedAlt = altText.trim()
+        if (trimmedAlt.isEmpty()) {
+            return markdown
+        }
+        val openBracket = markdown.indexOf('[')
+        val closeBracket = markdown.indexOf(']')
+        if (openBracket == -1 || closeBracket <= openBracket) {
+            return markdown
+        }
+        return buildString {
+            append(markdown.substring(0, openBracket + 1))
+            append(trimmedAlt)
+            append(markdown.substring(closeBracket))
+        }
+    }
+
     fun resolveOfflineMarkdownImages(
         context: Context,
         markdown: String,

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Testing replaceImagePlaceholder and applyAltTextToMarkdown behavior"

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Testing replaceImagePlaceholder and applyAltTextToMarkdown behavior"


### PR DESCRIPTION
🎯 **What:** Removed duplicate code by extracting the pure string manipulation logic of `replaceImagePlaceholder` and its private helper `applyAltTextToMarkdown` from `CreateVoiceActivity` and `DashboardPostDetailActivity` into the shared `MarkdownUtils` object. Removed a temporary test script.

💡 **Why:** Deduplicating these functions reduces maintenance overhead and prevents potential discrepancies in image markdown placeholder replacement logic across the application. Since these methods are pure text manipulation functions, they fit perfectly into `MarkdownUtils`.

✅ **Verification:** Verified that both `app:compileDebugKotlin` and `app:lint` pass, and ran all unit tests via `./gradlew testDebugUnitTest` to ensure functionality remains unchanged.

✨ **Result:** Improved code maintainability by centralizing identical logic into a single reusable utility function without affecting any existing application behavior.

---
*PR created automatically by Jules for task [10685780350952669424](https://jules.google.com/task/10685780350952669424) started by @dogi*