### PR TITLE
🧪 [Add unit tests for DashboardResourcesMediaUtils]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 250
-        versionName = "0.2.50"
+        versionCode = 272
+        versionName = "0.2.72"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1,0 +1,71 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DashboardResourcesMediaUtilsTest {
+
+    @Test
+    fun sanitizeResourceName_removesSpecialCharacters() {
+        assertEquals("My_Resource", DashboardResourcesMediaUtils.sanitizeResourceName("My Resource!"))
+        assertEquals("test-name_123", DashboardResourcesMediaUtils.sanitizeResourceName("test-name@123"))
+    }
+
+    @Test
+    fun sanitizeResourceName_collapsesUnderscores() {
+        assertEquals("a_b_c", DashboardResourcesMediaUtils.sanitizeResourceName("a____b!!!!c"))
+    }
+
+    @Test
+    fun sanitizeResourceName_trimsUnderscores() {
+        assertEquals("trimmed", DashboardResourcesMediaUtils.sanitizeResourceName("___trimmed___"))
+    }
+
+    @Test
+    fun sanitizeResourceName_handlesBlankInput() {
+        val result = DashboardResourcesMediaUtils.sanitizeResourceName("   ")
+        assertTrue(result.startsWith("resource_"))
+        assertTrue(result.substringAfter("resource_").toLong() > 0)
+    }
+
+    @Test
+    fun sanitizeResourceName_handlesEmptyInput() {
+        val result = DashboardResourcesMediaUtils.sanitizeResourceName("")
+        assertTrue(result.startsWith("resource_"))
+        assertTrue(result.substringAfter("resource_").toLong() > 0)
+    }
+
+    @Test
+    fun sanitizeResourceName_handlesOnlySpecialCharacters() {
+        val result = DashboardResourcesMediaUtils.sanitizeResourceName("!!!")
+        assertTrue(result.startsWith("resource_"))
+    }
+
+    @Test
+    fun normalizeResourceMediaType_returnsCorrectTypes() {
+        assertEquals("image", DashboardResourcesMediaUtils.normalizeResourceMediaType("image/jpeg"))
+        assertEquals("image", DashboardResourcesMediaUtils.normalizeResourceMediaType("IMAGE/PNG"))
+        assertEquals("video", DashboardResourcesMediaUtils.normalizeResourceMediaType("video/mp4"))
+        assertEquals("audio", DashboardResourcesMediaUtils.normalizeResourceMediaType("audio/mpeg"))
+        assertEquals("pdf", DashboardResourcesMediaUtils.normalizeResourceMediaType("application/pdf"))
+        assertEquals("text/plain", DashboardResourcesMediaUtils.normalizeResourceMediaType("text/plain"))
+    }
+
+    @Test
+    fun extensionForImageMimeType_returnsCorrectExtensions() {
+        assertEquals("png", DashboardResourcesMediaUtils.extensionForImageMimeType("image/png"))
+        assertEquals("webp", DashboardResourcesMediaUtils.extensionForImageMimeType("image/webp"))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("image/jpeg"))
+        assertEquals("jpg", DashboardResourcesMediaUtils.extensionForImageMimeType("unknown"))
+    }
+
+    @Test
+    fun formatDurationMs_formatsCorrectly() {
+        assertEquals("00:05", DashboardResourcesMediaUtils.formatDurationMs(5000))
+        assertEquals("01:05", DashboardResourcesMediaUtils.formatDurationMs(65000))
+        assertEquals("1:00:05", DashboardResourcesMediaUtils.formatDurationMs(3605000))
+        assertEquals("00:00", DashboardResourcesMediaUtils.formatDurationMs(0))
+        assertEquals("00:00", DashboardResourcesMediaUtils.formatDurationMs(-1000))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed.
- Added unit tests for `DashboardResourcesMediaUtils` utility functions which were previously untested.
- Specifically addressed the `ifBlank` edge case in `sanitizeResourceName`.

📊 **Coverage:** What scenarios are now tested.
- `sanitizeResourceName`: Basic sanitization, special characters, multiple underscores, trimming, and blank/empty/special-only inputs (triggering the `ifBlank` fallback).
- `normalizeResourceMediaType`: Correct normalization of image, video, audio, and PDF MIME types, as well as default behavior for others.
- `extensionForImageMimeType`: Correct mapping for PNG, WebP, and default (JPG) types.
- `formatDurationMs`: Correct formatting for durations under a minute, under an hour, over an hour, zero, and negative values.

✨ **Result:** The improvement in test coverage.
- Increased reliability of resource naming and media type handling.
- Ensured robust fallback behavior for blank resource names.
- Provided a safety net for future refactoring of these utility functions.

---
*PR created automatically by Jules for task [894683016488872302](https://jules.google.com/task/894683016488872302) started by @dogi*