### PR TITLE
🧪 Add tests for DashboardResourcesMediaUtils allowedVideoHeights

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 270
+        versionName = "0.2.70"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1,0 +1,46 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DashboardResourcesMediaUtilsTest {
+
+    @Test
+    fun testAllowedVideoHeights1080AndAbove() {
+        // >= 1080 -> listOf(480, 576, 720, 1080)
+        val expected = listOf(480, 576, 720, 1080)
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(1080))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(1920))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(2160)) // 4k
+    }
+
+    @Test
+    fun testAllowedVideoHeights720To1079() {
+        // >= 720 -> listOf(480, 576, 720)
+        val expected = listOf(480, 576, 720)
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(720))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(800))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(1079))
+    }
+
+    @Test
+    fun testAllowedVideoHeights576To719() {
+        // >= 576 -> listOf(480, 576)
+        val expected = listOf(480, 576)
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(576))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(600))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(719))
+    }
+
+    @Test
+    fun testAllowedVideoHeightsBelow576() {
+        // else -> listOf(480)
+        val expected = listOf(480)
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(575))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(480))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(360))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(240))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(0))
+        assertEquals(expected, DashboardResourcesMediaUtils.allowedVideoHeights(-10))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the pure function `allowedVideoHeights` inside `DashboardResourcesMediaUtils.kt`.
📊 **Coverage:** The new tests cover all branch conditions for source heights (`>= 1080`, `>= 720`, `>= 576`, and `< 576`), including edge cases like `0` and negative values.
✨ **Result:** The improvement in test coverage guarantees that any future refactoring of `allowedVideoHeights` will not introduce regressions without being caught by the test suite.

---
*PR created automatically by Jules for task [15632810339002737322](https://jules.google.com/task/15632810339002737322) started by @dogi*