### PR TITLE
🧹 [Refactor CourseWizardActivity] Simplify advanceToNextStep and bindStep

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 256
+        versionName = "0.2.56"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -104,16 +104,7 @@ class CourseWizardActivity : BaseActivity() {
             }
             pendingExamStepIndex = null
             if (this::stepPositionView.isInitialized) {
-                bindStep(
-                    stepPositionView,
-                    stepTitleView,
-                    descriptionView,
-                    attachmentsContainer,
-                    attachmentsTitle,
-                    attachmentsList,
-                    previousButton,
-                    nextButton
-                )
+                    bindStep()
             }
         }
 
@@ -137,16 +128,7 @@ class CourseWizardActivity : BaseActivity() {
             flushPendingExamSubmissions()
             flushPendingCourseProgress()
             currentIndex = resolveInitialStepIndex(startIndex)
-            bindStep(
-                stepPositionView,
-                stepTitleView,
-                descriptionView,
-                attachmentsContainer,
-                attachmentsTitle,
-                attachmentsList,
-                previousButton,
-                nextButton
-            )
+            bindStep()
             maybeAutoCompleteFirstStep()
         }
     }
@@ -250,16 +232,7 @@ class CourseWizardActivity : BaseActivity() {
         }
     }
 
-    private fun bindStep(
-        stepPositionView: TextView,
-        stepTitleView: TextView,
-        descriptionView: TextView,
-        attachmentsContainer: LinearLayout,
-        attachmentsTitle: TextView,
-        attachmentsList: LinearLayout,
-        previousButton: View,
-        nextButton: View
-    ) {
+    private fun bindStep() {
         val step = steps[currentIndex]
         stepPositionView.text = getString(
             R.string.course_wizard_step_position,
@@ -283,44 +256,22 @@ class CourseWizardActivity : BaseActivity() {
         previousButton.setOnClickListener {
             if (currentIndex > 0) {
                 currentIndex -= 1
-                bindStep(
-                    stepPositionView,
-                    stepTitleView,
-                    descriptionView,
-                    attachmentsContainer,
-                    attachmentsTitle,
-                    attachmentsList,
-                    previousButton,
-                    nextButton
-                )
+                bindStep()
             }
         }
         val examPending = step.exam?.questions?.isNotEmpty() == true &&
                 !completedExamSteps.contains(currentIndex)
         if (currentIndex >= steps.lastIndex) {
             nextButton.isEnabled = true
-            if (nextButton is TextView) {
-                nextButton.text = getString(R.string.course_wizard_finish)
-            }
+            (nextButton as? TextView)?.text = getString(R.string.course_wizard_finish)
             nextButton.setOnClickListener { finish() }
         } else {
             nextButton.isEnabled = true
-            if (nextButton is TextView) {
-                nextButton.text = getString(R.string.course_wizard_next)
-            }
+            (nextButton as? TextView)?.text = getString(R.string.course_wizard_next)
             nextButton.setOnClickListener {
                 if (currentIndex < steps.lastIndex) {
                     lifecycleScope.launch {
-                        advanceToNextStep(
-                            stepPositionView,
-                            stepTitleView,
-                            descriptionView,
-                            attachmentsContainer,
-                            attachmentsTitle,
-                            attachmentsList,
-                            previousButton,
-                            nextButton
-                        )
+                        advanceToNextStep()
                     }
                 }
             }
@@ -330,32 +281,14 @@ class CourseWizardActivity : BaseActivity() {
         }
     }
 
-    private fun advanceToNextStep(
-        stepPositionView: TextView,
-        stepTitleView: TextView,
-        descriptionView: TextView,
-        attachmentsContainer: LinearLayout,
-        attachmentsTitle: TextView,
-        attachmentsList: LinearLayout,
-        previousButton: View,
-        nextButton: View
-    ) {
+    private fun advanceToNextStep() {
         val targetIndex = (currentIndex + 1).coerceAtMost(steps.lastIndex)
         val targetStepNumber = targetIndex + 1
         lifecycleScope.launch {
             runCatching { updateCourseProgressIfNeeded(targetStepNumber) }
         }
         currentIndex = targetIndex
-        bindStep(
-            stepPositionView,
-            stepTitleView,
-            descriptionView,
-            attachmentsContainer,
-            attachmentsTitle,
-            attachmentsList,
-            previousButton,
-            nextButton
-        )
+        bindStep()
     }
 
     private suspend fun updateCourseProgressIfNeeded(targetStepNumber: Int) {


### PR DESCRIPTION
🎯 **What:** The `advanceToNextStep` and `bindStep` methods in `CourseWizardActivity` had a Long Parameter List code smell, taking 8 view parameters each. These methods were refactored to take zero parameters, utilizing the Activity's properties instead.
💡 **Why:** This refactoring significantly reduces code complexity, making the codebase easier to maintain, read, and understand.
✅ **Verification:** Compiled code using `compileDebugKotlin compileDebugUnitTestKotlin compileReleaseKotlin` and ran the full unit test suite via `./gradlew test`. Verified no regressions were introduced.
✨ **Result:** The code is cleaner, and the `advanceToNextStep` and `bindStep` methods are now parameterless.

---
*PR created automatically by Jules for task [5419148900038264451](https://jules.google.com/task/5419148900038264451) started by @dogi*