### PR TITLE
Fix resource leaks in Robolectric unit tests

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/BaseActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/BaseActivityTest.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
+import android.os.Looper
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.OnApplyWindowInsetsListener
@@ -25,6 +26,7 @@ import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 
 class TestActivity : BaseActivity() {
@@ -65,56 +67,67 @@ class BaseActivityTest {
     @Test
     fun testOnCreateAppliesLanguage() {
         val controller = Robolectric.buildActivity(TestActivity::class.java).setup()
-        val activity = controller.get()
-        assertNotNull(activity)
+        try {
+            val activity = controller.get()
+            assertNotNull(activity)
+        } finally {
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+            controller.pause().stop().destroy()
+        }
     }
 
     @Test
     @Config(qualifiers = "sw600dp")
     fun testOrientationLockOnTablet() {
         val controller = Robolectric.buildActivity(TestActivity::class.java).setup()
-        val activity = controller.get()
-        activity.callApplyDeviceOrientationLock()
-        assertEquals(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR, activity.requestedOrientation)
+        try {
+            val activity = controller.get() as TestActivity
+            activity.callApplyDeviceOrientationLock()
+            assertEquals(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR, activity.requestedOrientation)
+        } finally {
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+            controller.pause().stop().destroy()
+        }
     }
 
     @Test
     @Config(qualifiers = "sw400dp")
     fun testOrientationLockOnPhone() {
         val controller = Robolectric.buildActivity(TestActivity::class.java).setup()
-        val activity = controller.get()
-        activity.callApplyDeviceOrientationLock()
-        assertEquals(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT, activity.requestedOrientation)
+        try {
+            val activity = controller.get() as TestActivity
+            activity.callApplyDeviceOrientationLock()
+            assertEquals(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT, activity.requestedOrientation)
+        } finally {
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+            controller.pause().stop().destroy()
+        }
     }
 
     @Test
     fun testSetupEdgeToEdgePadding() {
         val controller = Robolectric.buildActivity(TestActivity::class.java).setup()
-        val activity = controller.get()
-
-        var listener: OnApplyWindowInsetsListener? = null
-
-        // ViewCompat is a Java class, we should mockkStatic
-        mockkStatic(ViewCompat::class)
-        every { ViewCompat.setOnApplyWindowInsetsListener(any(), any()) } answers {
-            listener = it.invocation.args[1] as OnApplyWindowInsetsListener
+        try {
+            val activity = controller.get() as TestActivity
+            var listener: OnApplyWindowInsetsListener? = null
+            mockkStatic(ViewCompat::class)
+            every { ViewCompat.setOnApplyWindowInsetsListener(any(), any()) } answers {
+                listener = it.invocation.args[1] as OnApplyWindowInsetsListener
+            }
+            activity.callSetupEdgeToEdgePadding(activity.rootView)
+            assertNotNull("Listener should be registered", listener)
+            val insets = WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.systemBars(), androidx.core.graphics.Insets.of(10, 20, 30, 40))
+                .build()
+            listener?.onApplyWindowInsets(activity.rootView, insets)
+            assertEquals(10, activity.rootView.paddingLeft)
+            assertEquals(20, activity.rootView.paddingTop)
+            assertEquals(30, activity.rootView.paddingRight)
+            assertEquals(40, activity.rootView.paddingBottom)
+            unmockkStatic(ViewCompat::class)
+        } finally {
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+            controller.pause().stop().destroy()
         }
-
-        activity.callSetupEdgeToEdgePadding(activity.rootView)
-
-        assertNotNull("Listener should be registered", listener)
-
-        val insets = WindowInsetsCompat.Builder()
-            .setInsets(WindowInsetsCompat.Type.systemBars(), androidx.core.graphics.Insets.of(10, 20, 30, 40))
-            .build()
-
-        listener?.onApplyWindowInsets(activity.rootView, insets)
-
-        assertEquals(10, activity.rootView.paddingLeft)
-        assertEquals(20, activity.rootView.paddingTop)
-        assertEquals(30, activity.rootView.paddingRight)
-        assertEquals(40, activity.rootView.paddingBottom)
-
-        unmockkStatic(ViewCompat::class)
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardActivityTest.kt
@@ -5,6 +5,7 @@ import android.os.Looper
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.viewpager2.widget.ViewPager2
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +18,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
@@ -46,69 +46,75 @@ class DashboardActivityTest {
 
     @Test
     fun `activity initializes views correctly`() {
-        val controller = Robolectric.buildActivity(DashboardActivity::class.java).create().start().resume()
-        val activity = controller.get()
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        ActivityScenario.launch<DashboardActivity>(DashboardActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-        val viewPager = activity.findViewById<ViewPager2>(R.id.dashboardViewPager)
-        val surveysContainer = activity.findViewById<FrameLayout>(R.id.dashboardSurveysContainer)
-        val homeIcon = activity.findViewById<ImageView>(R.id.dashboardHomeIcon)
-        val surveysIcon = activity.findViewById<ImageView>(R.id.dashboardSurveysIcon)
-        val coursesIcon = activity.findViewById<ImageView>(R.id.dashboardCoursesIcon)
-        val teamMembersIcon = activity.findViewById<ImageView>(R.id.dashboardTeamMembersIcon)
+                val viewPager = activity.findViewById<ViewPager2>(R.id.dashboardViewPager)
+                val surveysContainer = activity.findViewById<FrameLayout>(R.id.dashboardSurveysContainer)
+                val homeIcon = activity.findViewById<ImageView>(R.id.dashboardHomeIcon)
+                val surveysIcon = activity.findViewById<ImageView>(R.id.dashboardSurveysIcon)
+                val coursesIcon = activity.findViewById<ImageView>(R.id.dashboardCoursesIcon)
+                val teamMembersIcon = activity.findViewById<ImageView>(R.id.dashboardTeamMembersIcon)
 
-        // For robolectric the offline mode kicks in. Offline mode only shows surveys
-        assertEquals("Surveys Container should be visible in offline mode", View.VISIBLE, surveysContainer.visibility)
-        assertEquals("ViewPager should be gone in offline mode", View.GONE, viewPager.visibility)
+                // For robolectric the offline mode kicks in. Offline mode only shows surveys
+                assertEquals("Surveys Container should be visible in offline mode", View.VISIBLE, surveysContainer.visibility)
+                assertEquals("ViewPager should be gone in offline mode", View.GONE, viewPager.visibility)
 
-        assertEquals("Home Icon should be visible", View.VISIBLE, homeIcon.visibility)
-        assertEquals("Surveys Icon should be visible", View.VISIBLE, surveysIcon.visibility)
-        assertEquals("Courses Icon should be visible", View.VISIBLE, coursesIcon.visibility)
-        assertEquals("Team Members Icon should be visible", View.VISIBLE, teamMembersIcon.visibility)
+                assertEquals("Home Icon should be visible", View.VISIBLE, homeIcon.visibility)
+                assertEquals("Surveys Icon should be visible", View.VISIBLE, surveysIcon.visibility)
+                assertEquals("Courses Icon should be visible", View.VISIBLE, coursesIcon.visibility)
+                assertEquals("Team Members Icon should be visible", View.VISIBLE, teamMembersIcon.visibility)
+            }
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 
     @Test
     fun `bottom navigation switches sections correctly`() {
-        val controller = Robolectric.buildActivity(DashboardActivity::class.java).create().start().resume()
-        val activity = controller.get()
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        ActivityScenario.launch<DashboardActivity>(DashboardActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-        val viewPager = activity.findViewById<ViewPager2>(R.id.dashboardViewPager)
-        val surveysContainer = activity.findViewById<FrameLayout>(R.id.dashboardSurveysContainer)
-        val coursesContainer = activity.findViewById<FrameLayout>(R.id.dashboardCoursesContainer)
-        val teamMembersContainer = activity.findViewById<FrameLayout>(R.id.dashboardTeamMembersContainer)
+                val viewPager = activity.findViewById<ViewPager2>(R.id.dashboardViewPager)
+                val surveysContainer = activity.findViewById<FrameLayout>(R.id.dashboardSurveysContainer)
+                val coursesContainer = activity.findViewById<FrameLayout>(R.id.dashboardCoursesContainer)
+                val teamMembersContainer = activity.findViewById<FrameLayout>(R.id.dashboardTeamMembersContainer)
 
-        val surveysIcon = activity.findViewById<ImageView>(R.id.dashboardSurveysIcon)
-        val coursesIcon = activity.findViewById<ImageView>(R.id.dashboardCoursesIcon)
-        val teamMembersIcon = activity.findViewById<ImageView>(R.id.dashboardTeamMembersIcon)
-        val homeIcon = activity.findViewById<ImageView>(R.id.dashboardHomeIcon)
+                val surveysIcon = activity.findViewById<ImageView>(R.id.dashboardSurveysIcon)
+                val coursesIcon = activity.findViewById<ImageView>(R.id.dashboardCoursesIcon)
+                val teamMembersIcon = activity.findViewById<ImageView>(R.id.dashboardTeamMembersIcon)
+                val homeIcon = activity.findViewById<ImageView>(R.id.dashboardHomeIcon)
 
-        // Offline mode defaults to Surveys
-        assertEquals("Surveys Container should be visible initially in offline mode", View.VISIBLE, surveysContainer.visibility)
-        assertEquals("ViewPager should be gone initially in offline mode", View.GONE, viewPager.visibility)
+                // Offline mode defaults to Surveys
+                assertEquals("Surveys Container should be visible initially in offline mode", View.VISIBLE, surveysContainer.visibility)
+                assertEquals("ViewPager should be gone initially in offline mode", View.GONE, viewPager.visibility)
 
-        // Click Courses
-        coursesIcon.performClick()
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        assertEquals("Surveys Container should be gone after clicking Courses", View.GONE, surveysContainer.visibility)
-        assertEquals("Courses Container should be visible after clicking Courses", View.VISIBLE, coursesContainer.visibility)
+                // Click Courses
+                coursesIcon.performClick()
+                Shadows.shadowOf(Looper.getMainLooper()).idle()
+                assertEquals("Surveys Container should be gone after clicking Courses", View.GONE, surveysContainer.visibility)
+                assertEquals("Courses Container should be visible after clicking Courses", View.VISIBLE, coursesContainer.visibility)
 
-        // Click Surveys
-        surveysIcon.performClick()
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        assertEquals("Courses Container should be gone after clicking Surveys", View.GONE, coursesContainer.visibility)
-        assertEquals("Surveys Container should be visible after clicking Surveys", View.VISIBLE, surveysContainer.visibility)
+                // Click Surveys
+                surveysIcon.performClick()
+                Shadows.shadowOf(Looper.getMainLooper()).idle()
+                assertEquals("Courses Container should be gone after clicking Surveys", View.GONE, coursesContainer.visibility)
+                assertEquals("Surveys Container should be visible after clicking Surveys", View.VISIBLE, surveysContainer.visibility)
 
-        // Click Team Members (Disabled in offline mode so it shouldn't work)
-        teamMembersIcon.performClick()
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        assertEquals("Surveys Container should remain visible", View.VISIBLE, surveysContainer.visibility)
-        assertEquals("Team Members Container should remain gone", View.GONE, teamMembersContainer.visibility)
+                // Click Team Members (Disabled in offline mode so it shouldn't work)
+                teamMembersIcon.performClick()
+                Shadows.shadowOf(Looper.getMainLooper()).idle()
+                assertEquals("Surveys Container should remain visible", View.VISIBLE, surveysContainer.visibility)
+                assertEquals("Team Members Container should remain gone", View.GONE, teamMembersContainer.visibility)
 
-        // Click Home (Disabled in offline mode so it shouldn't work)
-        homeIcon.performClick()
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        assertEquals("Surveys Container should remain visible", View.VISIBLE, surveysContainer.visibility)
-        assertEquals("ViewPager should remain gone", View.GONE, viewPager.visibility)
+                // Click Home (Disabled in offline mode so it shouldn't work)
+                homeIcon.performClick()
+                Shadows.shadowOf(Looper.getMainLooper()).idle()
+                assertEquals("Surveys Container should remain visible", View.VISIBLE, surveysContainer.visibility)
+                assertEquals("ViewPager should remain gone", View.GONE, viewPager.visibility)
+            }
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Looper
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -116,7 +117,7 @@ class SplashScreenTest {
         )
     }
 
-    private fun waitForNextIntent(controller: org.robolectric.android.controller.ActivityController<SplashScreen>): Intent? {
+    private fun waitForNextIntent(scenario: ActivityScenario<SplashScreen>): Intent? {
         val maxWaitTimeMs = 5000
         val incrementMs = 100
         var totalWaitTime = 0
@@ -126,8 +127,11 @@ class SplashScreenTest {
             Thread.sleep(incrementMs.toLong())
             Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
 
-            val shadowActivity = Shadows.shadowOf(controller.get())
-            nextIntent = shadowActivity.nextStartedActivity
+            scenario.onActivity { activity ->
+                val shadowActivity = Shadows.shadowOf(activity)
+                nextIntent = shadowActivity.nextStartedActivity
+            }
+
             if (nextIntent != null) {
                 break
             }
@@ -140,13 +144,13 @@ class SplashScreenTest {
     fun `test splash screen routes to MyPlanetLite when no server URL is set`() {
         mockPrefs.edit().clear().commit()
 
-        val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()
-
-        val nextIntent = waitForNextIntent(controller)
-
-        assertNotNull("Expected nextIntent to not be null", nextIntent)
-        assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
-        assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+        ActivityScenario.launch<SplashScreen>(SplashScreen::class.java).use { scenario ->
+            val nextIntent = waitForNextIntent(scenario)
+            assertNotNull("Expected nextIntent to not be null", nextIntent)
+            assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
+            assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 
     @Test
@@ -156,13 +160,13 @@ class SplashScreenTest {
         mockAuth.storedToken = null
         AuthDependencies.overrideAuthService(mockAuth)
 
-        val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()
-
-        val nextIntent = waitForNextIntent(controller)
-
-        assertNotNull("Expected nextIntent to not be null", nextIntent)
-        assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
-        assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+        ActivityScenario.launch<SplashScreen>(SplashScreen::class.java).use { scenario ->
+            val nextIntent = waitForNextIntent(scenario)
+            assertNotNull("Expected nextIntent to not be null", nextIntent)
+            assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
+            assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 
     @Test
@@ -172,13 +176,13 @@ class SplashScreenTest {
         mockAuth.storedToken = "valid_token"
         AuthDependencies.overrideAuthService(mockAuth)
 
-        val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()
-
-        val nextIntent = waitForNextIntent(controller)
-
-        assertNotNull("Expected nextIntent to not be null", nextIntent)
-        assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
-        assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+        ActivityScenario.launch<SplashScreen>(SplashScreen::class.java).use { scenario ->
+            val nextIntent = waitForNextIntent(scenario)
+            assertNotNull("Expected nextIntent to not be null", nextIntent)
+            assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
+            assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 
     @Test
@@ -191,13 +195,13 @@ class SplashScreenTest {
         UserProfileDatabase.getInstance(context).saveProfile(createTestUserProfile())
         setNetworkState(false)
 
-        val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()
-
-        val nextIntent = waitForNextIntent(controller)
-
-        assertNotNull("Expected nextIntent to not be null for offline", nextIntent)
-        assertEquals(DashboardActivity::class.java.name, nextIntent?.component?.className)
-        assertTrue(nextIntent?.getBooleanExtra(DashboardActivity.EXTRA_OFFLINE_MODE, false) ?: false)
+        ActivityScenario.launch<SplashScreen>(SplashScreen::class.java).use { scenario ->
+            val nextIntent = waitForNextIntent(scenario)
+            assertNotNull("Expected nextIntent to not be null for offline", nextIntent)
+            assertEquals(DashboardActivity::class.java.name, nextIntent?.component?.className)
+            assertTrue(nextIntent?.getBooleanExtra(DashboardActivity.EXTRA_OFFLINE_MODE, false) ?: false)
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 
     @Test
@@ -216,13 +220,13 @@ class SplashScreenTest {
             .setResponseCode(200)
             .setBody("{\"_id\":\"org.couchdb.user:testuser\",\"name\":\"testuser\",\"roles\":[]}"))
 
-        val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()
-
-        val nextIntent = waitForNextIntent(controller)
-
-        assertNotNull("Expected nextIntent to not be null for online", nextIntent)
-        assertEquals(DashboardActivity::class.java.name, nextIntent?.component?.className)
-        assertEquals(false, nextIntent?.getBooleanExtra(DashboardActivity.EXTRA_OFFLINE_MODE, false))
+        ActivityScenario.launch<SplashScreen>(SplashScreen::class.java).use { scenario ->
+            val nextIntent = waitForNextIntent(scenario)
+            assertNotNull("Expected nextIntent to not be null for online", nextIntent)
+            assertEquals(DashboardActivity::class.java.name, nextIntent?.component?.className)
+            assertEquals(false, nextIntent?.getBooleanExtra(DashboardActivity.EXTRA_OFFLINE_MODE, false))
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 
     @Test
@@ -239,14 +243,14 @@ class SplashScreenTest {
         mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
         mockWebServer.enqueue(MockResponse().setResponseCode(401))
 
-        val controller = Robolectric.buildActivity(SplashScreen::class.java).create().start().resume()
-
-        val nextIntent = waitForNextIntent(controller)
-
-        assertNotNull("Expected nextIntent to not be null for failed refresh", nextIntent)
-        assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
-        assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
-        assertTrue(mockAuth.isLoggedOut)
+        ActivityScenario.launch<SplashScreen>(SplashScreen::class.java).use { scenario ->
+            val nextIntent = waitForNextIntent(scenario)
+            assertNotNull("Expected nextIntent to not be null for failed refresh", nextIntent)
+            assertEquals(MyPlanetLite::class.java.name, nextIntent?.component?.className)
+            assertTrue(nextIntent?.getBooleanExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, false) ?: false)
+            assertTrue(mockAuth.isLoggedOut)
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+        }
     }
 }
 


### PR DESCRIPTION
This change addresses `Surface` and `SurfaceControl` resource leak warnings in Robolectric tests by ensuring all activities are properly destroyed. 

Key changes:
- In `DashboardActivityTest` and `SplashScreenTest`, refactored tests to use `ActivityScenario.launch(...).use { ... }` for automatic lifecycle management and destruction.
- In `BaseActivityTest`, wrapped `Robolectric.buildActivity()` usage in `try-finally` blocks with explicit `controller.pause().stop().destroy()` calls, as `ActivityScenario` requires activities to be declared in the manifest.
- Added `Shadows.shadowOf(Looper.getMainLooper()).idle()` before activity destruction across all affected tests to ensure pending UI tasks and layout passes are completed, preventing orphaned surface references.
- Cleaned up unused imports.

---
*PR created automatically by Jules for task [18366174108394980001](https://jules.google.com/task/18366174108394980001) started by @PlataformasInformaticas*