### PR TITLE
🧪 [Add tests for extensionForImageMimeType in DashboardResourcesMediaUtils]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 258
-        versionName = "0.2.58"
+        versionCode = 259
+        versionName = "0.2.59"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1,0 +1,30 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DashboardResourcesMediaUtilsTest {
+
+    @Test
+    fun `extensionForImageMimeType returns png for png mime types`() {
+        assertEquals("png", DashboardResourcesMediaUtils.extensionForImageMimeType("image/png"))
+        assertEquals("png", DashboardResourcesMediaUtils.extensionForImageMimeType("image/x-png"))
+        assertEquals("png", DashboardResourcesMediaUtils.extensionForImageMimeType("PNG"))
+    }
+
+    @Test
+    fun `extensionForImageMimeType returns webp for webp mime types`() {
+        assertEquals("webp", DashboardResourcesMediaUtils.extensionForImageMimeType("image/webp"))
+        assertEquals("webp", DashboardResourcesMediaUtils.extensionForImageMimeType("WEBP"))
+    }
+
+    @Test
+    fun `extensionForImageMimeType returns jpg as fallback for other mime types`() {
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("image/jpeg"))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("image/gif"))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("image/bmp"))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("application/pdf"))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType(""))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("UNKNOWN"))
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for `extensionForImageMimeType` in `DashboardResourcesMediaUtils.kt`.

📊 **Coverage:**
- Tests verify behavior for "image/png", "image/x-png" and "PNG" returning "png".
- Tests verify behavior for "image/webp" and "WEBP" returning "webp".
- Tests verify the fallback branch returns "jpg" for unknown mime types, non-image mime types, and empty strings.

✨ **Result:** Increased test coverage for standard image MIME types and edge cases ensuring deterministic extension extraction.

---
*PR created automatically by Jules for task [17415282978063992535](https://jules.google.com/task/17415282978063992535) started by @dogi*