### PR TITLE
🧪 Add tests for sha256 and legacySha1 in OfflineCourseStorage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 272
-        versionName = "0.2.72"
+        versionCode = 271
+        versionName = "0.2.71"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 271
-        versionName = "0.2.71"
+        versionCode = 272
+        versionName = "0.2.72"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 251
-        versionName = "0.2.51"
+        versionCode = 271
+        versionName = "0.2.71"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/OfflineCourseStorageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/OfflineCourseStorageTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.lite
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import java.io.File
+import java.lang.reflect.Method
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -286,5 +287,37 @@ class OfflineCourseStorageTest {
         assertNotNull(uri)
         assertTrue(uri?.startsWith("file:/") == true)
         assertTrue(uri?.endsWith(".jpg") == true)
+    }
+
+    @Test
+    fun testSha256() {
+        val method: Method = OfflineCourseStorage::class.java.getDeclaredMethod("sha256", String::class.java)
+        method.isAccessible = true
+
+        val input = "test string"
+        val expected = "d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b"
+        val result = method.invoke(OfflineCourseStorage, input) as String
+        assertEquals(expected, result)
+
+        val emptyInput = ""
+        val emptyExpected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        val emptyResult = method.invoke(OfflineCourseStorage, emptyInput) as String
+        assertEquals(emptyExpected, emptyResult)
+    }
+
+    @Test
+    fun testLegacySha1() {
+        val method: Method = OfflineCourseStorage::class.java.getDeclaredMethod("legacySha1", String::class.java)
+        method.isAccessible = true
+
+        val input = "test string"
+        val expected = "661295c9cbf9d6b2f6428414504a8deed3020641"
+        val result = method.invoke(OfflineCourseStorage, input) as String
+        assertEquals(expected, result)
+
+        val emptyInput = ""
+        val emptyExpected = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+        val emptyResult = method.invoke(OfflineCourseStorage, emptyInput) as String
+        assertEquals(emptyExpected, emptyResult)
     }
 }


### PR DESCRIPTION
🎯 **What:** The untested private functions `sha256` and `legacySha1` in `OfflineCourseStorage` were lacking explicit test coverage.

📊 **Coverage:** Added test coverage for `sha256` and `legacySha1` explicitly using reflection. Scenarios tested include standard string inputs and empty string edge cases with predefined known hash assertions.

✨ **Result:** Improved test coverage and reliability for pure hashing functions inside `OfflineCourseStorage` ensuring these critical hash utilities continue to work as expected.

---
*PR created automatically by Jules for task [3295263396194574850](https://jules.google.com/task/3295263396194574850) started by @dogi*