### PR TITLE
🧹 [Refactor SplashScreen to reduce onCreate complexity]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 218
+        versionName = "0.2.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 218
-        versionName = "0.2.18"
+        versionCode = 219
+        versionName = "0.2.19"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
@@ -49,6 +49,14 @@ class SplashScreen : BaseActivity() {
         enableEdgeToEdge()
         setContentView(R.layout.activity_splash_screen)
         setupEdgeToEdgePadding(findViewById(R.id.main))
+        startLogoAnimation()
+        lifecycleScope.launch {
+            delay(SPLASH_DELAY_MS)
+            routeToNextActivity()
+        }
+    }
+
+    private fun startLogoAnimation() {
         val logo = findViewById<ImageView>(R.id.logoImageView)
         val startOffset = -resources.displayMetrics.heightPixels * 0.5f
         logo.translationY = startOffset
@@ -93,34 +101,34 @@ class SplashScreen : BaseActivity() {
                 .setInterpolator(AccelerateDecelerateInterpolator())
                 .start()
         }
-        lifecycleScope.launch {
-            delay(SPLASH_DELAY_MS)
-            val launchMode = attemptDirectDashboardLaunch()
-            val nextIntent = when (launchMode) {
-                DashboardLaunchMode.ONLINE -> Intent(this@SplashScreen, DashboardActivity::class.java)
-                DashboardLaunchMode.OFFLINE -> Intent(this@SplashScreen, DashboardActivity::class.java).apply {
-                    putExtra(DashboardActivity.EXTRA_OFFLINE_MODE, true)
-                }
-                DashboardLaunchMode.NONE -> Intent(this@SplashScreen, MyPlanetLite::class.java).apply {
-                    putExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, true)
-                }
-            }
+    }
 
-            if (intent.action == Intent.ACTION_VIEW && intent.data != null) {
-                if (launchMode == DashboardLaunchMode.NONE) {
-                    nextIntent.action = intent.action
-                    nextIntent.data = intent.data
-                } else {
-                    val postId = IntentUtils.extractDeepLinkPostId(intent)
-                    if (postId != null) {
-                        nextIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
-                    }
-                }
+    private suspend fun routeToNextActivity() {
+        val launchMode = attemptDirectDashboardLaunch()
+        val nextIntent = when (launchMode) {
+            DashboardLaunchMode.ONLINE -> Intent(this@SplashScreen, DashboardActivity::class.java)
+            DashboardLaunchMode.OFFLINE -> Intent(this@SplashScreen, DashboardActivity::class.java).apply {
+                putExtra(DashboardActivity.EXTRA_OFFLINE_MODE, true)
             }
-
-            startActivity(nextIntent)
-            finish()
+            DashboardLaunchMode.NONE -> Intent(this@SplashScreen, MyPlanetLite::class.java).apply {
+                putExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, true)
+            }
         }
+
+        if (intent.action == Intent.ACTION_VIEW && intent.data != null) {
+            if (launchMode == DashboardLaunchMode.NONE) {
+                nextIntent.action = intent.action
+                nextIntent.data = intent.data
+            } else {
+                val postId = IntentUtils.extractDeepLinkPostId(intent)
+                if (postId != null) {
+                    nextIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
+                }
+            }
+        }
+
+        startActivity(nextIntent)
+        finish()
     }
 
     private suspend fun attemptDirectDashboardLaunch(): DashboardLaunchMode {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the complexity and length of the `onCreate` method in `SplashScreen.kt`. It contained both the logo animation logic and intent routing logic directly within its body.
💡 **Why:** Extracting the animation and intent routing logic into private helper methods (`startLogoAnimation` and `routeToNextActivity`) improves the maintainability and readability of the codebase by following the single responsibility principle and making the `onCreate` method much shorter and easier to understand.
✅ **Verification:** I confirmed the change is safe by using `sed` to verify that the edits were correct, running `./gradlew compileDebugKotlin` to ensure there are no compilation errors, and running `./gradlew testDebugUnitTest` to guarantee there are no test regressions. Furthermore, the code review system assessed the change as correct and safe.
✨ **Result:** The `onCreate` method is now clean and concise, executing its setup operations and immediately calling two expressive helper functions (`startLogoAnimation()` and `routeToNextActivity()`), significantly enhancing readability.

---
*PR created automatically by Jules for task [12355229823141556824](https://jules.google.com/task/12355229823141556824) started by @dogi*