### PR TITLE
all: smoother importing (fixes #660)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 250
-        versionName = "0.2.50"
+        versionCode = 251
+        versionName = "0.2.51"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesFabMenuExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesFabMenuExtensions.kt
@@ -4,8 +4,8 @@ import android.view.ContextThemeWrapper
 import android.view.View
 import android.view.animation.LinearInterpolator
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.view.MenuCompat
 import androidx.core.content.FileProvider
+import androidx.core.view.MenuCompat
 import java.io.File
 
 internal fun DashboardResourcesPageFragment.showAddResourceMenu(anchor: View) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
@@ -1,13 +1,13 @@
 package org.ole.planet.myplanet.lite
 
+import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
-import androidx.core.view.isVisible
+import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferences
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
-import kotlinx.coroutines.launch
 
 internal fun DashboardResourcesPageFragment.refreshContent(forceRefresh: Boolean = false) {
         val content = contentView ?: return

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
@@ -14,8 +14,8 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.FileProvider
-import org.ole.planet.myplanet.lite.util.RecordingWaveformView
 import java.io.File
+import org.ole.planet.myplanet.lite.util.RecordingWaveformView
 
 @SuppressLint("SetTextI18n")
 internal fun DashboardResourcesPageFragment.showRecordAudioPopup() {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadDocumentImageExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadDocumentImageExtensions.kt
@@ -13,13 +13,13 @@ import android.widget.Spinner
 import android.widget.TextView
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.Glide
 import com.google.android.material.slider.Slider
 import java.io.File
 import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import com.bumptech.glide.Glide
 import org.json.JSONArray
 import org.json.JSONObject
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -29,7 +29,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.AppCompatImageView
@@ -39,7 +38,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -18,7 +18,6 @@ import org.json.JSONObject
 import org.ole.planet.myplanet.lite.util.BirthDateString
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 
-
 class DashboardResourcesRepository {
 
     private val client: OkHttpClient = OkHttpClient.Builder().build()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -6,17 +6,11 @@
 
 package org.ole.planet.myplanet.lite.dashboard
 
-import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.ToJson
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
-import java.text.ParseException
-import java.text.SimpleDateFormat
-import java.util.Locale
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -31,7 +25,6 @@ import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.ole.planet.myplanet.lite.util.BirthDateString
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 import org.ole.planet.myplanet.lite.util.nullIfBlank
-
 
 class DashboardTeamsRepository(
     private val client: OkHttpClient = OkHttpClient.Builder().build(),

--- a/app/src/test/java/org/ole/planet/myplanet/lite/BaseActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/BaseActivityTest.kt
@@ -1,6 +1,5 @@
 package org.ole.planet.myplanet.lite
 
-import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.ActivityInfo
 import android.os.Build
@@ -13,8 +12,8 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import org.junit.After

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardActivityTest.kt
@@ -18,10 +18,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
-import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardSurveysFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardSurveysFragmentTest.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.lite
 
 import android.content.Context
-import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragmentTest.kt
@@ -6,24 +6,22 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.ole.planet.myplanet.lite.dashboard.DashboardOfflineSurveyStore
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
-import org.ole.planet.myplanet.lite.dashboard.DashboardOfflineSurveyStore
-import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore
-import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamsFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamsFragmentTest.kt
@@ -1,7 +1,6 @@
 package org.ole.planet.myplanet.lite
 
 import android.content.Context
-import android.content.ContextWrapper
 import android.content.SharedPreferences
 import android.widget.FrameLayout
 import android.widget.ImageButton

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardVoicesFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardVoicesFragmentTest.kt
@@ -3,22 +3,20 @@ package org.ole.planet.myplanet.lite
 import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.fragment.app.testing.FragmentScenario
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.shadows.ShadowLooper
 import org.mockito.Mockito
-import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ApplicationProvider
-import org.junit.After
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLooper
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], instrumentedPackages = ["androidx.loader.content"]) // Helps prevent FragmentScenario crash

--- a/app/src/test/java/org/ole/planet/myplanet/lite/MyPlanetLiteTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/MyPlanetLiteTest.kt
@@ -9,10 +9,10 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
-import org.robolectric.annotation.Config
-import org.robolectric.android.controller.ActivityController
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
+import org.robolectric.Robolectric
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.P])

--- a/app/src/test/java/org/ole/planet/myplanet/lite/PrivacyPolicyActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/PrivacyPolicyActivityTest.kt
@@ -1,8 +1,8 @@
 package org.ole.planet.myplanet.lite
 
 import android.content.Context
-import android.widget.TextView
 import android.widget.ImageButton
+import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.appbar.MaterialToolbar
 import org.junit.Assert.assertNotNull
@@ -10,10 +10,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.controller.ActivityController
-import org.mockito.Mockito
 
 @RunWith(RobolectricTestRunner::class)
 class PrivacyPolicyActivityTest {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SignupActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SignupActivityTest.kt
@@ -1,22 +1,21 @@
 package org.ole.planet.myplanet.lite
 
-import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Looper
-import android.view.View
 import android.widget.AutoCompleteTextView
 import android.widget.RadioGroup
-import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
-import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
-import com.google.android.material.textfield.TextInputLayout
 import java.lang.reflect.Method
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.jvm.isAccessible
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -30,21 +29,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
-import org.ole.planet.myplanet.lite.profile.GENDER_FEMALE
+import org.mockito.Mockito.mock
 import org.ole.planet.myplanet.lite.profile.GENDER_MALE
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
-import kotlin.reflect.full.memberFunctions
-import kotlin.reflect.full.callSuspend
-import kotlin.reflect.jvm.isAccessible
-import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.advanceUntilIdle
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SplashScreenTest.kt
@@ -8,14 +8,7 @@ import android.net.NetworkCapabilities
 import android.os.Looper
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -32,12 +25,9 @@ import org.ole.planet.myplanet.lite.auth.UserCredentials
 import org.ole.planet.myplanet.lite.profile.UserProfile
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
-import org.robolectric.shadows.ShadowConnectivityManager
 import org.robolectric.shadows.ShadowNetworkCapabilities
-import java.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardActivityTest.kt
@@ -1,4 +1,5 @@
 package org.ole.planet.myplanet.lite
+
 import android.content.Intent
 import android.content.SharedPreferences
 import androidx.core.content.IntentCompat
@@ -7,7 +8,10 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.mlkit.common.sdkinternal.MlKitContext
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,6 +20,7 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyD
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+
 @RunWith(RobolectricTestRunner::class)
 class SurveyWizardActivityTest {
     @Before

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardFragmentTest.kt
@@ -1,19 +1,19 @@
 package org.ole.planet.myplanet.lite
 
+import android.os.Bundle
+import androidx.fragment.app.FragmentActivity
 import androidx.test.core.app.ApplicationProvider
+import com.google.mlkit.common.sdkinternal.MlKitContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowToast
-import android.os.Bundle
-import org.robolectric.Robolectric
-import androidx.fragment.app.FragmentActivity
-import com.google.mlkit.common.sdkinternal.MlKitContext
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/TeamsActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/TeamsActivityTest.kt
@@ -6,7 +6,6 @@ import android.widget.ImageButton
 import androidx.activity.OnBackPressedCallback
 import com.google.android.material.appbar.MaterialToolbar
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoaderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoaderTest.kt
@@ -27,7 +27,6 @@ import org.ole.planet.myplanet.lite.profile.AvatarUpdateNotifier
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowLog
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursePageFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursePageFragmentTest.kt
@@ -4,12 +4,12 @@ import android.os.Bundle
 import androidx.fragment.app.testing.launchFragmentInContainer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.junit.Before
-import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.ole.planet.myplanet.lite.DashboardCoursePageFragment
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
+import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class DashboardCoursePageFragmentTest {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMembersFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMembersFragmentTest.kt
@@ -1,13 +1,10 @@
 package org.ole.planet.myplanet.lite.dashboard
 
-import android.content.Context
 import android.content.SharedPreferences
-import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.recyclerview.widget.RecyclerView
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.R as MaterialR
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -24,13 +21,9 @@ import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.auth.AuthResult
 import org.ole.planet.myplanet.lite.auth.AuthService
 import org.ole.planet.myplanet.lite.auth.UserCredentials
-import org.ole.planet.myplanet.lite.dashboard.DashboardTeamsRepository.TeamMemberDetails
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
-import java.util.concurrent.TimeUnit
-import com.google.android.material.R as MaterialR
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepositoryTest.kt
@@ -11,9 +11,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SubmissionParent
 import org.ole.planet.myplanet.lite.dashboard.DashboardOfflineSurveyStore
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SubmissionParent
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SubmissionUser
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument


### PR DESCRIPTION
🧹 Sort imports, expand catchalls, and remove unused

🎯 **What:**
Sorted all Kotlin imports alphabetically, expanded catchall imports (like `org.junit.Assert.*`), removed unused imports, and ensured exactly one empty line before and after the import blocks across the repository, while strictly preserving file-level comments and without running `ktlint`.

💡 **Why:**
To improve code health, readability, and satisfy the user's specific formatting requirements for Kotlin files.

✅ **Verification:**
Manually ran `./gradlew assembleDebug` and `./gradlew testDebugUnitTest` to verify that the project still compiles and tests pass without using the prohibited `./gradle test` command. Used a Python script to enforce constraints.

✨ **Result:**
Cleaner and properly sorted imports in Kotlin files.

---
*PR created automatically by Jules for task [5874487764219595954](https://jules.google.com/task/5874487764219595954) started by @dogi*