### PR TITLE
Fix Surface.release resource leak in Robolectric tests

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStore.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.util.getStringOrNull
 
-class DashboardOfflineSurveyStore(
+class DashboardOfflineSurveyStore private constructor(
     context: Context,
     moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
 ) : SQLiteOpenHelper(context.applicationContext, DATABASE_NAME, null, DATABASE_VERSION) {
@@ -129,7 +129,7 @@ class DashboardOfflineSurveyStore(
         }
     }
 
-    private companion object {
+    companion object {
         private const val DATABASE_NAME = "dashboard_offline_surveys.db"
         private const val DATABASE_VERSION = 1
         private const val TABLE_SURVEYS = "surveys"
@@ -137,5 +137,20 @@ class DashboardOfflineSurveyStore(
         private const val COLUMN_REV = "rev"
         private const val COLUMN_TEAM_ID = "team_id"
         private const val COLUMN_DOCUMENT = "document"
+
+        @Volatile
+        private var instance: DashboardOfflineSurveyStore? = null
+
+        fun getInstance(context: Context): DashboardOfflineSurveyStore {
+            return instance ?: synchronized(this) {
+                instance ?: DashboardOfflineSurveyStore(context.applicationContext).also { instance = it }
+            }
+        }
+
+        fun resetForTesting(context: Context) {
+            instance?.close()
+            instance = null
+            context.deleteDatabase(DATABASE_NAME)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
@@ -48,7 +48,7 @@ class DashboardOutboxDetailActivity : BaseActivity() {
     private lateinit var sendButton: MaterialButton
     private lateinit var deleteButton: MaterialButton
     private lateinit var emptyView: TextView
-    private val outboxStore by lazy { DashboardSurveyOutboxStore(applicationContext) }
+    private val outboxStore by lazy { DashboardSurveyOutboxStore.getInstance(applicationContext) }
 
     private val httpClient by lazy { OkHttpClient.Builder().build() }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.util.getStringOrNull
 
-class DashboardSurveyOutboxStore(
+class DashboardSurveyOutboxStore private constructor(
     context: Context,
     moshi: Moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
 ) : SQLiteOpenHelper(context.applicationContext, DATABASE_NAME, null, DATABASE_VERSION) {
@@ -214,7 +214,7 @@ class DashboardSurveyOutboxStore(
         val payload: String,
     )
 
-    private companion object {
+    companion object {
         private const val DATABASE_NAME = "dashboard_survey_outbox.db"
         private const val DATABASE_VERSION = 1
         private const val TABLE_SUBMISSIONS = "outbox_submissions"
@@ -225,5 +225,20 @@ class DashboardSurveyOutboxStore(
         private const val COLUMN_SURVEY_NAME = "survey_name"
         private const val COLUMN_CREATED_AT = "created_at"
         private const val COLUMN_PAYLOAD = "payload"
+
+        @Volatile
+        private var instance: DashboardSurveyOutboxStore? = null
+
+        fun getInstance(context: Context): DashboardSurveyOutboxStore {
+            return instance ?: synchronized(this) {
+                instance ?: DashboardSurveyOutboxStore(context.applicationContext).also { instance = it }
+            }
+        }
+
+        fun resetForTesting(context: Context) {
+            instance?.close()
+            instance = null
+            context.deleteDatabase(DATABASE_NAME)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
@@ -18,11 +18,9 @@ import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
 import org.ole.planet.myplanet.lite.util.NetworkUtils
 
 class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
-    private val offlineStoreDelegate = lazy { DashboardOfflineSurveyStore(context.applicationContext) }
-    private val outboxStoreDelegate = lazy { DashboardSurveyOutboxStore(context.applicationContext) }
+    private val offlineStore get() = DashboardOfflineSurveyStore.getInstance(context)
+    private val outboxStore get() = DashboardSurveyOutboxStore.getInstance(context)
     private val submissionsRepoDelegate = lazy { DashboardSurveySubmissionsRepository() }
-    private val offlineStore get() = offlineStoreDelegate.value
-    private val outboxStore get() = outboxStoreDelegate.value
     private val submissionsRepo get() = submissionsRepoDelegate.value
 
     suspend fun getSavedSurveyIds(): Set<String> = offlineStore.getSavedSurveyIds()
@@ -78,11 +76,6 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
     }
 
     override fun close() {
-        if (offlineStoreDelegate.isInitialized()) {
-            offlineStore.close()
-        }
-        if (outboxStoreDelegate.isInitialized()) {
-            outboxStore.close()
-        }
+        // Managed by singletons
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationCache.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationCache.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.util.getStringOrNull
 
-class SurveyTranslationCache(
+class SurveyTranslationCache private constructor(
     context: Context,
     moshi: Moshi = Moshi.Builder().build(),
 ) : SQLiteOpenHelper(context.applicationContext, DATABASE_NAME, null, DATABASE_VERSION) {
@@ -105,7 +105,7 @@ class SurveyTranslationCache(
         }
     }
 
-    private companion object {
+    companion object {
         private const val DATABASE_NAME = "survey_translations.db"
         private const val DATABASE_VERSION = 1
         private const val TABLE_TRANSLATIONS = "survey_translations"
@@ -116,5 +116,20 @@ class SurveyTranslationCache(
         private const val COLUMN_BODY = "body"
         private const val COLUMN_CHOICES = "choices"
         private val TYPES_STRING_LIST = Types.newParameterizedType(List::class.java, String::class.javaObjectType)
+
+        @Volatile
+        private var instance: SurveyTranslationCache? = null
+
+        fun getInstance(context: Context): SurveyTranslationCache {
+            return instance ?: synchronized(this) {
+                instance ?: SurveyTranslationCache(context.applicationContext).also { instance = it }
+            }
+        }
+
+        fun resetForTesting(context: Context) {
+            instance?.close()
+            instance = null
+            context.deleteDatabase(DATABASE_NAME)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
@@ -38,7 +38,7 @@ class SurveyTranslationManager(
     private val languageIdentifier: com.google.mlkit.nl.languageid.LanguageIdentifier =
         LanguageIdentification.getClient(),
     private val translationClient: OpenAiTranslationClient = OpenAiTranslationClient(),
-    private val translationCache: SurveyTranslationCache = SurveyTranslationCache(appContext),
+    private val translationCache: SurveyTranslationCache = SurveyTranslationCache.getInstance(appContext),
 ) {
 
     suspend fun translateSurvey(

--- a/app/src/test/java/android/util/Log.java
+++ b/app/src/test/java/android/util/Log.java
@@ -14,12 +14,26 @@ public class Log {
     public static int d(String tag, String msg, Throwable tr) { return 0; }
     public static int i(String tag, String msg) { return 0; }
     public static int i(String tag, String msg, Throwable tr) { return 0; }
-    public static int w(String tag, String msg) { return 0; }
-    public static int w(String tag, String msg, Throwable tr) { return 0; }
+    public static int w(String tag, String msg) {
+        if (msg != null && (msg.contains("Invalid ID 0x00000000") || msg.contains("No actions in intent filter"))) {
+            return 0;
+        }
+        System.out.println("W/" + tag + ": " + msg);
+        return 0;
+    }
+    public static int w(String tag, String msg, Throwable tr) { return w(tag, msg); }
     public static int w(String tag, Throwable tr) { return 0; }
-    public static int e(String tag, String msg) { return 0; }
-    public static int e(String tag, String msg, Throwable tr) { return 0; }
-    public static int println(int priority, String tag, String msg) { return 0; }
-    public static boolean isLoggable(String tag, int level) { return false; }
+    public static int e(String tag, String msg) {
+        System.err.println("E/" + tag + ": " + msg);
+        return 0;
+    }
+    public static int e(String tag, String msg, Throwable tr) { return e(tag, msg); }
+    public static int println(int priority, String tag, String msg) {
+        if (priority >= WARN) {
+            return w(tag, msg);
+        }
+        return 0;
+    }
+    public static boolean isLoggable(String tag, int level) { return level >= INFO; }
     public static String getStackTraceString(Throwable tr) { return ""; }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardSurveysFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardSurveysFragmentTest.kt
@@ -13,6 +13,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.ole.planet.myplanet.lite.dashboard.DashboardOfflineSurveyStore
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferences
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferencesTest
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
@@ -37,6 +39,8 @@ class DashboardSurveysFragmentTest {
     @After
     fun tearDown() {
         SecurePreferencesProvider.injectedPreferences = null
+        DashboardSurveyOutboxStore.resetForTesting(context)
+        DashboardOfflineSurveyStore.resetForTesting(context)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardSurveysFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardSurveysFragmentTest.kt
@@ -41,47 +41,41 @@ class DashboardSurveysFragmentTest {
 
     @Test
     fun `when no team is selected, empty view is visible and content is hidden`() {
-        val scenario = launchFragmentInContainer<DashboardSurveysFragment>(
+        launchFragmentInContainer<DashboardSurveysFragment>(
             themeResId = R.style.Theme_MyPlanetLite
-        )
-
-        scenario.onFragment { fragment ->
-            val view = fragment.requireView()
-            val emptyView = view.findViewById<View>(R.id.dashboardSurveysEmptyView)
-            val contentContainer = view.findViewById<View>(R.id.dashboardSurveysContentContainer)
-
-            assertTrue(emptyView.visibility == View.VISIBLE)
-            assertTrue(contentContainer.visibility == View.GONE)
-
-            // Verify empty view text is correct
-            val emptyTextView = emptyView as android.widget.TextView
-            assertEquals(fragment.getString(R.string.dashboard_teams_select_team_hint), emptyTextView.text.toString())
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                val view = fragment.requireView()
+                val emptyView = view.findViewById<View>(R.id.dashboardSurveysEmptyView)
+                val contentContainer = view.findViewById<View>(R.id.dashboardSurveysContentContainer)
+                assertTrue(emptyView.visibility == View.VISIBLE)
+                assertTrue(contentContainer.visibility == View.GONE)
+                // Verify empty view text is correct
+                val emptyTextView = emptyView as android.widget.TextView
+                assertEquals(fragment.getString(R.string.dashboard_teams_select_team_hint), emptyTextView.text.toString())
+            }
         }
     }
 
     @Test
     fun `when team is selected, empty view is hidden and team surveys fragment is loaded`() {
         DashboardTeamSelectionPreferences.setSelectedTeam(context, "team-123", "Team Alpha")
-
-        val scenario = launchFragmentInContainer<DashboardSurveysFragment>(
+        launchFragmentInContainer<DashboardSurveysFragment>(
             themeResId = R.style.Theme_MyPlanetLite
-        )
-
-        scenario.onFragment { fragment ->
-            val view = fragment.requireView()
-            val emptyView = view.findViewById<View>(R.id.dashboardSurveysEmptyView)
-            val contentContainer = view.findViewById<View>(R.id.dashboardSurveysContentContainer)
-
-            assertTrue(emptyView.visibility == View.GONE)
-            assertTrue(contentContainer.visibility == View.VISIBLE)
-
-            // Execute pending transactions
-            fragment.childFragmentManager.executePendingTransactions()
-
-            val teamFragment = fragment.childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)
-            assertNotNull(teamFragment)
-            assertTrue(teamFragment is DashboardTeamSurveysFragment)
-            assertTrue((teamFragment as DashboardTeamSurveysFragment).isSurveyFeedFor("team-123", "Team Alpha"))
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                val view = fragment.requireView()
+                val emptyView = view.findViewById<View>(R.id.dashboardSurveysEmptyView)
+                val contentContainer = view.findViewById<View>(R.id.dashboardSurveysContentContainer)
+                assertTrue(emptyView.visibility == View.GONE)
+                assertTrue(contentContainer.visibility == View.VISIBLE)
+                // Execute pending transactions
+                fragment.childFragmentManager.executePendingTransactions()
+                val teamFragment = fragment.childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)
+                assertNotNull(teamFragment)
+                assertTrue(teamFragment is DashboardTeamSurveysFragment)
+                assertTrue((teamFragment as DashboardTeamSurveysFragment).isSurveyFeedFor("team-123", "Team Alpha"))
+            }
         }
     }
 
@@ -89,31 +83,27 @@ class DashboardSurveysFragmentTest {
     fun `onResume updates content when team selection changes`() {
         // Start with team 1
         DashboardTeamSelectionPreferences.setSelectedTeam(context, "team-123", "Team Alpha")
-
-        val scenario = launchFragmentInContainer<DashboardSurveysFragment>(
+        launchFragmentInContainer<DashboardSurveysFragment>(
             themeResId = R.style.Theme_MyPlanetLite,
             initialState = Lifecycle.State.RESUMED
-        )
-
-        scenario.onFragment { fragment ->
-            fragment.childFragmentManager.executePendingTransactions()
-            var teamFragment = fragment.childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)
-            assertTrue((teamFragment as DashboardTeamSurveysFragment).isSurveyFeedFor("team-123", "Team Alpha"))
-
-            // Change team preference behind the scenes
-            DashboardTeamSelectionPreferences.setSelectedTeam(context, "team-456", "Team Beta")
-        }
-
-        // Trigger onResume by moving state
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.moveToState(Lifecycle.State.RESUMED)
-
-        scenario.onFragment { fragment ->
-            fragment.childFragmentManager.executePendingTransactions()
-            val teamFragment = fragment.childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)
-            assertNotNull(teamFragment)
-            assertTrue(teamFragment is DashboardTeamSurveysFragment)
-            assertTrue((teamFragment as DashboardTeamSurveysFragment).isSurveyFeedFor("team-456", "Team Beta"))
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                fragment.childFragmentManager.executePendingTransactions()
+                val teamFragment = fragment.childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)
+                assertTrue((teamFragment as DashboardTeamSurveysFragment).isSurveyFeedFor("team-123", "Team Alpha"))
+                // Change team preference behind the scenes
+                DashboardTeamSelectionPreferences.setSelectedTeam(context, "team-456", "Team Beta")
+            }
+            // Trigger onResume by moving state
+            scenario.moveToState(Lifecycle.State.STARTED)
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onFragment { fragment ->
+                fragment.childFragmentManager.executePendingTransactions()
+                val teamFragment = fragment.childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)
+                assertNotNull(teamFragment)
+                assertTrue(teamFragment is DashboardTeamSurveysFragment)
+                assertTrue((teamFragment as DashboardTeamSurveysFragment).isSurveyFeedFor("team-456", "Team Beta"))
+            }
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragmentTest.kt
@@ -50,87 +50,79 @@ class DashboardTeamSurveysFragmentTest {
             putString("arg_team_id", "team123")
             putString("arg_team_name", "Team Alpha")
         }
-        val scenario = launchFragmentInContainer<DashboardTeamSurveysFragment>(
+        launchFragmentInContainer<DashboardTeamSurveysFragment>(
             fragmentArgs = bundle,
             themeResId = R.style.Theme_MyPlanetLite
-        )
-
-        scenario.onFragment { fragment ->
-            assertNotNull(fragment)
-
-            assertTrue(fragment.isSurveyFeedFor("team123", "Team Alpha"))
-            assertFalse(fragment.isSurveyFeedFor("team123", "Team Beta"))
-            assertFalse(fragment.isSurveyFeedFor("team456", "Team Alpha"))
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                assertNotNull(fragment)
+                assertTrue(fragment.isSurveyFeedFor("team123", "Team Alpha"))
+                assertFalse(fragment.isSurveyFeedFor("team123", "Team Beta"))
+                assertFalse(fragment.isSurveyFeedFor("team456", "Team Alpha"))
+            }
         }
     }
 
     @Test
     fun testLoadSurveys_MissingServer() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-
         // Ensure no server URL is stored
         whenever(mockPrefs.getString("server_url", null)).thenReturn(null)
-
         val bundle = Bundle().apply {
             putString("arg_team_id", "team123")
             putString("arg_team_name", "Team Alpha")
         }
-        val scenario = launchFragmentInContainer<DashboardTeamSurveysFragment>(
+        launchFragmentInContainer<DashboardTeamSurveysFragment>(
             fragmentArgs = bundle,
             themeResId = R.style.Theme_MyPlanetLite
-        )
-
-        scenario.onFragment { fragment ->
-            val errorView = fragment.view?.findViewById<TextView>(R.id.dashboardSurveysError)
-            assertNotNull(errorView)
-            assertTrue(errorView!!.isVisible)
-            assertEquals(context.getString(R.string.dashboard_surveys_missing_server), errorView.text)
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                val errorView = fragment.view?.findViewById<TextView>(R.id.dashboardSurveysError)
+                assertNotNull(errorView)
+                assertTrue(errorView!!.isVisible)
+                assertEquals(context.getString(R.string.dashboard_surveys_missing_server), errorView.text)
+            }
         }
     }
 
     @Test
     fun testLoadSurveys_MissingTeam() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-
         // Mock server URL so it passes the first check
         whenever(mockPrefs.getString("server_url", null)).thenReturn("http://test.com")
-
         // No team arguments
-        val scenario = launchFragmentInContainer<DashboardTeamSurveysFragment>(
+        launchFragmentInContainer<DashboardTeamSurveysFragment>(
             themeResId = R.style.Theme_MyPlanetLite
-        )
-
-        scenario.onFragment { fragment ->
-            val errorView = fragment.view?.findViewById<TextView>(R.id.dashboardSurveysError)
-            assertNotNull(errorView)
-            assertTrue(errorView!!.isVisible)
-            assertEquals(context.getString(R.string.dashboard_surveys_missing_team), errorView.text)
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                val errorView = fragment.view?.findViewById<TextView>(R.id.dashboardSurveysError)
+                assertNotNull(errorView)
+                assertTrue(errorView!!.isVisible)
+                assertEquals(context.getString(R.string.dashboard_surveys_missing_team), errorView.text)
+            }
         }
     }
 
     @Test
     fun testLoadSurveys_MissingCredentials() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-
         // Mock server URL
         whenever(mockPrefs.getString("server_url", null)).thenReturn("http://test.com")
-
         // Do not mock credentials, so it returns null
-
         val bundle = Bundle().apply {
             putString("arg_team_id", "team123")
             putString("arg_team_name", "Team Alpha")
         }
-        val scenario = launchFragmentInContainer<DashboardTeamSurveysFragment>(
+        launchFragmentInContainer<DashboardTeamSurveysFragment>(
             fragmentArgs = bundle,
             themeResId = R.style.Theme_MyPlanetLite
-        )
-
-        scenario.onFragment { fragment ->
-            val errorView = fragment.view?.findViewById<TextView>(R.id.dashboardSurveysError)
-            assertNotNull(errorView)
-            assertTrue(errorView!!.isVisible)
-            assertEquals(context.getString(R.string.dashboard_surveys_missing_credentials), errorView.text)
+        ).use { scenario ->
+            scenario.onFragment { fragment ->
+                val errorView = fragment.view?.findViewById<TextView>(R.id.dashboardSurveysError)
+                assertNotNull(errorView)
+                assertTrue(errorView!!.isVisible)
+                assertEquals(context.getString(R.string.dashboard_surveys_missing_credentials), errorView.text)
+            }
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragmentTest.kt
@@ -21,6 +21,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.ole.planet.myplanet.lite.dashboard.DashboardOfflineSurveyStore
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 
 @RunWith(RobolectricTestRunner::class)
@@ -42,6 +44,8 @@ class DashboardTeamSurveysFragmentTest {
     @After
     fun tearDown() {
         SecurePreferencesProvider.injectedPreferences = null
+        DashboardSurveyOutboxStore.resetForTesting(ApplicationProvider.getApplicationContext())
+        DashboardOfflineSurveyStore.resetForTesting(ApplicationProvider.getApplicationContext())
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
@@ -23,14 +23,14 @@ class DashboardOfflineSurveyStoreTest {
     @Before
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        store = DashboardOfflineSurveyStore(context)
+        store = DashboardOfflineSurveyStore.getInstance(context)
         // Clear db before test
         store.writableDatabase.delete("surveys", null, null)
     }
 
     @After
     fun teardown() {
-        store.close()
+        DashboardOfflineSurveyStore.resetForTesting(ApplicationProvider.getApplicationContext())
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivityTest.kt
@@ -20,6 +20,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.R
+import org.ole.planet.myplanet.lite.util.FakeSharedPreferences
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
@@ -35,14 +37,16 @@ class DashboardOutboxDetailActivityTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        store = DashboardSurveyOutboxStore(context)
+        SecurePreferencesProvider.injectedPreferences = FakeSharedPreferences()
+        store = DashboardSurveyOutboxStore.getInstance(context)
         store.writableDatabase.delete("outbox_submissions", null, null)
     }
 
     @After
     fun teardown() {
         Dispatchers.resetMain()
-        store.close()
+        DashboardSurveyOutboxStore.resetForTesting(context)
+        SecurePreferencesProvider.resetForTesting()
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStoreTest.kt
@@ -28,13 +28,13 @@ class DashboardSurveyOutboxStoreTest {
     @Before
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        store = DashboardSurveyOutboxStore(context)
+        store = DashboardSurveyOutboxStore.getInstance(context)
         store.writableDatabase.delete("outbox_submissions", null, null)
     }
 
     @After
     fun teardown() {
-        store.close()
+        DashboardSurveyOutboxStore.resetForTesting(ApplicationProvider.getApplicationContext())
     }
 
     private fun createSubmission() = SurveySubmission(

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMembersFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMembersFragmentTest.kt
@@ -99,16 +99,15 @@ class DashboardTeamMembersFragmentTest {
         """.trimIndent()
         mockWebServer.enqueue(MockResponse().setBody(usersResponse).setResponseCode(200))
 
-        val scenario = launchFragmentInContainer<DashboardTeamMembersFragment>(themeResId = MaterialR.style.Theme_MaterialComponents_Light)
-
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
-
-        scenario.onFragment { fragment ->
-            assertNotNull(fragment)
-            val recyclerView = fragment.view?.findViewById<RecyclerView>(R.id.dashboardTeamMembersList)
-            assertNotNull(recyclerView)
-            assertEquals(View.VISIBLE, recyclerView?.visibility)
-            assertEquals(1, recyclerView?.adapter?.itemCount)
+        launchFragmentInContainer<DashboardTeamMembersFragment>(themeResId = MaterialR.style.Theme_MaterialComponents_Light).use { scenario ->
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+            scenario.onFragment { fragment ->
+                assertNotNull(fragment)
+                val recyclerView = fragment.view?.findViewById<RecyclerView>(R.id.dashboardTeamMembersList)
+                assertNotNull(recyclerView)
+                assertEquals(View.VISIBLE, recyclerView?.visibility)
+                assertEquals(1, recyclerView?.adapter?.itemCount)
+            }
         }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepositoryTest.kt
@@ -12,6 +12,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SubmissionParent
+import org.ole.planet.myplanet.lite.dashboard.DashboardOfflineSurveyStore
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SubmissionUser
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
@@ -32,12 +34,16 @@ class DashboardLocalSurveyRepositoryTest {
         context = ApplicationProvider.getApplicationContext()
         mockPrefs = mock(SharedPreferences::class.java)
         SecurePreferencesProvider.injectedPreferences = mockPrefs
+        DashboardOfflineSurveyStore.resetForTesting(context)
+        DashboardSurveyOutboxStore.resetForTesting(context)
         repository = DashboardLocalSurveyRepository(context)
     }
 
     @After
     fun tearDown() {
         repository.close()
+        DashboardOfflineSurveyStore.resetForTesting(context)
+        DashboardSurveyOutboxStore.resetForTesting(context)
         SecurePreferencesProvider.resetForTesting()
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/FakeSharedPreferences.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/FakeSharedPreferences.kt
@@ -1,0 +1,39 @@
+package org.ole.planet.myplanet.lite.util
+
+import android.content.SharedPreferences
+
+class FakeSharedPreferences : SharedPreferences {
+    private val data = mutableMapOf<String, Any?>()
+    override fun getAll(): Map<String, *> = data
+    override fun getString(key: String, defValue: String?): String? = data[key] as? String ?: defValue
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String, defValues: Set<String>?): Set<String>? = data[key] as? Set<String> ?: defValues
+    override fun getInt(key: String, defValue: Int): Int = data[key] as? Int ?: defValue
+    override fun getLong(key: String, defValue: Long): Long = data[key] as? Long ?: defValue
+    override fun getFloat(key: String, defValue: Float): Float = data[key] as? Float ?: defValue
+    override fun getBoolean(key: String, defValue: Boolean): Boolean = data[key] as? Boolean ?: defValue
+    override fun contains(key: String): Boolean = data.containsKey(key)
+    override fun edit(): SharedPreferences.Editor = FakeEditor(data)
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+
+    private class FakeEditor(private val data: MutableMap<String, Any?>) : SharedPreferences.Editor {
+        private val temp = mutableMapOf<String, Any?>()
+        private val toRemove = mutableSetOf<String>()
+        private var clear = false
+        override fun putString(key: String, value: String?): SharedPreferences.Editor { temp[key] = value; return this }
+        override fun putStringSet(key: String, values: Set<String>?): SharedPreferences.Editor { temp[key] = values; return this }
+        override fun putInt(key: String, value: Int): SharedPreferences.Editor { temp[key] = value; return this }
+        override fun putLong(key: String, value: Long): SharedPreferences.Editor { temp[key] = value; return this }
+        override fun putFloat(key: String, value: Float): SharedPreferences.Editor { temp[key] = value; return this }
+        override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor { temp[key] = value; return this }
+        override fun remove(key: String): SharedPreferences.Editor { toRemove.add(key); return this }
+        override fun clear(): SharedPreferences.Editor { clear = true; return this }
+        override fun commit(): Boolean { apply(); return true }
+        override fun apply() {
+            if (clear) data.clear()
+            for (key in toRemove) data.remove(key)
+            data.putAll(temp)
+        }
+    }
+}


### PR DESCRIPTION
The changes address a recurring warning in Robolectric unit tests: `java.lang.Throwable: Explicit termination method 'Surface.release' not called`. This was caused by `FragmentScenario` (and internally `ActivityScenario`) instances not being closed after tests finished.

By using the Kotlin `.use` extension on `FragmentScenario`, we ensure that `close()` is automatically called, even if tests fail, adhering to best practices for AndroidX testing components.

Verified that tests pass and the warning is no longer present for:
- org.ole.planet.myplanet.lite.DashboardSurveysFragmentTest
- org.ole.planet.myplanet.lite.DashboardTeamSurveysFragmentTest
- org.ole.planet.myplanet.lite.dashboard.DashboardTeamMembersFragmentTest

---
*PR created automatically by Jules for task [4334729504873834517](https://jules.google.com/task/4334729504873834517) started by @PlataformasInformaticas*