### PR TITLE
🧪 add edge case for login with null body in NetworkAuthService

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 167
-        versionName = "0.1.67"
+        versionCode = 210
+        versionName = "0.2.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -268,4 +268,18 @@ class NetworkAuthServiceTest {
         assertEquals(null, token)
     }
 
+    @Test
+    fun `login successful with null body returns error`() = runTest {
+        val mockApi = mock<AuthApi>()
+        whenever(mockApi.login(any())).thenReturn(Response.success(null))
+
+        val serviceWithMockApi = NetworkAuthService(mockApi, tokenStorage, Dispatchers.Unconfined)
+        val result = serviceWithMockApi.login("user", "pass")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(200, error.code)
+        assertEquals("Respuesta inválida del servidor", error.message)
+    }
+
 }


### PR DESCRIPTION
This PR addresses a missing edge case in the `NetworkAuthService` unit tests.

### 🎯 What:
The testing gap addressed is the scenario where the server returns a successful HTTP response (200 OK) but with a `null` body.

### 📊 Coverage:
A new test case `login successful with null body returns error` has been added to `NetworkAuthServiceTest.kt`. This test:
- Mocks `AuthApi` to return `Response.success(null)`.
- Asserts that `AuthService.login` returns `AuthResult.Error`.
- Verifies the status code is 200 and the error message matches "Respuesta inválida del servidor", as defined in the implementation.

### ✨ Result:
The reliability of the authentication service is improved by ensuring that unexpected empty responses from the server are correctly identified and reported as invalid responses.

---
*PR created automatically by Jules for task [5797584563108958383](https://jules.google.com/task/5797584563108958383) started by @dogi*