### PR TITLE
Fix SplashScreen routing logic on profile refresh failure

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
@@ -171,7 +171,8 @@ class SplashScreen : BaseActivity() {
         return if (refreshed) {
             DashboardLaunchMode.ONLINE
         } else {
-            DashboardLaunchMode.OFFLINE
+            authService.logout()
+            DashboardLaunchMode.NONE
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
@@ -66,6 +66,7 @@ class SplashScreenTest {
         mockWebServer.shutdown()
     }
 
+    @Suppress("DEPRECATION")
     private fun setNetworkState(isOnline: Boolean) {
         val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val shadowConnectivityManager = Shadows.shadowOf(connectivityManager)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
@@ -210,6 +210,7 @@ class SplashScreenTest {
         UserProfileDatabase.getInstance(context).saveProfile(createTestUserProfile())
         setNetworkState(true)
 
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
         mockWebServer.enqueue(MockResponse()
             .setResponseCode(200)
             .setBody("{\"_id\":\"org.couchdb.user:testuser\",\"name\":\"testuser\",\"roles\":[]}"))
@@ -234,6 +235,7 @@ class SplashScreenTest {
         UserProfileDatabase.getInstance(context).saveProfile(createTestUserProfile())
         setNetworkState(true)
 
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
         mockWebServer.enqueue(MockResponse().setResponseCode(401))
 
         val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()


### PR DESCRIPTION
This PR fixes a regression in the SplashScreen routing logic where a failed profile refresh (e.g., 401 Unauthorized) while the server was online would incorrectly lead to DashboardActivity in offline mode. The expected behavior, as defined in unit tests, is to logout the user and return to the login screen (MyPlanetLite).

Changes:
- Modified `SplashScreen.kt` to call `authService.logout()` and return `DashboardLaunchMode.NONE` when `userProfileSync.refreshProfile` fails.
- Updated `SplashScreenTest.kt` to include the required mock response for the initial server connectivity check performed by `SplashScreen`.
- Verified all unit tests pass with `./gradlew testDebugUnitTest`.

---
*PR created automatically by Jules for task [13560313670051700239](https://jules.google.com/task/13560313670051700239) started by @PlataformasInformaticas*