### PR TITLE
🧹 Remove redundant instance variable in SecurePreferencesProvider

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 222
+        versionName = "0.2.22"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
@@ -21,17 +21,13 @@ object SecurePreferencesProvider {
     private const val ENCRYPTED_PREFS_NAME = "encrypted_server_preferences"
     private const val LEGACY_PREFS_NAME = "server_preferences"
 
-    @Suppress("unused")
-    @Volatile
-    private var instance: SharedPreferences? = null
-
     private val cachedInstances = mutableMapOf<String, SharedPreferences>()
 
     fun getServerPreferences(context: Context): SharedPreferences {
         injectedPreferences?.let { return it }
 
         return synchronized(this) {
-            instance ?: run {
+            cachedInstances[ENCRYPTED_PREFS_NAME] ?: run {
                 val encryptedPrefs = getEncryptedPreferences(
                     context = context,
                     prefsName = ENCRYPTED_PREFS_NAME
@@ -45,7 +41,6 @@ object SecurePreferencesProvider {
                     encryptedPrefs
                 }
                 created.also {
-                    instance = it
                     cachedInstances[ENCRYPTED_PREFS_NAME] = it
                 }
             }
@@ -141,7 +136,6 @@ object SecurePreferencesProvider {
     fun resetForTesting() {
         synchronized(this) {
             injectedPreferences = null
-            instance = null
             cachedInstances.clear()
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -50,7 +50,7 @@ class SecurePreferencesProviderTest {
     }
 
     @Test
-    fun `getServerPreferences returns instance when already created`() {
+    fun `getServerPreferences returns cached instance when already created`() {
         SecurePreferencesProvider.injectedPreferences = mockPrefs
 
         val result = SecurePreferencesProvider.getServerPreferences(mockContext)
@@ -58,7 +58,7 @@ class SecurePreferencesProviderTest {
     }
 
     @Test
-    fun `getServerPreferences creates EncryptedSharedPreferences when instance is null`() {
+    fun `getServerPreferences creates EncryptedSharedPreferences when not cached`() {
         val legacyPrefs = mock(SharedPreferences::class.java)
         `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE)).thenReturn(legacyPrefs)
         `when`(legacyPrefs.all).thenReturn(emptyMap<String, Any?>())


### PR DESCRIPTION
🎯 **What:** Removed the redundant `@Volatile private var instance` variable from `SecurePreferencesProvider.kt` and updated the logic to use the existing `cachedInstances` map.
💡 **Why:** The `instance` variable was serving as a secondary cache for the same object already stored in `cachedInstances`, making it redundant. Removing it improves maintainability and simplifies the object's state.
✅ **Verification:**
- Verified code changes by reading the modified files.
- Confirmed thread-safety is preserved by using the same `synchronized(this)` block for map access.
- Updated `SecurePreferencesProviderTest.kt` to match the new naming conventions.
- Attempted to run unit tests and compilation; although they timed out in the environment, the logic was thoroughly manually reviewed and confirmed in code review.
✨ **Result:** A cleaner, more maintainable `SecurePreferencesProvider` with a single source of truth for cached preference instances.

---
*PR created automatically by Jules for task [13269567342371387948](https://jules.google.com/task/13269567342371387948) started by @dogi*