### PR TITLE
Fix deprecation warning in SurveyWizardActivityTest

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardActivityTest.kt
@@ -1,10 +1,11 @@
 package org.ole.planet.myplanet.lite
-
 import android.content.Intent
 import android.content.SharedPreferences
+import androidx.core.content.IntentCompat
 import androidx.fragment.app.Fragment
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.mlkit.common.sdkinternal.MlKitContext
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -15,16 +16,12 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyD
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import com.google.mlkit.common.sdkinternal.MlKitContext
-
 @RunWith(RobolectricTestRunner::class)
 class SurveyWizardActivityTest {
-
     @Before
     fun setUp() {
         val mockPrefs = mock(SharedPreferences::class.java)
         SecurePreferencesProvider.injectedPreferences = mockPrefs
-
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         try {
             MlKitContext.initializeIfNeeded(context)
@@ -32,21 +29,17 @@ class SurveyWizardActivityTest {
             // Ignore if already initialized
         }
     }
-
     @After
     fun tearDown() {
         SecurePreferencesProvider.injectedPreferences = null
     }
-
     @Test
     fun `onCreate with null survey finishes activity`() {
         val intent = Intent(ApplicationProvider.getApplicationContext(), SurveyWizardActivity::class.java)
         val controller = Robolectric.buildActivity(SurveyWizardActivity::class.java, intent)
         val activity = controller.create().get()
-
         assertTrue(activity.isFinishing)
     }
-
     @Test
     fun `onCreate with survey sets up toolbar and fragment`() {
         val surveyDocument = SurveyDocument(id = "survey123", name = "Test Survey")
@@ -58,27 +51,21 @@ class SurveyWizardActivityTest {
             courseId = "course1",
             isExam = true
         )
-
         val controller = Robolectric.buildActivity(SurveyWizardActivity::class.java, intent)
         val activity = controller.create().start().resume().visible().get()
-
         assertFalse(activity.isFinishing)
-
         // Verify toolbar setup
         val toolbar: MaterialToolbar = activity.findViewById(R.id.surveyWizardToolbar)
         assertNotNull(toolbar)
-
         // Verify fragment was added
         val fragment: Fragment? = activity.supportFragmentManager.findFragmentById(R.id.surveyWizardFragmentContainer)
         assertNotNull(fragment)
         assertTrue(fragment is SurveyWizardFragment)
     }
-
     @Test
     fun `newIntent creates correct intent`() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val surveyDocument = SurveyDocument(id = "survey123", name = "Test Survey")
-
         val intent = SurveyWizardActivity.newIntent(
             context = context,
             document = surveyDocument,
@@ -87,13 +74,10 @@ class SurveyWizardActivityTest {
             courseId = "course1",
             isExam = true
         )
-
         assertEquals(SurveyWizardActivity::class.java.name, intent.component?.className)
         assertTrue(intent.hasExtra(SurveyWizardActivity.EXTRA_DOCUMENT))
-
-        val extraDoc = intent.getSerializableExtra(SurveyWizardActivity.EXTRA_DOCUMENT) as SurveyDocument
+        val extraDoc = IntentCompat.getSerializableExtra(intent, SurveyWizardActivity.EXTRA_DOCUMENT, SurveyDocument::class.java)!!
         assertEquals("survey123", extraDoc.id)
-
         // Use reflection to get private constants for testing
         assertEquals("team1", intent.getStringExtra("extra_team_id"))
         assertEquals("Test Team", intent.getStringExtra("extra_team_name"))


### PR DESCRIPTION
This PR resolves a deprecation warning in the `SurveyWizardActivityTest.kt` unit test. 

Starting with Android API 33, `Intent.getSerializableExtra(String)` is deprecated. The recommended replacement for backward compatibility is `androidx.core.content.IntentCompat.getSerializableExtra(Intent, String, Class)`.

Additionally, following the project's formatting guidelines, I've:
1. Sorted the import statements alphabetically.
2. Removed unnecessary blank lines to 'compress' the source file.
3. Ensured no unused imports were left.

Verified the fix by running `./gradlew testDebugUnitTest --tests "org.ole.planet.myplanet.lite.SurveyWizardActivityTest"`, which now passes without the deprecation warning.

---
*PR created automatically by Jules for task [12674023351627397934](https://jules.google.com/task/12674023351627397934) started by @PlataformasInformaticas*