### PR TITLE
🔒 Ensure atomic and synchronous migration of legacy preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ benchmark.kt
 app/baseline_time.txt
 
 plan.md
+
+.kotlin/sessions/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 276
-        versionName = "0.2.76"
+        versionCode = 275
+        versionName = "0.2.75"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 273
-        versionName = "0.2.73"
+        versionCode = 275
+        versionName = "0.2.75"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 275
-        versionName = "0.2.75"
+        versionCode = 276
+        versionName = "0.2.76"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProvider.kt
@@ -7,14 +7,8 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import java.security.KeyStore
 import javax.crypto.AEADBadTagException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 
 object SecurePreferencesProvider {
-    private val migrationScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     @androidx.annotation.VisibleForTesting
     var injectedPreferences: SharedPreferences? = null
 
@@ -64,8 +58,8 @@ object SecurePreferencesProvider {
                     val legacyFile = java.io.File(appContext.applicationInfo.dataDir, "shared_prefs/$legacyPrefsName.xml")
                     if (legacyFile.exists()) {
                         val legacyPrefs = appContext.getSharedPreferences(legacyPrefsName, Context.MODE_PRIVATE)
-                        val job = migrateLegacyPreferences(appContext, encryptedPrefs, legacyPrefs, legacyPrefsName)
-                        MigrationAwarePreferences(encryptedPrefs, legacyPrefs, job)
+                        migrateLegacyPreferences(appContext, encryptedPrefs, legacyPrefs, legacyPrefsName, legacyFile)
+                        encryptedPrefs
                     } else {
                         encryptedPrefs
                     }
@@ -146,119 +140,33 @@ object SecurePreferencesProvider {
         context: Context,
         encryptedPrefs: SharedPreferences,
         legacyPrefs: SharedPreferences,
-        legacyPrefsName: String
-    ): Job {
-        return migrationScope.launch {
-            val allLegacy = legacyPrefs.all
-            if (allLegacy.isNotEmpty()) {
-                val editor = encryptedPrefs.edit()
-                for ((key, value) in allLegacy) {
-                    if (encryptedPrefs.contains(key)) continue
-                    when (value) {
-                        is String -> editor.putString(key, value)
-                        is Int -> editor.putInt(key, value)
-                        is Boolean -> editor.putBoolean(key, value)
-                        is Float -> editor.putFloat(key, value)
-                        is Long -> editor.putLong(key, value)
-                        is Set<*> -> @Suppress("UNCHECKED_CAST") editor.putStringSet(key, value as Set<String>)
-                    }
+        legacyPrefsName: String,
+        legacyFile: java.io.File
+    ) {
+        val allLegacy = legacyPrefs.all
+        if (allLegacy.isNotEmpty()) {
+            val editor = encryptedPrefs.edit()
+            for ((key, value) in allLegacy) {
+                if (encryptedPrefs.contains(key)) continue
+                when (value) {
+                    is String -> editor.putString(key, value)
+                    is Int -> editor.putInt(key, value)
+                    is Boolean -> editor.putBoolean(key, value)
+                    is Float -> editor.putFloat(key, value)
+                    is Long -> editor.putLong(key, value)
+                    is Set<*> -> @Suppress("UNCHECKED_CAST") editor.putStringSet(key, value as Set<String>)
                 }
-                if (editor.commit()) {
-                    context.deleteSharedPreferences(legacyPrefsName)
-                }
-            } else {
+            }
+            if (editor.commit()) {
+                legacyPrefs.edit().clear().apply()
                 context.deleteSharedPreferences(legacyPrefsName)
+                legacyFile.delete()
             }
+        } else {
+            legacyPrefs.edit().clear().apply()
+            context.deleteSharedPreferences(legacyPrefsName)
+            legacyFile.delete()
         }
     }
 
-    private class MigrationAwarePreferences(
-        private val encryptedPrefs: SharedPreferences,
-        private val legacyPrefs: SharedPreferences,
-        private val migrationJob: Job
-    ) : SharedPreferences {
-        override fun getAll(): Map<String, *> {
-            return if (migrationJob.isActive) {
-                val combined = legacyPrefs.all.toMutableMap()
-                combined.putAll(encryptedPrefs.all)
-                combined
-            } else {
-                encryptedPrefs.all
-            }
-        }
-
-        override fun getString(key: String?, defValue: String?): String? {
-            return if (encryptedPrefs.contains(key)) {
-                encryptedPrefs.getString(key, defValue)
-            } else if (migrationJob.isActive) {
-                legacyPrefs.getString(key, defValue)
-            } else {
-                defValue
-            }
-        }
-
-        override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? {
-            return if (encryptedPrefs.contains(key)) {
-                encryptedPrefs.getStringSet(key, defValues)
-            } else if (migrationJob.isActive) {
-                legacyPrefs.getStringSet(key, defValues)
-            } else {
-                defValues
-            }
-        }
-
-        override fun getInt(key: String?, defValue: Int): Int {
-            return if (encryptedPrefs.contains(key)) {
-                encryptedPrefs.getInt(key, defValue)
-            } else if (migrationJob.isActive) {
-                legacyPrefs.getInt(key, defValue)
-            } else {
-                defValue
-            }
-        }
-
-        override fun getLong(key: String?, defValue: Long): Long {
-            return if (encryptedPrefs.contains(key)) {
-                encryptedPrefs.getLong(key, defValue)
-            } else if (migrationJob.isActive) {
-                legacyPrefs.getLong(key, defValue)
-            } else {
-                defValue
-            }
-        }
-
-        override fun getFloat(key: String?, defValue: Float): Float {
-            return if (encryptedPrefs.contains(key)) {
-                encryptedPrefs.getFloat(key, defValue)
-            } else if (migrationJob.isActive) {
-                legacyPrefs.getFloat(key, defValue)
-            } else {
-                defValue
-            }
-        }
-
-        override fun getBoolean(key: String?, defValue: Boolean): Boolean {
-            return if (encryptedPrefs.contains(key)) {
-                encryptedPrefs.getBoolean(key, defValue)
-            } else if (migrationJob.isActive) {
-                legacyPrefs.getBoolean(key, defValue)
-            } else {
-                defValue
-            }
-        }
-
-        override fun contains(key: String?): Boolean {
-            return encryptedPrefs.contains(key) || (migrationJob.isActive && legacyPrefs.contains(key))
-        }
-
-        override fun edit(): SharedPreferences.Editor = encryptedPrefs.edit()
-
-        override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-            encryptedPrefs.registerOnSharedPreferenceChangeListener(listener)
-        }
-
-        override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-            encryptedPrefs.unregisterOnSharedPreferenceChangeListener(listener)
-        }
-    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/SecurePreferencesProviderTest.kt
@@ -6,8 +6,6 @@ import android.content.SharedPreferences
 import android.content.pm.ApplicationInfo
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -92,75 +90,84 @@ class SecurePreferencesProviderTest {
 
     @Test
     fun `migrateLegacyPreferences migrates data and deletes legacy prefs`() {
-        runBlocking {
-            val mockLegacyPrefs = mock(SharedPreferences::class.java)
-            val mockEncryptedPrefs = mock(SharedPreferences::class.java)
-            val mockEncryptedEditor = mock(SharedPreferences.Editor::class.java)
+        val mockLegacyPrefs = mock(SharedPreferences::class.java)
+        val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+        val mockEncryptedEditor = mock(SharedPreferences.Editor::class.java)
+        val mockLegacyEditor = mock(SharedPreferences.Editor::class.java)
+        val mockLegacyFile = mock(java.io.File::class.java)
 
-            `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
-                .thenReturn(mockLegacyPrefs)
+        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
+            .thenReturn(mockLegacyPrefs)
 
-            val legacyData = mapOf<String, Any?>(
-                "string_key" to "value",
-                "int_key" to 42,
-                "bool_key" to true,
-                "float_key" to 3.14f,
-                "long_key" to 100L,
-                "set_key" to setOf("a", "b")
-            )
+        val legacyData = mapOf<String, Any?>(
+            "string_key" to "value",
+            "int_key" to 42,
+            "bool_key" to true,
+            "float_key" to 3.14f,
+            "long_key" to 100L,
+            "set_key" to setOf("a", "b")
+        )
 
-            `when`(mockLegacyPrefs.all).thenReturn(legacyData)
-            `when`(mockEncryptedPrefs.edit()).thenReturn(mockEncryptedEditor)
-            `when`(mockEncryptedEditor.commit()).thenReturn(true)
+        `when`(mockLegacyPrefs.all).thenReturn(legacyData)
+        `when`(mockEncryptedPrefs.edit()).thenReturn(mockEncryptedEditor)
+        `when`(mockEncryptedEditor.commit()).thenReturn(true)
+        `when`(mockLegacyPrefs.edit()).thenReturn(mockLegacyEditor)
+        `when`(mockLegacyEditor.clear()).thenReturn(mockLegacyEditor)
 
-            val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
-                "migrateLegacyPreferences",
-                Context::class.java,
-                SharedPreferences::class.java,
-                SharedPreferences::class.java,
-                String::class.java
-            )
-            method.isAccessible = true
-            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs, "server_preferences") as Job
-            job.join()
+        val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
+            "migrateLegacyPreferences",
+            Context::class.java,
+            SharedPreferences::class.java,
+            SharedPreferences::class.java,
+            String::class.java,
+            java.io.File::class.java
+        )
+        method.isAccessible = true
+        method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs, "server_preferences", mockLegacyFile)
 
-            verify(mockEncryptedEditor).putString("string_key", "value")
-            verify(mockEncryptedEditor).putInt("int_key", 42)
-            verify(mockEncryptedEditor).putBoolean("bool_key", true)
-            verify(mockEncryptedEditor).putFloat("float_key", 3.14f)
-            verify(mockEncryptedEditor).putLong("long_key", 100L)
-            verify(mockEncryptedEditor).putStringSet("set_key", setOf("a", "b"))
-            verify(mockEncryptedEditor).commit()
+        verify(mockEncryptedEditor).putString("string_key", "value")
+        verify(mockEncryptedEditor).putInt("int_key", 42)
+        verify(mockEncryptedEditor).putBoolean("bool_key", true)
+        verify(mockEncryptedEditor).putFloat("float_key", 3.14f)
+        verify(mockEncryptedEditor).putLong("long_key", 100L)
+        verify(mockEncryptedEditor).putStringSet("set_key", setOf("a", "b"))
+        verify(mockEncryptedEditor).commit()
 
-            verify(mockContext).deleteSharedPreferences("server_preferences")
-        }
+        verify(mockLegacyEditor).clear()
+        verify(mockLegacyEditor).apply()
+        verify(mockContext).deleteSharedPreferences("server_preferences")
+        verify(mockLegacyFile).delete()
     }
 
     @Test
     fun `migrateLegacyPreferences deletes legacy prefs when they are empty`() {
-        runBlocking {
-            val mockLegacyPrefs = mock(SharedPreferences::class.java)
-            val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+        val mockLegacyPrefs = mock(SharedPreferences::class.java)
+        val mockEncryptedPrefs = mock(SharedPreferences::class.java)
+        val mockLegacyEditor = mock(SharedPreferences.Editor::class.java)
+        val mockLegacyFile = mock(java.io.File::class.java)
 
-            `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
-                .thenReturn(mockLegacyPrefs)
+        `when`(mockContext.getSharedPreferences("server_preferences", Context.MODE_PRIVATE))
+            .thenReturn(mockLegacyPrefs)
 
-            `when`(mockLegacyPrefs.all).thenReturn(emptyMap<String, Any?>())
+        `when`(mockLegacyPrefs.all).thenReturn(emptyMap<String, Any?>())
+        `when`(mockLegacyPrefs.edit()).thenReturn(mockLegacyEditor)
+        `when`(mockLegacyEditor.clear()).thenReturn(mockLegacyEditor)
 
-            val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
-                "migrateLegacyPreferences",
-                Context::class.java,
-                SharedPreferences::class.java,
-                SharedPreferences::class.java,
-                String::class.java
-            )
-            method.isAccessible = true
-            val job = method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs, "server_preferences") as Job
-            job.join()
+        val method = SecurePreferencesProvider::class.java.getDeclaredMethod(
+            "migrateLegacyPreferences",
+            Context::class.java,
+            SharedPreferences::class.java,
+            SharedPreferences::class.java,
+            String::class.java,
+            java.io.File::class.java
+        )
+        method.isAccessible = true
+        method.invoke(SecurePreferencesProvider, mockContext, mockEncryptedPrefs, mockLegacyPrefs, "server_preferences", mockLegacyFile)
 
-            verify(mockEncryptedPrefs, never()).edit()
-            verify(mockLegacyPrefs, never()).edit()
-            verify(mockContext).deleteSharedPreferences("server_preferences")
-        }
+        verify(mockEncryptedPrefs, never()).edit()
+        verify(mockLegacyEditor).clear()
+        verify(mockLegacyEditor).apply()
+        verify(mockContext).deleteSharedPreferences("server_preferences")
+        verify(mockLegacyFile).delete()
     }
 }


### PR DESCRIPTION
🎯 **What:** The `SecurePreferencesProvider` used a `MigrationAwarePreferences` wrapper that asynchronously migrated unencrypted legacy preferences to encrypted storage while still allowing access to the plaintext data during the migration window.
⚠️ **Risk:** If the background migration coroutine failed or was interrupted, the legacy plaintext file would remain on the device indefinitely, posing a security risk of unencrypted sensitive data exposure. Furthermore, the fallback inherently read the unencrypted values.
🛡️ **Solution:** Enforced an atomic and synchronous migration process. The legacy data is copied synchronously, committed to the encrypted store, and the old legacy file is securely and immediately wiped from the disk. This eliminates the vulnerability window and forces all reads to go through the encrypted store.

---
*PR created automatically by Jules for task [3155012632031643116](https://jules.google.com/task/3155012632031643116) started by @dogi*