### PR TITLE
🧪 [Add test cases for edge conditions in AuthUtils]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 260
+        versionName = "0.2.60"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/AuthUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/AuthUtilsTest.kt
@@ -82,4 +82,42 @@ class AuthUtilsTest {
         val url = "not_a_valid_url"
         assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
     }
+
+    @Test
+    fun isSecureAndTrustedUrl_noHost_returnsFalse() {
+        val base = "https://example.com"
+        val url = "file:///path/to/local/file"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_mixedCaseHttps_returnsTrue() {
+        val base = "https://example.com"
+        val url = "HTTPS://example.com/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_invalidPrivateIpClassA_returnsFalse() {
+        // 10.999.999.999 fails to parse as a valid URI, so URI.create throws and the catch block returns false
+        val base = "http://10.999.999.999"
+        val url = "http://10.999.999.999/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_invalidPrivateIpClassB_returnsFalse() {
+        // 172.32.0.0 is outside the 172.16-31 range.
+        val base = "http://172.32.0.0"
+        val url = "http://172.32.0.0/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_invalidPrivateIpClassC_returnsFalse() {
+        // 192.168.256.0 fails to parse as a valid URI, throwing an exception and returning false
+        val base = "http://192.168.256.0"
+        val url = "http://192.168.256.0/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `AuthUtils` validation has been addressed. Missing tests for mixed-case schemes, missing hosts, and invalid private IPs were added to the test suite to ensure comprehensive coverage.

📊 **Coverage:** The new tests cover:
- Edge case where `uri.host` is null (e.g., `file:///path`).
- Uppercase or mixed-case `HTTPS` schemes (e.g., `HTTPS://example.com`), ensuring `.lowercase()` is tested.
- Out of bound/invalid private IP address definitions (e.g., `10.999.999.999`, `172.32.0.0`, `192.168.256.0`), verifying robust failing for malicious or incorrectly formatted inputs.

✨ **Result:** Test coverage for `AuthUtils` is improved, establishing a better safety net for refactoring the URL and IP validation logic, and confirming that the current logic throws gracefully or correctly identifies invalid URL strings.

---
*PR created automatically by Jules for task [135634102246397236](https://jules.google.com/task/135634102246397236) started by @dogi*