### PR TITLE
Fix Robolectric native runtime and SQLite stability issues

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabase.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabase.kt
@@ -172,5 +172,11 @@ class UserProfileDatabase private constructor(context: Context) :
                 legacyDbFile.renameTo(newDbFile)
             }
         }
+
+        fun resetForTesting(context: Context) {
+            instance?.close()
+            instance = null
+            context.deleteDatabase(DATABASE_NAME)
+        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardVoicesFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardVoicesFragmentTest.kt
@@ -15,10 +15,19 @@ import org.robolectric.RobolectricTestRunner
 import org.mockito.Mockito
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 
 @RunWith(RobolectricTestRunner::class)
-@Config(instrumentedPackages = ["androidx.loader.content"]) // Helps prevent FragmentScenario crash
+@Config(sdk = [33], instrumentedPackages = ["androidx.loader.content"]) // Helps prevent FragmentScenario crash
 class DashboardVoicesFragmentTest {
+
+    @After
+    fun tearDown() {
+        UserProfileDatabase.resetForTesting(ApplicationProvider.getApplicationContext())
+        SecurePreferencesProvider.resetForTesting()
+    }
 
     @Test
     fun `newInstanceForTeam creates fragment with correct arguments`() {
@@ -45,9 +54,10 @@ class DashboardVoicesFragmentTest {
 
         // To ensure initializeSession reads the arguments from the Bundle provided through FragmentScenario,
         // we must allow it to proceed to RESUMED since the method is triggered via lifecycleScope.launch in onViewCreated
-        val scenario = FragmentScenario.launchInContainer(DashboardVoicesFragment::class.java, args, R.style.Theme_MyPlanetLite)
-        scenario.onFragment { fragment ->
-            block(fragment)
+        FragmentScenario.launchInContainer(DashboardVoicesFragment::class.java, args, R.style.Theme_MyPlanetLite).use { scenario ->
+            scenario.onFragment { fragment ->
+                block(fragment)
+            }
         }
 
         SecurePreferencesProvider.injectedPreferences = null

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseErrorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseErrorTest.kt
@@ -28,10 +28,7 @@ class UserProfileDatabaseErrorTest {
 
     @After
     fun teardown() {
-        database.close()
-        val instanceField = UserProfileDatabase::class.java.getDeclaredField("instance")
-        instanceField.isAccessible = true
-        instanceField.set(null, null)
+        UserProfileDatabase.resetForTesting(context)
     }
 
     @Test

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileDatabaseTest.kt
@@ -31,12 +31,7 @@ class UserProfileDatabaseTest {
 
     @After
     fun teardown() {
-        database.clearProfile()
-        database.close()
-        // Reset the singleton instance using reflection
-        val instanceField = UserProfileDatabase::class.java.getDeclaredField("instance")
-        instanceField.isAccessible = true
-        instanceField.set(null, null)
+        UserProfileDatabase.resetForTesting(context)
     }
 
     private fun createDummyProfile(username: String, isAdmin: Boolean = false): UserProfile {


### PR DESCRIPTION
Addressed `FileSystemAlreadyExistsException` and `UnsatisfiedLinkError` in Robolectric tests by pinning `DashboardVoicesFragmentTest` to a stable SDK version (33) and improving resource management. 

Key changes:
- Added `UserProfileDatabase.resetForTesting(context)` to properly close the database singleton between tests.
- Updated `UserProfileDatabaseTest` and `UserProfileDatabaseErrorTest` to utilize this new cleanup method.
- Refactored `DashboardVoicesFragmentTest` to ensure `FragmentScenario` is closed and all shared state (preferences and database) is reset after each test execution.

---
*PR created automatically by Jules for task [14411021184584046489](https://jules.google.com/task/14411021184584046489) started by @PlataformasInformaticas*