### PR TITLE
🧹 Refactor SurveyWizardFragment onViewCreated to reduce complexity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 220
+        versionName = "0.2.20"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
@@ -141,35 +141,8 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        titleView = view.findViewById(R.id.surveyWizardTitle)
-        descriptionView = view.findViewById(R.id.surveyWizardDescription)
-        counterView = view.findViewById(R.id.surveyWizardCounter)
-        progressBar = view.findViewById(R.id.surveyWizardProgress)
-        translationOverlay = view.findViewById(R.id.surveyWizardTranslationOverlay)
-        translationProgressBar = view.findViewById(R.id.surveyWizardTranslationProgress)
-        translationNoticeView = view.findViewById(R.id.surveyWizardTranslationNotice)
-        questionBodyView = view.findViewById(R.id.surveyWizardQuestionBody)
-        questionContainer = view.findViewById(R.id.surveyWizardQuestionContainer)
-        previousButton = view.findViewById(R.id.surveyWizardPreviousButton)
-        nextButton = view.findViewById(R.id.surveyWizardNextButton)
-        val contentView: View = view.findViewById(R.id.surveyWizardContent)
-        val initialPaddingStart = contentView.paddingStart
-        val initialPaddingTop = contentView.paddingTop
-        val initialPaddingEnd = contentView.paddingEnd
-        val initialPaddingBottom = contentView.paddingBottom
-
-        ViewCompat.setOnApplyWindowInsetsListener(contentView) { content, insets ->
-            val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
-            val bottomInset = maxOf(systemInsets.bottom, imeInsets.bottom)
-            content.setPadding(
-                initialPaddingStart,
-                initialPaddingTop,
-                initialPaddingEnd,
-                initialPaddingBottom + bottomInset
-            )
-            insets
-        }
+        bindViews(view)
+        setupInsets(view)
 
         translationNoticeView.setOnClickListener {
             startActivity(Intent(requireContext(), PrivacyPolicyActivity::class.java))
@@ -197,6 +170,10 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
 
         showStep(currentIndex)
 
+        setupNavigationButtons()
+    }
+
+    private fun setupNavigationButtons() {
         previousButton.setOnClickListener {
             activeCollector?.invoke()
             if (currentIndex > 0) {
@@ -216,6 +193,41 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
                 }
             }
         }
+    }
+
+    private fun setupInsets(view: View) {
+        val contentView: View = view.findViewById(R.id.surveyWizardContent)
+        val initialPaddingStart = contentView.paddingStart
+        val initialPaddingTop = contentView.paddingTop
+        val initialPaddingEnd = contentView.paddingEnd
+        val initialPaddingBottom = contentView.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(contentView) { content, insets ->
+            val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val bottomInset = maxOf(systemInsets.bottom, imeInsets.bottom)
+            content.setPadding(
+                initialPaddingStart,
+                initialPaddingTop,
+                initialPaddingEnd,
+                initialPaddingBottom + bottomInset
+            )
+            insets
+        }
+    }
+
+    private fun bindViews(view: View) {
+        titleView = view.findViewById(R.id.surveyWizardTitle)
+        descriptionView = view.findViewById(R.id.surveyWizardDescription)
+        counterView = view.findViewById(R.id.surveyWizardCounter)
+        progressBar = view.findViewById(R.id.surveyWizardProgress)
+        translationOverlay = view.findViewById(R.id.surveyWizardTranslationOverlay)
+        translationProgressBar = view.findViewById(R.id.surveyWizardTranslationProgress)
+        translationNoticeView = view.findViewById(R.id.surveyWizardTranslationNotice)
+        questionBodyView = view.findViewById(R.id.surveyWizardQuestionBody)
+        questionContainer = view.findViewById(R.id.surveyWizardQuestionContainer)
+        previousButton = view.findViewById(R.id.surveyWizardPreviousButton)
+        nextButton = view.findViewById(R.id.surveyWizardNextButton)
     }
 
     override fun onStart() {


### PR DESCRIPTION
🎯 **What:** Extracted the view binding, inset handling, and navigation button setup from `onViewCreated` in `SurveyWizardFragment.kt` into three distinct helper functions (`bindViews`, `setupInsets`, and `setupNavigationButtons`).

💡 **Why:** This drastically reduces the complexity of `onViewCreated`, making the core lifecycle method much easier to read and maintain. The functionality remains functionally identical but logically segmented.

✅ **Verification:** Verified by compiling the codebase (`./gradlew compileDebugKotlin`) and successfully running the full test suite (`./gradlew testDebugUnitTest`), confirming no regressions were introduced. Also passed code review validation.

✨ **Result:** Improved maintainability and readability of `SurveyWizardFragment.kt` with a cleaner separation of concerns inside `onViewCreated`.

---
*PR created automatically by Jules for task [2820614552194119073](https://jules.google.com/task/2820614552194119073) started by @dogi*