### PR TITLE
🧹 Extract duplicated server connectivity check

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 189
-        versionName = "0.1.89"
+        versionCode = 214
+        versionName = "0.2.14"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -71,6 +71,8 @@ import org.ole.planet.myplanet.lite.profile.UserProfileSync
 import org.ole.planet.myplanet.lite.util.IntentUtils
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.ole.planet.myplanet.lite.util.ServerMetadataExtractor
+import org.ole.planet.myplanet.lite.model.ServerConnectivityResult
+import org.ole.planet.myplanet.lite.dashboard.ServerConnectivityRepository
 
 class MyPlanetLite : BaseActivity() {
 
@@ -123,6 +125,9 @@ class MyPlanetLite : BaseActivity() {
         SecurePreferencesProvider.getEncryptedPreferences(applicationContext, SECURE_PREFS_NAME)
     }
     private val moshi: Moshi by lazy { Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build() }
+    private val serverConnectivityRepository: ServerConnectivityRepository by lazy {
+        ServerConnectivityRepository(connectivityClient, moshi)
+    }
 
     private val signupLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         if (result.resultCode == RESULT_OK) {
@@ -1201,12 +1206,6 @@ class MyPlanetLite : BaseActivity() {
 
     private data class ServerConfiguration(val baseUrl: String, val countryCode: String, val displayName: String)
 
-    private data class ServerConnectivityResult(
-        val reachable: Boolean,
-        val parentCode: String? = null,
-        val code: String? = null
-    )
-
     private data class BuiltInServer(val nameRes: Int, val baseUrl: String, val countryCode: String)
 
     private data class CustomServer(val displayName: String, val baseUrl: String, val countryCode: String) {
@@ -1329,7 +1328,7 @@ class MyPlanetLite : BaseActivity() {
         serverStatusIconView.setOnClickListener(null)
         serverStatusJob = lifecycleScope.launch {
             showServerStatusChecking()
-            val result = withContext(Dispatchers.IO) { fetchServerConnectivity(baseUrl) }
+            val result = withContext(Dispatchers.IO) { serverConnectivityRepository.checkServerConnectivity(baseUrl) }
             if (!isActive) {
                 return@launch
             }
@@ -1340,35 +1339,6 @@ class MyPlanetLite : BaseActivity() {
                 showServerDisconnectedState(allowRetry = true)
             }
         }
-    }
-
-    private fun fetchServerConnectivity(baseUrl: String): ServerConnectivityResult {
-        val requestUrl = buildConfigurationRequestUrl(baseUrl) ?: return ServerConnectivityResult(false)
-        return runCatching {
-            val request = Request.Builder()
-                .url(requestUrl)
-                .get()
-                .build()
-            connectivityClient.newCall(request).execute().use { response ->
-                if (response.code != 200) {
-                    return@use ServerConnectivityResult(false)
-                }
-                val body = response.body.string()
-                if (body.isBlank()) {
-                    return@use ServerConnectivityResult(true)
-                }
-                val metadata = ServerMetadataExtractor.extract(body, moshi)
-                ServerConnectivityResult(true, metadata?.first, metadata?.second)
-            }
-        }.getOrDefault(ServerConnectivityResult(false))
-    }
-
-    private fun buildConfigurationRequestUrl(baseUrl: String): String? {
-        return baseUrl.toHttpUrlOrNull()?.newBuilder()
-            ?.addPathSegments("db/configurations/_all_docs")
-            ?.addQueryParameter("include_docs", "true")
-            ?.build()
-            ?.toString()
     }
 
     private fun persistServerMetadata(baseUrl: String, parentCode: String?, code: String?) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
@@ -56,6 +56,8 @@ import org.ole.planet.myplanet.lite.profile.GENDER_MALE
 import org.ole.planet.myplanet.lite.profile.LearningLevelTranslator
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.ole.planet.myplanet.lite.util.ServerMetadataExtractor
+import org.ole.planet.myplanet.lite.model.ServerConnectivityResult
+import org.ole.planet.myplanet.lite.dashboard.ServerConnectivityRepository
 
 class SignupActivity : BaseActivity() {
 
@@ -161,6 +163,9 @@ class SignupActivity : BaseActivity() {
         SecurePreferencesProvider.getServerPreferences(applicationContext)
     }
     private val moshi: Moshi by lazy { Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build() }
+    private val serverConnectivityRepository: ServerConnectivityRepository by lazy {
+        ServerConnectivityRepository(connectivityClient, moshi)
+    }
 
     private val steps = SignupStep.entries
     private var currentStepIndex = 0
@@ -836,7 +841,7 @@ class SignupActivity : BaseActivity() {
         val job = lifecycleScope.launch {
             applyConnectivityState(step, reachable = false, checking = true)
             val connectivityResult = withContext(Dispatchers.IO) {
-                performServerConnectivityCheck(trimmedBaseUrl)
+                serverConnectivityRepository.checkServerConnectivity(trimmedBaseUrl)
             }
             if (!isActive) {
                 return@launch
@@ -853,27 +858,6 @@ class SignupActivity : BaseActivity() {
 
         serverCheckJob = job
         return job
-    }
-
-    private fun performServerConnectivityCheck(baseUrl: String): ServerConnectivityResult {
-        val requestUrl = buildConfigurationRequestUrl(baseUrl) ?: return ServerConnectivityResult(false)
-        return runCatching {
-            val request = Request.Builder()
-                .url(requestUrl)
-                .get()
-                .build()
-            connectivityClient.newCall(request).execute().use { response ->
-                if (response.code != 200) {
-                    return@use ServerConnectivityResult(false)
-                }
-                val body = response.body.string()
-                if (body.isBlank()) {
-                    return@use ServerConnectivityResult(true)
-                }
-                val metadata = ServerMetadataExtractor.extract(body, moshi)
-                ServerConnectivityResult(true, metadata?.first, metadata?.second)
-            }
-        }.getOrDefault(ServerConnectivityResult(false))
     }
 
     private fun persistServerMetadata(baseUrl: String, parentCode: String?, code: String?) {
@@ -985,14 +969,6 @@ class SignupActivity : BaseActivity() {
                 UsernameAvailability.UNKNOWN
             }
         }
-    }
-
-    private fun buildConfigurationRequestUrl(baseUrl: String): String? {
-        return baseUrl.toHttpUrlOrNull()?.newBuilder()
-            ?.addPathSegments("db/configurations/_all_docs")
-            ?.addQueryParameter("include_docs", "true")
-            ?.build()
-            ?.toString()
     }
 
     private fun buildUsernameLookupUrl(username: String): String? {
@@ -1111,12 +1087,6 @@ class SignupActivity : BaseActivity() {
             put("roles", JSONArray().apply { put("learner") })
         }
     }
-
-    private data class ServerConnectivityResult(
-        val reachable: Boolean,
-        val parentCode: String? = null,
-        val code: String? = null
-    )
 
     private enum class UsernameAvailability { AVAILABLE, TAKEN, UNKNOWN }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/ServerConnectivityRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/ServerConnectivityRepository.kt
@@ -1,0 +1,43 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import com.squareup.moshi.Moshi
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.ole.planet.myplanet.lite.model.ServerConnectivityResult
+import org.ole.planet.myplanet.lite.util.ServerMetadataExtractor
+
+class ServerConnectivityRepository(
+    private val client: OkHttpClient,
+    private val moshi: Moshi
+) {
+
+    fun checkServerConnectivity(baseUrl: String): ServerConnectivityResult {
+        val requestUrl = buildConfigurationRequestUrl(baseUrl) ?: return ServerConnectivityResult(false)
+        return runCatching {
+            val request = Request.Builder()
+                .url(requestUrl)
+                .get()
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (response.code != 200) {
+                    return@use ServerConnectivityResult(false)
+                }
+                val body = response.body.string()
+                if (body.isBlank()) {
+                    return@use ServerConnectivityResult(true)
+                }
+                val metadata = ServerMetadataExtractor.extract(body, moshi)
+                ServerConnectivityResult(true, metadata?.first, metadata?.second)
+            }
+        }.getOrDefault(ServerConnectivityResult(false))
+    }
+
+    private fun buildConfigurationRequestUrl(baseUrl: String): String? {
+        return baseUrl.toHttpUrlOrNull()?.newBuilder()
+            ?.addPathSegments("db/configurations/_all_docs")
+            ?.addQueryParameter("include_docs", "true")
+            ?.build()
+            ?.toString()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/model/ServerConnectivityResult.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/model/ServerConnectivityResult.kt
@@ -1,0 +1,7 @@
+package org.ole.planet.myplanet.lite.model
+
+data class ServerConnectivityResult(
+    val reachable: Boolean,
+    val parentCode: String? = null,
+    val code: String? = null
+)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted duplicate logic for checking server connectivity and building configuration request URLs from `SignupActivity.kt` and `MyPlanetLite.kt` into a new, shared `ServerConnectivityRepository`. `ServerConnectivityResult` was also moved to the shared `model` package.

💡 **Why:** How this improves maintainability
This eliminates copy-pasted network request logic and redundant private data class definitions, making updates to the server check process centralized and reducing code duplication.

✅ **Verification:** How you confirmed the change is safe
Ran local build `compileDebugKotlin` and full unit test suite via `testDebugUnitTest` to ensure functionality and compilation were preserved with zero regressions.

✨ **Result:** The improvement achieved
A single source of truth for the server configuration check now exists in `ServerConnectivityRepository`, significantly simplifying both activity classes.

---
*PR created automatically by Jules for task [12425444278893356474](https://jules.google.com/task/12425444278893356474) started by @dogi*