### PR TITLE
🧪 [testing improvement] Add MarkdownUtils placeholder and altText tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 263
+        versionName = "0.2.63"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -150,7 +150,7 @@ class DashboardResourcesMediaUtilsTest {
         assertEquals(1, DashboardResourcesMediaUtils.resolveDefaultLanguageIndex(context, resources, options))
 
         // Test Spanish locale
-        val localesSpanish = android.os.LocaleList(Locale("es"))
+        val localesSpanish = android.os.LocaleList(Locale.forLanguageTag("es"))
         `when`(configuration.locales).thenReturn(localesSpanish)
         assertEquals(2, DashboardResourcesMediaUtils.resolveDefaultLanguageIndex(context, resources, options))
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/MarkdownUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/MarkdownUtilsTest.kt
@@ -99,4 +99,65 @@ class MarkdownUtilsTest {
         val expected = "![alt](http://base/db/image1.png) ![html](http://base/db/image2.png)"
         assertEquals(expected, result)
     }
+
+    @Test
+    fun replaceImagePlaceholder_emptyAltText_returnsReplacement() {
+        val source = "Some text ![](image.png) here"
+        val replacement = "![new](new.png)"
+        val expected = "Some text ![new](new.png) here"
+        assertEquals(expected, MarkdownUtils.replaceImagePlaceholder(source, "image.png", replacement))
+    }
+
+    @Test
+    fun replaceImagePlaceholder_withAltText_insertsAltTextIntoReplacement() {
+        val source = "Some text ![alt text](image.png) here"
+        val replacement = "![](new.png)"
+        val expected = "Some text ![alt text](new.png) here"
+        assertEquals(expected, MarkdownUtils.replaceImagePlaceholder(source, "image.png", replacement))
+    }
+
+    @Test
+    fun replaceImagePlaceholder_noMatch_appendsReplacement() {
+        val source = "Some text"
+        val replacement = "![new](new.png)"
+        val expected = "Some text\n\n![new](new.png)"
+        assertEquals(expected, MarkdownUtils.replaceImagePlaceholder(source, "image.png", replacement))
+
+        val sourceEmpty = ""
+        val expectedEmpty = "![new](new.png)"
+        assertEquals(expectedEmpty, MarkdownUtils.replaceImagePlaceholder(sourceEmpty, "image.png", replacement))
+    }
+
+    @Test
+    fun applyAltText_emptyAltText_returnsOriginal() {
+        val markdown = "![](image.png)"
+        assertEquals(markdown, MarkdownUtils.applyAltText(markdown, "   "))
+        assertEquals(markdown, MarkdownUtils.applyAltText(markdown, ""))
+    }
+
+    @Test
+    fun applyAltText_noBrackets_returnsOriginal() {
+        val markdown = "image.png"
+        assertEquals(markdown, MarkdownUtils.applyAltText(markdown, "alt text"))
+
+        val markdownMissingOpen = "image.png]"
+        assertEquals(markdownMissingOpen, MarkdownUtils.applyAltText(markdownMissingOpen, "alt text"))
+
+        val markdownMissingClose = "[image.png"
+        assertEquals(markdownMissingClose, MarkdownUtils.applyAltText(markdownMissingClose, "alt text"))
+
+        val markdownWrongOrder = "]image.png["
+        assertEquals(markdownWrongOrder, MarkdownUtils.applyAltText(markdownWrongOrder, "alt text"))
+    }
+
+    @Test
+    fun applyAltText_validBrackets_insertsAltText() {
+        val markdown = "![](image.png)"
+        val expected = "![myalt](image.png)"
+        assertEquals(expected, MarkdownUtils.applyAltText(markdown, "myalt"))
+
+        val markdownWithExisting = "![old](image.png)"
+        val expectedExisting = "![myalt](image.png)"
+        assertEquals(expectedExisting, MarkdownUtils.applyAltText(markdownWithExisting, "myalt"))
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `replaceImagePlaceholder` and `applyAltText` within `MarkdownUtilsTest.kt`.
📊 **Coverage:** Covered replacing placeholders with and without alt text modifications, fallback parsing for text without matching tokens, appending text properly, empty alt text handling, and string structures with malformed markdown brackets.
✨ **Result:** Test coverage significantly increased for `MarkdownUtils.kt`, ensuring string parsing behavior remains robust across different formatting configurations.

---
*PR created automatically by Jules for task [8064980262767076106](https://jules.google.com/task/8064980262767076106) started by @dogi*