### PR TITLE
all: smoother importing (fixes #715)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 273
-        versionName = "0.2.73"
+        versionCode = 274
+        versionName = "0.2.74"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -4,16 +4,17 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
+import java.util.Locale
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.*
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P])

--- a/app/src/test/java/org/ole/planet/myplanet/lite/ResourceDownloadServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/ResourceDownloadServiceTest.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.lite
 
 import android.content.Context
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
@@ -11,7 +12,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.annotation.Config
-import android.os.Build
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.P])


### PR DESCRIPTION
I processed all Kotlin (`.kt`) files across the codebase and rigorously applied the following rules via a custom formatting script:

1. **Sort all imports alphabetically.**
2. **Expand all catchall `.*` imports** (notably `org.mockito.Mockito.*`).
3. **Format import blocks** with exactly one empty line separating them from the package/header declaration and the main body.
4. **Preserve exact trailing newlines** at the end of the file.

*Note:* Because the script strictly checks formatting, Git only registered changes on two test files (`DashboardResourcesMediaUtilsTest.kt` and `ResourceDownloadServiceTest.kt`) that didn't already conform to this precise standard. The remainder of the Kotlin files were already properly formatted.

---
*PR created automatically by Jules for task [12278842184354829112](https://jules.google.com/task/12278842184354829112) started by @dogi*