### PR TITLE
🧹 Refactor setupFocusAndValidationListeners to reduce complexity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 218
+        versionName = "0.2.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
@@ -416,10 +416,14 @@ class SignupActivity : BaseActivity() {
         initializeLanguageSelection()
     }
 
-    private fun setupFocusAndValidationListeners() {
-        levelInput.doAfterTextChanged {
-            levelLayout.error = null
+    private fun TextView.clearErrorOnTextChange(layout: TextInputLayout) {
+        doAfterTextChanged {
+            layout.error = null
         }
+    }
+
+    private fun setupFocusAndValidationListeners() {
+        levelInput.clearErrorOnTextChange(levelLayout)
 
         val focusableInputs = listOf(
             usernameInput,
@@ -453,26 +457,15 @@ class SignupActivity : BaseActivity() {
             ensureVisible(scrollView, genderGroup)
         }
 
+        usernameInput.clearErrorOnTextChange(usernameLayout)
         usernameInput.doAfterTextChanged {
-            usernameLayout.error = null
             verifyServerAvailability(SignupStep.USERNAME, force = true)
         }
 
-        firstNameInput.doAfterTextChanged {
-            firstNameLayout.error = null
-        }
-
-        lastNameInput.doAfterTextChanged {
-            lastNameLayout.error = null
-        }
-
-        emailInput.doAfterTextChanged {
-            emailLayout.error = null
-        }
-
-        phoneInput.doAfterTextChanged {
-            phoneLayout.error = null
-        }
+        firstNameInput.clearErrorOnTextChange(firstNameLayout)
+        lastNameInput.clearErrorOnTextChange(lastNameLayout)
+        emailInput.clearErrorOnTextChange(emailLayout)
+        phoneInput.clearErrorOnTextChange(phoneLayout)
 
         birthDateInput.keyListener = null
         birthDateInput.setOnClickListener {


### PR DESCRIPTION
🎯 **What:** The `setupFocusAndValidationListeners` method in `SignupActivity.kt` contained repetitive `doAfterTextChanged` blocks designed solely to clear errors from their corresponding `TextInputLayouts`. This was extracted into a private extension function `TextView.clearErrorOnTextChange(layout: TextInputLayout)`.
💡 **Why:** This abstraction significantly reduces visual clutter and prevents duplicated boilerplate when adding new inputs, adhering to the DRY (Don't Repeat Yourself) principle. It isolates the boilerplate error-clearing logic from more specific listeners (e.g. the network validation call in `usernameInput`).
✅ **Verification:** Ran `./gradlew testDebugUnitTest` and confirmed all tests pass without issue. The single, additional text watcher added alongside `usernameInput` acts independently and safely.
✨ **Result:** A cleaner, more readable `setupFocusAndValidationListeners` method with identical behavior but higher maintainability.

---
*PR created automatically by Jules for task [3625302784780186812](https://jules.google.com/task/3625302784780186812) started by @dogi*