### PR TITLE
🧪 Add tests for DateStringAdapter JSON serialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 273
-        versionName = "0.2.73"
+        versionCode = 276
+        versionName = "0.2.76"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DateStringAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DateStringAdapterTest.kt
@@ -1,0 +1,80 @@
+package org.ole.planet.myplanet.lite.util
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.util.TimeZone
+
+class DateStringAdapterTest {
+    private lateinit var adapter: DateStringAdapter
+    private val originalTimeZone = TimeZone.getDefault()
+
+    @Before
+    fun setUp() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        adapter = DateStringAdapter()
+    }
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(originalTimeZone)
+    }
+
+    @Test
+    fun `fromJson returns long when input is a Number`() {
+        val input = 1672531200000L
+        val result = adapter.fromJson(input)
+        assertEquals(input, result)
+    }
+
+    @Test
+    fun `fromJson returns long when input is a valid ISO date string`() {
+        val input = "2023-01-01T00:00:00Z"
+        val expected = 1672531200000L
+        val result = adapter.fromJson(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `fromJson returns long when input is a numeric string`() {
+        val input = "1672531200000"
+        val expected = 1672531200000L
+        val result = adapter.fromJson(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `fromJson returns null when input is an invalid string`() {
+        val input = "not-a-date"
+        val result = adapter.fromJson(input)
+        assertNull(result)
+    }
+
+    @Test
+    fun `fromJson returns null when input is null`() {
+        val result = adapter.fromJson(null)
+        assertNull(result)
+    }
+
+    @Test
+    fun `fromJson returns null when input is an unsupported type`() {
+        val result = adapter.fromJson(true)
+        assertNull(result)
+    }
+
+    @Test
+    fun `toJson returns ISO date string when input is a Long`() {
+        val input = 1672531200000L
+        val expected = "2023-01-01T00:00:00Z"
+        val result = adapter.toJson(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `toJson returns null when input is null`() {
+        val result = adapter.toJson(null)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for `DateStringAdapter` to ensure reliable JSON serialization and deserialization of birth dates.
📊 **Coverage:**
- `fromJson` conversion from `Number` (Long).
- `fromJson` conversion from valid ISO 8601 date strings.
- `fromJson` conversion from numeric strings.
- `fromJson` handling of invalid strings, nulls, and unsupported types.
- `toJson` conversion from `Long` to ISO 8601 date string.
- `toJson` handling of null values.
✨ **Result:** Improved test coverage for utility classes, ensuring date transformations are handled correctly and consistently across different input formats.

---
*PR created automatically by Jules for task [16443090032783496995](https://jules.google.com/task/16443090032783496995) started by @dogi*