### PR TITLE
🔒 Fix insecure SharedPreferences file creation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 216
+        versionName = "0.2.16"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -65,25 +65,30 @@ class CourseWizardActivity : BaseActivity() {
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
-        val legacyPrefs = getSharedPreferences(PREF_LEGACY_PENDING_COURSE_PROGRESS, MODE_PRIVATE)
-        val allLegacy = legacyPrefs.all
-        if (allLegacy.isNotEmpty()) {
-            encryptedPrefs.edit {
-                for ((key, value) in allLegacy) {
-                    when (value) {
-                        is String -> putString(key, value)
-                        is Int -> putInt(key, value)
-                        is Boolean -> putBoolean(key, value)
-                        is Float -> putFloat(key, value)
-                        is Long -> putLong(key, value)
-                        is Set<*> -> @Suppress("UNCHECKED_CAST") putStringSet(
-                            key,
-                            value as Set<String>
-                        )
+        val legacyFile = java.io.File(applicationContext.applicationInfo.dataDir, "shared_prefs/$PREF_LEGACY_PENDING_COURSE_PROGRESS.xml")
+        if (legacyFile.exists()) {
+            val legacyPrefs = getSharedPreferences(PREF_LEGACY_PENDING_COURSE_PROGRESS, MODE_PRIVATE)
+            val allLegacy = legacyPrefs.all
+            if (allLegacy.isNotEmpty()) {
+                encryptedPrefs.edit {
+                    for ((key, value) in allLegacy) {
+                        when (value) {
+                            is String -> putString(key, value)
+                            is Int -> putInt(key, value)
+                            is Boolean -> putBoolean(key, value)
+                            is Float -> putFloat(key, value)
+                            is Long -> putLong(key, value)
+                            is Set<*> -> @Suppress("UNCHECKED_CAST") putStringSet(
+                                key,
+                                value as Set<String>
+                            )
+                        }
                     }
                 }
             }
+            legacyPrefs.edit().clear().apply()
             applicationContext.deleteSharedPreferences(PREF_LEGACY_PENDING_COURSE_PROGRESS)
+            legacyFile.delete()
         }
         encryptedPrefs
     }


### PR DESCRIPTION
🎯 **What:** The `CourseWizardActivity` previously loaded the `PREF_LEGACY_PENDING_COURSE_PROGRESS` legacy shared preference file unconditionally, which caused a new empty unencrypted XML file to be created on the disk if none existed before. Furthermore, when migrating existing data to `EncryptedSharedPreferences`, the original unencrypted file was not thoroughly deleted, leaving sensitive data vulnerable.

⚠️ **Risk:** Storing or persisting sensitive legacy data in standard `SharedPreferences` (MODE_PRIVATE) leaves it vulnerable to local extraction on rooted devices or via backup extraction. Creating the unencrypted file indiscriminately triggers security scanner warnings.

🛡️ **Solution:** The fix checks if the legacy XML file exists using `java.io.File.exists()` before calling `getSharedPreferences()`. This ensures we don't accidentally create an empty insecure file. If the legacy file exists, the data is read and migrated to `EncryptedSharedPreferences`. Finally, the legacy preferences are securely destroyed by clearing them in memory (`legacyPrefs.edit().clear().apply()`), asking the framework to delete them (`applicationContext.deleteSharedPreferences`), and forcefully deleting the file from disk (`legacyFile.delete()`).

---
*PR created automatically by Jules for task [10540469072689229523](https://jules.google.com/task/10540469072689229523) started by @dogi*