### PR TITLE
🧹 [code health improvement] Refactor submitProfileUpdates to reduce complexity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 227
+        versionName = "0.2.27"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -434,12 +434,19 @@ class ProfileActivity : BaseActivity() {
         return userProfileSync.refreshProfile(normalizedBase, username.orEmpty(), sessionCookie)
     }
 
-    private suspend fun submitProfileUpdates(formValues: ProfileFormValues): Boolean {
+    private data class ProfileUpdateContext(
+        val storedProfile: UserProfile?,
+        val normalizedBase: String,
+        val username: String,
+        val sessionCookie: String
+    )
+
+    private suspend fun resolveProfileUpdateContext(): ProfileUpdateContext? {
         val storedProfile = withContext(Dispatchers.IO) { userProfileDatabase.getProfile() }
         val storedBaseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
         val sanitizedBase = (storedBaseUrl ?: BuildConfig.PLANET_BASE_URL).trim()
         if (sanitizedBase.isEmpty()) {
-            return false
+            return null
         }
         val normalizedBase = sanitizedBase.trimEnd('/')
         var username = storedProfile?.username
@@ -448,7 +455,7 @@ class ProfileActivity : BaseActivity() {
             username = storedCredentials?.username
         }
         if (username.isNullOrBlank()) {
-            return false
+            return null
         }
 
         val authService = AuthDependencies.provideAuthService(this, sanitizedBase)
@@ -461,26 +468,26 @@ class ProfileActivity : BaseActivity() {
 
                 is AuthResult.Error, is AuthResult.Failure -> {
                     if (sessionCookie.isNullOrBlank()) {
-                        return false
+                        return null
                     }
                 }
             }
         }
 
-        val nonNullCookie = sessionCookie.nullIfBlank() ?: return false
-        val avatarUploadBytes = pendingAvatarUpload
-        val document = buildUpdatedProfileDocument(
-            normalizedBase,
-            username,
-            nonNullCookie,
-            formValues,
-            storedProfile,
-            avatarUploadBytes
-        ) ?: return false
+        val nonNullCookie = sessionCookie.nullIfBlank() ?: return null
 
-        val avatarBytesToPersist = avatarUploadBytes ?: storedProfile?.avatarImage
+        return ProfileUpdateContext(storedProfile, normalizedBase, username, nonNullCookie)
+    }
 
-        val success = withContext(Dispatchers.IO) {
+    private suspend fun executeProfileUpdateRequest(
+        normalizedBase: String,
+        username: String,
+        nonNullCookie: String,
+        document: JSONObject,
+        avatarUploadBytes: ByteArray?,
+        avatarBytesToPersist: ByteArray?
+    ): Boolean {
+        return withContext(Dispatchers.IO) {
             try {
                 val requestBody = document.toString()
                     .toRequestBody("application/json; charset=utf-8".toMediaType())
@@ -510,10 +517,34 @@ class ProfileActivity : BaseActivity() {
                 false
             }
         }
+    }
+
+    private suspend fun submitProfileUpdates(formValues: ProfileFormValues): Boolean {
+        val context = resolveProfileUpdateContext() ?: return false
+        val avatarUploadBytes = pendingAvatarUpload
+        val document = buildUpdatedProfileDocument(
+            context.normalizedBase,
+            context.username,
+            context.sessionCookie,
+            formValues,
+            context.storedProfile,
+            avatarUploadBytes
+        ) ?: return false
+
+        val avatarBytesToPersist = avatarUploadBytes ?: context.storedProfile?.avatarImage
+
+        val success = executeProfileUpdateRequest(
+            context.normalizedBase,
+            context.username,
+            context.sessionCookie,
+            document,
+            avatarUploadBytes,
+            avatarBytesToPersist
+        )
 
         if (success && avatarUploadBytes != null) {
             pendingAvatarUpload = null
-            AvatarUpdateNotifier.notifyAvatarUpdated(username)
+            AvatarUpdateNotifier.notifyAvatarUpdated(context.username)
         }
 
         return success


### PR DESCRIPTION
🎯 **What:** Refactored the `submitProfileUpdates` method in `ProfileActivity.kt` to extract the context resolution logic and network execution block into separate private functions (`resolveProfileUpdateContext` and `executeProfileUpdateRequest`).

💡 **Why:** The `submitProfileUpdates` function had grown too complex by handling multiple responsibilities (fetching stored profile, resolving credentials, authenticating, building the document, executing the network request, and saving the results). Extracting these responsibilities improves code maintainability and readability by separating concerns.

✅ **Verification:** Verified by running `./gradlew compileDebugKotlin` and executing the full test suite via `./gradlew testDebugUnitTest`. All tests passed, confirming the refactoring introduces no functional regressions or syntax errors.

✨ **Result:** A more modular and easier-to-read profile submission flow.

---
*PR created automatically by Jules for task [4133602480982467885](https://jules.google.com/task/4133602480982467885) started by @dogi*