### PR TITLE
🧪 [testing improvement] Add unit tests for FullscreenPdfActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 225
+        versionName = "0.2.25"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/FullscreenPdfActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/FullscreenPdfActivityTest.kt
@@ -1,0 +1,36 @@
+package org.ole.planet.myplanet.lite
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FullscreenPdfActivityTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `activity finishes when launched without EXTRA_PDF_URL`() {
+        val controller = Robolectric.buildActivity(FullscreenPdfActivity::class.java)
+        val activity = controller.create().get()
+
+        assertTrue(activity.isFinishing)
+    }
+
+    @Test
+    fun `createIntent returns correct intent with extras`() {
+        val pdfUrl = "https://example.com/file.pdf"
+        val authHeader = "Basic dXNlcjpwYXNz"
+
+        val intent = FullscreenPdfActivity.createIntent(context, pdfUrl, authHeader)
+
+        assertEquals(FullscreenPdfActivity::class.java.name, intent.component?.className)
+        assertEquals(pdfUrl, intent.getStringExtra("extra_pdf_url"))
+        assertEquals(authHeader, intent.getStringExtra("extra_auth_header"))
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `FullscreenPdfActivity` intent handling.
📊 **Coverage:** The new tests cover the `createIntent` factory method (ensuring the correct class and intent extras are bundled) and the error/edge case where the activity is launched without the required `EXTRA_PDF_URL` (expecting the activity to finish).
✨ **Result:** Improved test coverage for `FullscreenPdfActivity` initialization and safe intent handling, reducing the risk of regressions.

---
*PR created automatically by Jules for task [9315413707408570097](https://jules.google.com/task/9315413707408570097) started by @dogi*