### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 258
+        versionName = "0.2.58"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/auth/NetworkAuthServiceTest.kt
@@ -11,6 +11,7 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -362,6 +363,33 @@ class NetworkAuthServiceTest {
         val error = result as AuthResult.Error
         assertEquals(null, error.code)
         assertTrue(error.message.contains("Error de red: Custom IO error"))
+    }
+
+    @Test
+    fun `login io exception with real network client interceptor returns network error`() = runTest {
+        // Create an OkHttpClient that throws an IOException on any request using an Interceptor
+        val client = OkHttpClient.Builder()
+            .addInterceptor { _ ->
+                throw java.io.IOException("Mocked network client exception")
+            }
+            .build()
+
+        val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+        val retrofit = Retrofit.Builder()
+            .baseUrl("http://localhost/")
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+
+        val customApi = retrofit.create(AuthApi::class.java)
+        val customService = NetworkAuthService(customApi, tokenStorage, Dispatchers.Unconfined)
+
+        val result = customService.login("user", "pass")
+
+        assertTrue(result is AuthResult.Error)
+        val error = result as AuthResult.Error
+        assertEquals(null, error.code)
+        assertTrue(error.message.contains("Error de red: Mocked network client exception"))
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** Added a unit test to cover the `IOException` error path in `AuthService.login`, simulating a network client failure using an `OkHttpClient` interceptor.
📊 **Coverage:** The test explicitly verifies that a thrown `IOException` during the network call is correctly caught and mapped to an `AuthResult.Error` with the expected "Error de red" prefix.
✨ **Result:** Improved test reliability and coverage for real network-level exceptions in the authentication service.

---
*PR created automatically by Jules for task [17832972813744727113](https://jules.google.com/task/17832972813744727113) started by @dogi*