### PR TITLE
Align AndroidX Test and Espresso versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,7 +112,6 @@ dependencies {
 
     // testImplementation
     // testing
-    testImplementation(libs.androidx.core)
     testImplementation(libs.androidx.junit)
     testImplementation(libs.androidx.test.core)
     debugImplementation(libs.androidx.fragment.testing)
@@ -136,4 +135,19 @@ dependencies {
     androidTestImplementation(libs.core.ktx)
     androidTestImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.mockwebserver)
+
+    // Force consistent versions
+    configurations.all {
+        resolutionStrategy {
+            force(
+                libs.androidx.test.core,
+                libs.androidx.test.monitor,
+                libs.androidx.test.runner,
+                libs.androidx.espresso.core,
+                libs.androidx.espresso.intents,
+                libs.androidx.junit,
+                libs.core.ktx
+            )
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,20 @@
 [versions]
 activity = "1.13.0"
 agp = "9.2.0"
+androidxTest = "1.6.1"
+androidxTestMonitor = "1.7.1"
 appcompat = "1.7.1"
 bytebuddy = "1.18.8"
 circleimageview = "3.1.0"
 constraintlayout = "2.2.1"
 core = "4.6.2"
 coreKtx = "1.18.0"
-coreKtxVersion = "1.7.0"
-espressoCore = "3.7.0"
+espressoCore = "3.6.1"
 fragmentKtx = "1.8.9"
 glide = "5.0.7"
 json = "20251224"
 junit = "4.13.2"
-junitVersion = "1.3.0"
+junitVersion = "1.2.1"
 kotlin = "2.3.20"
 kotlinxCoroutinesTest = "1.10.2"
 languageId = "17.0.6"
@@ -38,28 +39,27 @@ worldcountrydata = "1.5.3"
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
-androidx-core = { module = "androidx.test:core", version.ref = "coreKtxVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espressoCore" }
+androidx-espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "espressoCore" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
-androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "fragmentKtx" }
+androidx-fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "fragmentKtx" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Exoplayer" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
-androidx-test-core = { group = "androidx.test", name = "core", version.ref = "coreKtxVersion" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTest" }
+androidx-test-monitor = { group = "androidx.test", name = "monitor", version.ref = "androidxTestMonitor" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }
 byte-buddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "bytebuddy" }
 byte-buddy-agent = { group = "net.bytebuddy", name = "byte-buddy-agent", version.ref = "bytebuddy" }
 circleimageview = { module = "de.hdodenhof:circleimageview", version.ref = "circleimageview" }
 converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
 core = { module = "io.noties.markwon:core", version.ref = "core" }
-core-ktx = { module = "androidx.test:core-ktx", version.ref = "coreKtxVersion" }
+core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "androidxTest" }
 ext-tables = { module = "io.noties.markwon:ext-tables", version.ref = "core" }
-markwon-html = { module = "io.noties.markwon:html", version.ref = "core" }
-markwon-image-glide = { module = "io.noties.markwon:image-glide", version.ref = "core" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 json = { group = "org.json", name = "json", version.ref = "json" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -67,6 +67,8 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 language-id = { module = "com.google.mlkit:language-id", version.ref = "languageId" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "mockwebserver" }
+markwon-html = { module = "io.noties.markwon:html", version.ref = "core" }
+markwon-image-glide = { module = "io.noties.markwon:image-glide", version.ref = "core" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }


### PR DESCRIPTION
Align AndroidX Test (1.6.1) and Espresso (3.6.1) versions to resolve java.lang.NoSuchMethodError. Explicitly force these versions in app/build.gradle.kts to override incompatible constraints from AGP 9.2.0 and fragment-testing.

---
*PR created automatically by Jules for task [10680838456867738133](https://jules.google.com/task/10680838456867738133) started by @PlataformasInformaticas*