### PR TITLE
🧪 Add tests for estimateAudioUploadSizeBytes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 261
+        versionName = "0.2.61"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -38,6 +38,7 @@ class DashboardResourcesMediaUtilsTest {
             151200000L,
             DashboardResourcesMediaUtils.estimateAudioUploadSizeBytes(320, 3600000L)
         )
+    }
     fun `extensionForImageMimeType returns png for png mime types`() {
         assertEquals("png", DashboardResourcesMediaUtils.extensionForImageMimeType("image/png"))
         assertEquals("png", DashboardResourcesMediaUtils.extensionForImageMimeType("image/x-png"))

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1,0 +1,42 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DashboardResourcesMediaUtilsTest {
+
+    @Test
+    fun testEstimateAudioUploadSizeBytes() {
+        // Standard scenario: 128 kbps, 60 seconds (60000ms)
+        // Math: 128000 bits/sec * 60 sec = 7680000 bits
+        // Bytes: 7680000 / 8 = 960000 bytes
+        // Overhead (1.05): 960000 * 1.05 = 1008000 bytes
+        assertEquals(
+            1008000L,
+            DashboardResourcesMediaUtils.estimateAudioUploadSizeBytes(128, 60000L)
+        )
+
+        // Zero scenario: 0 kbps, 0ms
+        // Expected: 1024L (fallback)
+        assertEquals(
+            1024L,
+            DashboardResourcesMediaUtils.estimateAudioUploadSizeBytes(0, 0L)
+        )
+
+        // Very short duration: 128 kbps, 1ms
+        // Bytes: 128000 * 0.001 / 8 = 16 bytes. With overhead -> 16.8 bytes.
+        // Expected: 1024L (fallback)
+        assertEquals(
+            1024L,
+            DashboardResourcesMediaUtils.estimateAudioUploadSizeBytes(128, 1L)
+        )
+
+        // Long duration scenario: 320 kbps, 1 hour (3600000ms)
+        // Math: 320000 * 3600 = 1152000000 bits -> 144000000 bytes
+        // Overhead: 144000000 * 1.05 = 151200000 bytes
+        assertEquals(
+            151200000L,
+            DashboardResourcesMediaUtils.estimateAudioUploadSizeBytes(320, 3600000L)
+        )
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the function `estimateAudioUploadSizeBytes` in `DashboardResourcesMediaUtils.kt` lacked test coverage.
📊 **Coverage:** The scenarios now tested include standard usage, very short duration fallback, zero duration/bitrate fallback, and long duration mathematical constraints.
✨ **Result:** The test coverage for `DashboardResourcesMediaUtils` is improved, ensuring the byte estimation math is correct and stable.

---
*PR created automatically by Jules for task [13317042986731131182](https://jules.google.com/task/13317042986731131182) started by @dogi*