### PR TITLE
🧹 Refactor onViewCreated in DashboardVoicesFragment to reduce complexity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 224
+        versionName = "0.2.24"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -125,6 +125,12 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupViews(view)
+        setupRecyclerView()
+        setupObserversAndLoadInitial()
+    }
+
+    private fun setupViews(view: View) {
         recyclerView = view.findViewById(R.id.postsRecyclerView)
         loadingView = view.findViewById(R.id.postsLoading)
         emptyView = view.findViewById(R.id.postsEmptyView)
@@ -134,7 +140,9 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
             openCreateVoiceComposer()
         }
         fab.enableDrag()
+    }
 
+    private fun setupRecyclerView() {
         markwon = Markwon.builder(requireContext()).build()
         adapter = DashboardNewsAdapter(
             markwon,
@@ -189,7 +197,9 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
                 }
             }
         })
+    }
 
+    private fun setupObserversAndLoadInitial() {
         viewLifecycleOwner.lifecycleScope.launch {
             initializeSession()
             val profile = loadCurrentUserProfile()


### PR DESCRIPTION
🎯 **What:** Extracted view initialization, adapter configuration, and lifecycle observation in `DashboardVoicesFragment.onViewCreated` into separate, smaller methods (`setupViews`, `setupRecyclerView`, and `setupObserversAndLoadInitial`).
💡 **Why:** Reduces complexity of a large `onViewCreated` block, improving code readability and making future modifications much easier.
✅ **Verification:** Ensured project successfully compiled (`./gradlew compileDebugKotlin`) and ran full unit test suite without regression (`./gradlew testDebugUnitTest`).
✨ **Result:** A more maintainable and readable `DashboardVoicesFragment`.

---
*PR created automatically by Jules for task [9793257090932762962](https://jules.google.com/task/9793257090932762962) started by @dogi*