### PR TITLE
Refactor EncryptedSharedPreferences and fix deprecation warnings in tests

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -1,4 +1,3 @@
-@file:Suppress("DEPRECATION")
 /**
  * Author: Walfre López Prado
  * Email: loppra@plataformasinformaticas.com
@@ -30,8 +29,6 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.PlayerView
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import io.noties.markwon.Markwon
 import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.html.HtmlPlugin
@@ -51,46 +48,16 @@ import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository
 import org.ole.planet.myplanet.lite.util.MarkdownUtils
 import org.ole.planet.myplanet.lite.util.NetworkUtils
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class CourseWizardActivity : BaseActivity() {
     private val pendingProgressPrefs by lazy {
-        val masterKey = MasterKey.Builder(applicationContext)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        val encryptedPrefs = EncryptedSharedPreferences.create(
-            applicationContext,
-            PREF_ENCRYPTED_PENDING_COURSE_PROGRESS,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        SecurePreferencesProvider.getEncryptedPreferences(
+            context = applicationContext,
+            prefsName = PREF_ENCRYPTED_PENDING_COURSE_PROGRESS,
+            legacyPrefsName = PREF_LEGACY_PENDING_COURSE_PROGRESS
         )
-        val legacyFile = java.io.File(applicationContext.applicationInfo.dataDir, "shared_prefs/$PREF_LEGACY_PENDING_COURSE_PROGRESS.xml")
-        if (legacyFile.exists()) {
-            val legacyPrefs = getSharedPreferences(PREF_LEGACY_PENDING_COURSE_PROGRESS, MODE_PRIVATE)
-            val allLegacy = legacyPrefs.all
-            if (allLegacy.isNotEmpty()) {
-                encryptedPrefs.edit {
-                    for ((key, value) in allLegacy) {
-                        when (value) {
-                            is String -> putString(key, value)
-                            is Int -> putInt(key, value)
-                            is Boolean -> putBoolean(key, value)
-                            is Float -> putFloat(key, value)
-                            is Long -> putLong(key, value)
-                            is Set<*> -> @Suppress("UNCHECKED_CAST") putStringSet(
-                                key,
-                                value as Set<String>
-                            )
-                        }
-                    }
-                }
-            }
-            legacyPrefs.edit().clear().apply()
-            applicationContext.deleteSharedPreferences(PREF_LEGACY_PENDING_COURSE_PROGRESS)
-            legacyFile.delete()
-        }
-        encryptedPrefs
     }
 
     private lateinit var markwon: Markwon

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
@@ -24,36 +24,22 @@ object SecurePreferencesProvider {
     private val cachedInstances = mutableMapOf<String, SharedPreferences>()
 
     fun getServerPreferences(context: Context): SharedPreferences {
-        injectedPreferences?.let { return it }
-
-        return synchronized(this) {
-            cachedInstances[ENCRYPTED_PREFS_NAME] ?: run {
-                val encryptedPrefs = getEncryptedPreferences(
-                    context = context,
-                    prefsName = ENCRYPTED_PREFS_NAME
-                )
-                val legacyFile = java.io.File(context.applicationInfo.dataDir, "shared_prefs/$LEGACY_PREFS_NAME.xml")
-                val created = if (legacyFile.exists()) {
-                    val legacyPrefs = context.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE)
-                    val job = migrateLegacyPreferences(context, encryptedPrefs, legacyPrefs)
-                    MigrationAwarePreferences(encryptedPrefs, legacyPrefs, job)
-                } else {
-                    encryptedPrefs
-                }
-                created.also {
-                    cachedInstances[ENCRYPTED_PREFS_NAME] = it
-                }
-            }
-        }
+        return getEncryptedPreferences(
+            context = context,
+            prefsName = ENCRYPTED_PREFS_NAME,
+            legacyPrefsName = LEGACY_PREFS_NAME
+        )
     }
 
     fun getEncryptedPreferences(
         context: Context,
-        prefsName: String
+        prefsName: String,
+        legacyPrefsName: String? = null
     ): SharedPreferences {
         return getEncryptedPreferences(
             context = context,
             prefsName = prefsName,
+            legacyPrefsName = legacyPrefsName,
             onCreated = { _, _ -> }
         )
     }
@@ -61,17 +47,33 @@ object SecurePreferencesProvider {
     private fun getEncryptedPreferences(
         context: Context,
         prefsName: String,
+        legacyPrefsName: String? = null,
         onCreated: (Context, SharedPreferences) -> Unit
     ): SharedPreferences {
         injectedPreferences?.let { return it }
         val appContext = context.applicationContext
 
         return synchronized(this) {
-            cachedInstances[prefsName] ?: createEncryptedPreferences(
-                appContext = appContext,
-                prefsName = prefsName,
-                onCreated = onCreated
-            ).also { cachedInstances[prefsName] = it }
+            cachedInstances[prefsName] ?: run {
+                val encryptedPrefs = createEncryptedPreferences(
+                    appContext = appContext,
+                    prefsName = prefsName,
+                    onCreated = onCreated
+                )
+                val created = if (legacyPrefsName != null) {
+                    val legacyFile = java.io.File(appContext.applicationInfo.dataDir, "shared_prefs/$legacyPrefsName.xml")
+                    if (legacyFile.exists()) {
+                        val legacyPrefs = appContext.getSharedPreferences(legacyPrefsName, Context.MODE_PRIVATE)
+                        val job = migrateLegacyPreferences(appContext, encryptedPrefs, legacyPrefs, legacyPrefsName)
+                        MigrationAwarePreferences(encryptedPrefs, legacyPrefs, job)
+                    } else {
+                        encryptedPrefs
+                    }
+                } else {
+                    encryptedPrefs
+                }
+                created.also { cachedInstances[prefsName] = it }
+            }
         }
     }
 
@@ -143,7 +145,8 @@ object SecurePreferencesProvider {
     private fun migrateLegacyPreferences(
         context: Context,
         encryptedPrefs: SharedPreferences,
-        legacyPrefs: SharedPreferences
+        legacyPrefs: SharedPreferences,
+        legacyPrefsName: String
     ): Job {
         return migrationScope.launch {
             val allLegacy = legacyPrefs.all
@@ -161,10 +164,10 @@ object SecurePreferencesProvider {
                     }
                 }
                 if (editor.commit()) {
-                    context.deleteSharedPreferences(LEGACY_PREFS_NAME)
+                    context.deleteSharedPreferences(legacyPrefsName)
                 }
             } else {
-                context.deleteSharedPreferences(LEGACY_PREFS_NAME)
+                context.deleteSharedPreferences(legacyPrefsName)
             }
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/CourseWizardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/CourseWizardActivityTest.kt
@@ -3,14 +3,10 @@ package org.ole.planet.myplanet.lite
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import io.mockk.mockkConstructor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -24,6 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.DashboardCoursePageFragment.CourseItem
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -37,27 +34,14 @@ class CourseWizardActivityTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-
-        mockkConstructor(MasterKey.Builder::class)
-        every { anyConstructed<MasterKey.Builder>().setKeyScheme(any()) } answers { callOriginal() }
-        every { anyConstructed<MasterKey.Builder>().build() } returns mockk()
-
-        mockkStatic(EncryptedSharedPreferences::class)
         val mockPrefs = mockk<SharedPreferences>(relaxed = true)
-        every {
-            EncryptedSharedPreferences.create(
-                any<Context>(),
-                any<String>(),
-                any<MasterKey>(),
-                any<EncryptedSharedPreferences.PrefKeyEncryptionScheme>(),
-                any<EncryptedSharedPreferences.PrefValueEncryptionScheme>()
-            )
-        } returns mockPrefs
+        SecurePreferencesProvider.injectedPreferences = mockPrefs
     }
 
     @After
     fun teardown() {
         Dispatchers.resetMain()
+        SecurePreferencesProvider.resetForTesting()
         unmockkAll()
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/FullscreenPlayerActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/FullscreenPlayerActivityTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.lite
 
 import android.content.Context
+import android.os.Build
 import android.widget.ImageButton
 import androidx.lifecycle.Lifecycle
 import androidx.media3.ui.PlayerView
@@ -12,8 +13,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
 class FullscreenPlayerActivityTest {
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -117,10 +117,11 @@ class SecurePreferencesProviderTest {
                 "migrateLegacyPreferences",
                 Context::class.java,
                 SharedPreferences::class.java,
-                SharedPreferences::class.java
+                SharedPreferences::class.java,
+                String::class.java
             )
             method.isAccessible = true
-            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
+            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs, "server_preferences") as Job
             job.join()
 
             verify(mockEncryptedEditor).putString("string_key", "value")
@@ -150,10 +151,11 @@ class SecurePreferencesProviderTest {
                 "migrateLegacyPreferences",
                 Context::class.java,
                 SharedPreferences::class.java,
-                SharedPreferences::class.java
+                SharedPreferences::class.java,
+                String::class.java
             )
             method.isAccessible = true
-            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs) as Job
+            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs, "server_preferences") as Job
             job.join()
 
             verify(mockEncryptedPrefs, never()).edit()


### PR DESCRIPTION
Refactored CourseWizardActivity and its corresponding unit tests to eliminate deprecation warnings associated with `EncryptedSharedPreferences` and `MasterKey`. 

Key changes:
- **`SecurePreferencesProvider` Enhancement**: Added support for generic migration from legacy unencrypted SharedPreferences files.
- **`CourseWizardActivity` Refactoring**: Replaced manual, deprecated initialization of encrypted preferences with a call to the centralized provider.
- **Test Modernization**: Updated `CourseWizardActivityTest` to use the `injectedPreferences` feature for mocking, removing the need for fragile static mocks of deprecated security APIs.
- **Warning Cleanup**: Removed deprecated imports and unnecessary `@Suppress("DEPRECATION")` annotations where the code was modernized.

---
*PR created automatically by Jules for task [13783874539293525264](https://jules.google.com/task/13783874539293525264) started by @PlataformasInformaticas*