### PR TITLE
🧹 Refactor applyAltTextToMarkdown logic to shared utility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 207
+        versionName = "0.2.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -10,7 +10,6 @@ import android.app.Activity
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputType
@@ -40,11 +39,6 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
 import org.ole.planet.myplanet.lite.util.MarkdownUtils
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileOutputStream
-import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.LinkedHashMap
 import java.util.LinkedHashSet
 import java.util.Locale
@@ -65,10 +59,7 @@ import okhttp3.OkHttpClient
 import org.json.JSONObject
 import org.ole.planet.myplanet.lite.BaseActivity
 import org.ole.planet.myplanet.lite.R
-import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
-import org.ole.planet.myplanet.lite.dashboard.DashboardNewsActionsRepository
-import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences.getServerBaseUrl
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences.getServerCode
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -39,6 +39,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
+import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -1433,7 +1434,7 @@ class CreateVoiceActivity : BaseActivity() {
             if (altText.isBlank()) {
                 replacement
             } else {
-                applyAltTextToMarkdown(replacement, altText)
+                MarkdownUtils.applyAltText(replacement, altText)
             }
         }
         if (matched) {
@@ -1448,23 +1449,6 @@ class CreateVoiceActivity : BaseActivity() {
         }
         builder.append(replacement)
         return builder.toString()
-    }
-
-    private fun applyAltTextToMarkdown(markdown: String, altText: String): String {
-        val trimmedAlt = altText.trim()
-        if (trimmedAlt.isEmpty()) {
-            return markdown
-        }
-        val openBracket = markdown.indexOf('[')
-        val closeBracket = markdown.indexOf(']')
-        if (openBracket == -1 || closeBracket <= openBracket) {
-            return markdown
-        }
-        return buildString {
-            append(markdown.substring(0, openBracket + 1))
-            append(trimmedAlt)
-            append(markdown.substring(closeBracket))
-        }
     }
 
     private suspend fun loadCachedProfile(): UserProfile? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -10,8 +10,6 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.graphics.Rect
 import android.net.Uri
 import android.os.Build
@@ -53,12 +51,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
 import org.ole.planet.myplanet.lite.util.MarkdownUtils
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.FileOutputStream
-import java.text.SimpleDateFormat
 import java.util.ArrayList
-import java.util.Date
 import java.util.LinkedHashMap
 import java.util.LinkedHashSet
 import java.util.Locale
@@ -73,7 +66,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
-import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository.NewsDocument
 import org.ole.planet.myplanet.lite.profile.AvatarUpdateNotifier
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -52,6 +52,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
+import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -1259,7 +1260,7 @@ class DashboardPostDetailActivity : AppCompatActivity() {
             if (altText.isBlank()) {
                 replacement
             } else {
-                applyAltTextToMarkdown(replacement, altText)
+                MarkdownUtils.applyAltText(replacement, altText)
             }
         }
         if (matched) {
@@ -1274,23 +1275,6 @@ class DashboardPostDetailActivity : AppCompatActivity() {
         }
         builder.append(replacement)
         return builder.toString()
-    }
-
-    private fun applyAltTextToMarkdown(markdown: String, altText: String): String {
-        val trimmedAlt = altText.trim()
-        if (trimmedAlt.isEmpty()) {
-            return markdown
-        }
-        val openBracket = markdown.indexOf('[')
-        val closeBracket = markdown.indexOf(']')
-        if (openBracket == -1 || closeBracket <= openBracket) {
-            return markdown
-        }
-        return buildString {
-            append(markdown.substring(0, openBracket + 1))
-            append(trimmedAlt)
-            append(markdown.substring(closeBracket))
-        }
     }
 
     private suspend fun loadCachedProfile(): UserProfile? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/MarkdownUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/MarkdownUtils.kt
@@ -74,4 +74,21 @@ object MarkdownUtils {
         }
         return resolved
     }
+
+    fun applyAltText(markdown: String, altText: String): String {
+        val trimmedAlt = altText.trim()
+        if (trimmedAlt.isEmpty()) {
+            return markdown
+        }
+        val openBracket = markdown.indexOf('[')
+        val closeBracket = markdown.indexOf(']')
+        if (openBracket == -1 || closeBracket <= openBracket) {
+            return markdown
+        }
+        return buildString {
+            append(markdown.substring(0, openBracket + 1))
+            append(trimmedAlt)
+            append(markdown.substring(closeBracket))
+        }
+    }
 }


### PR DESCRIPTION
🎯 **What:** Removed duplicated alt text markdown logic from `CreateVoiceActivity.kt` and `DashboardPostDetailActivity.kt` by extracting it into `MarkdownUtils.kt`.
💡 **Why:** Moving this pure function to a shared utility is low-risk, reduces code size, and improves the overall maintainability of the codebase.
✅ **Verification:** Verified by compiling the app successfully (`./gradlew compileDebugKotlin`), running the linter (`./gradlew lint app:compileDebugKotlin`), and running the full unit test suite (`./gradlew testDebugUnitTest`), which all passed.
✨ **Result:** A cleaner, more maintainable codebase with centralized Markdown processing logic and no duplicated methods.

---
*PR created automatically by Jules for task [13109356114231769039](https://jules.google.com/task/13109356114231769039) started by @dogi*