### PR TITLE
🔒 [security fix] Use Context.MODE_PRIVATE for SharedPreferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 250
-        versionName = "0.2.50"
+        versionCode = 265
+        versionName = "0.2.65"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceDownloadService.kt
@@ -23,7 +23,7 @@ internal class ResourceDownloadService(
     }
 
     fun loadDownloadedResources(): List<ResourceUi> {
-        val raw = context.getSharedPreferences(prefsName, 0)
+        val raw = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
             .getString(downloadedResourcesKey, "[]")
             .orEmpty()
         val json = runCatching { JSONArray(raw) }.getOrElse { JSONArray() }
@@ -53,7 +53,7 @@ internal class ResourceDownloadService(
     }
 
     fun upsertDownloadedResource(item: ResourceUi) {
-        val prefs = context.getSharedPreferences(prefsName, 0)
+        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
         val existing = runCatching {
             JSONArray(prefs.getString(downloadedResourcesKey, "[]").orEmpty())
         }.getOrElse { JSONArray() }
@@ -84,7 +84,7 @@ internal class ResourceDownloadService(
     }
 
     fun removeDownloadedResource(item: ResourceUi) {
-        val prefs = context.getSharedPreferences(prefsName, 0)
+        val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
         val existing = runCatching {
             JSONArray(prefs.getString(downloadedResourcesKey, "[]").orEmpty())
         }.getOrElse { JSONArray() }


### PR DESCRIPTION
🎯 **What:** Replaced the deprecated and potentially ambiguous use of the literal integer `0` with the explicit constant `Context.MODE_PRIVATE` in all `getSharedPreferences` calls within `ResourceDownloadService.kt`.
⚠️ **Risk:** While `0` currently maps to `MODE_PRIVATE`, using magic numbers for security-sensitive configurations can lead to accidental misconfigurations if other modes (like the deprecated `MODE_WORLD_READABLE`) were used by mistake.
🛡️ **Solution:** Updated the code to use the standard Android constant `Context.MODE_PRIVATE`, ensuring clarity and adherence to secure coding best practices.

---
*PR created automatically by Jules for task [4027938317827752836](https://jules.google.com/task/4027938317827752836) started by @dogi*