### PR TITLE
🧪 [Testing Improvement] Add mock verification test for logout in NetworkAuthService

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 206
+        versionName = "0.2.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -22,6 +22,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import retrofit2.HttpException
 import retrofit2.Response
@@ -344,6 +345,17 @@ class NetworkAuthServiceTest {
         service.logout()
 
         assertEquals(null, tokenStorage.token)
+    }
+
+    @Test
+    fun `logout invokes clearToken on mocked token storage`() = runTest {
+        val mockApi = mock<AuthApi>()
+        val mockTokenStorage = mock<TokenStorage>()
+        val serviceWithMockStorage = NetworkAuthService(mockApi, mockTokenStorage, Dispatchers.Unconfined)
+
+        serviceWithMockStorage.logout()
+
+        verify(mockTokenStorage).clearToken()
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The testing gap where the `logout()` suspend function in `NetworkAuthService` was not explicitly verified has been addressed by adding a Mockito verification test.
📊 **Coverage:** The test now completely covers the `logout` function path, ensuring the expected side effect (`tokenStorage.clearToken()`) is triggered when the function is invoked.
✨ **Result:** Improved test coverage and explicit assurance that the authentication state is correctly wiped upon logout requests.

---
*PR created automatically by Jules for task [10135588121653605225](https://jules.google.com/task/10135588121653605225) started by @dogi*