### PR TITLE
🧪 [testing improvement] Add missing tests for CourseWizardActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 215
-        versionName = "0.2.15"
+        versionCode = 229
+        versionName = "0.2.29"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/CourseWizardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/CourseWizardActivityTest.kt
@@ -1,0 +1,100 @@
+package org.ole.planet.myplanet.lite
+
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.mockkConstructor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.ole.planet.myplanet.lite.DashboardCoursePageFragment.CourseItem
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CourseWizardActivityTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        mockkConstructor(MasterKey.Builder::class)
+        every { anyConstructed<MasterKey.Builder>().setKeyScheme(any()) } answers { callOriginal() }
+        every { anyConstructed<MasterKey.Builder>().build() } returns mockk()
+
+        mockkStatic(EncryptedSharedPreferences::class)
+        val mockPrefs = mockk<SharedPreferences>(relaxed = true)
+        every {
+            EncryptedSharedPreferences.create(
+                any<Context>(),
+                any<String>(),
+                any<MasterKey>(),
+                any<EncryptedSharedPreferences.PrefKeyEncryptionScheme>(),
+                any<EncryptedSharedPreferences.PrefValueEncryptionScheme>()
+            )
+        } returns mockPrefs
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `activity finishes when launched without steps`() = runTest(testDispatcher) {
+        val controller = Robolectric.buildActivity(CourseWizardActivity::class.java)
+        val activity = controller.create().get()
+
+        assertTrue(activity.isFinishing)
+    }
+
+    @Test
+    fun `activity doesn't finish when launched with steps`() = runTest(testDispatcher) {
+        val courseId = "course1"
+        val courseTitle = "Test Course"
+        val startStep = 0
+        val steps = listOf(
+            CourseItem.LessonStep(
+                title = "Step 1",
+                description = "Desc 1",
+                mediaTypes = emptyList(),
+                resources = emptyList(),
+                exam = null,
+                survey = null
+            )
+        )
+
+        val intent = Intent(context, CourseWizardActivity::class.java).apply {
+            putExtra("extra_course_id", courseId)
+            putExtra("extra_title", courseTitle)
+            putExtra("extra_steps", ArrayList(steps))
+            putExtra("extra_start_step", startStep)
+        }
+
+        val controller = Robolectric.buildActivity(CourseWizardActivity::class.java, intent)
+        val activity = controller.create().get()
+
+        assertFalse(activity.isFinishing)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for `CourseWizardActivity`. Specifically, there were no existing unit tests validating the initial behavior of the activity when launched with or without intent steps.

📊 **Coverage:** What scenarios are now tested
*   **Missing Steps Scenario:** Added a test to verify that the activity safely finishes (`isFinishing == true`) when no course steps are provided in the intent, preventing a crash or blank screen.
*   **Valid Steps Scenario:** Added a test to ensure the activity initializes properly and stays alive (`isFinishing == false`) when valid steps are provided in the launch intent.
*   **Android KeyStore Dependencies:** Tests successfully mock `EncryptedSharedPreferences` and `MasterKey` initialization behavior since these classes crash under standard Robolectric context without proper stubs.

✨ **Result:** The improvement in test coverage
`CourseWizardActivity` now has functional UI test scaffolding using `Robolectric`. This improves confidence when modifying intent handling or the lifecycle state inside the activity, ensuring early exits function correctly.

---
*PR created automatically by Jules for task [1487199099472348963](https://jules.google.com/task/1487199099472348963) started by @dogi*