### PR TITLE
🧪 Add tests for NetworkUtils.isDeviceOnline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 274
-        versionName = "0.2.74"
+        versionCode = 278
+        versionName = "0.2.78"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/NetworkUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/NetworkUtilsTest.kt
@@ -1,0 +1,78 @@
+package org.ole.planet.myplanet.lite.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class NetworkUtilsTest {
+
+    @Test
+    fun `isDeviceOnline returns false when ConnectivityManager is null`() {
+        val context = mock<Context> {
+            on { getSystemService(Context.CONNECTIVITY_SERVICE) } doReturn null
+        }
+        assertFalse(NetworkUtils.isDeviceOnline(context))
+    }
+
+    @Test
+    fun `isDeviceOnline returns false when activeNetwork is null`() {
+        val connectivityManager = mock<ConnectivityManager> {
+            on { activeNetwork } doReturn null
+        }
+        val context = mock<Context> {
+            on { getSystemService(Context.CONNECTIVITY_SERVICE) } doReturn connectivityManager
+        }
+        assertFalse(NetworkUtils.isDeviceOnline(context))
+    }
+
+    @Test
+    fun `isDeviceOnline returns false when NetworkCapabilities is null`() {
+        val network = mock<Network>()
+        val connectivityManager = mock<ConnectivityManager> {
+            on { activeNetwork } doReturn network
+            on { getNetworkCapabilities(network) } doReturn null
+        }
+        val context = mock<Context> {
+            on { getSystemService(Context.CONNECTIVITY_SERVICE) } doReturn connectivityManager
+        }
+        assertFalse(NetworkUtils.isDeviceOnline(context))
+    }
+
+    @Test
+    fun `isDeviceOnline returns false when no INTERNET capability`() {
+        val networkCapabilities = mock<NetworkCapabilities> {
+            on { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } doReturn false
+        }
+        val network = mock<Network>()
+        val connectivityManager = mock<ConnectivityManager> {
+            on { activeNetwork } doReturn network
+            on { getNetworkCapabilities(network) } doReturn networkCapabilities
+        }
+        val context = mock<Context> {
+            on { getSystemService(Context.CONNECTIVITY_SERVICE) } doReturn connectivityManager
+        }
+        assertFalse(NetworkUtils.isDeviceOnline(context))
+    }
+
+    @Test
+    fun `isDeviceOnline returns true when INTERNET capability is present`() {
+        val networkCapabilities = mock<NetworkCapabilities> {
+            on { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } doReturn true
+        }
+        val network = mock<Network>()
+        val connectivityManager = mock<ConnectivityManager> {
+            on { activeNetwork } doReturn network
+            on { getNetworkCapabilities(network) } doReturn networkCapabilities
+        }
+        val context = mock<Context> {
+            on { getSystemService(Context.CONNECTIVITY_SERVICE) } doReturn connectivityManager
+        }
+        assertTrue(NetworkUtils.isDeviceOnline(context))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `NetworkUtils.isDeviceOnline` has been addressed by writing a new unit test class.
📊 **Coverage:** Scenarios covered:
- Returns false when `ConnectivityManager` is null.
- Returns false when `activeNetwork` is null.
- Returns false when `NetworkCapabilities` is null.
- Returns false when `INTERNET` capability is missing.
- Returns true when `INTERNET` capability is present.
✨ **Result:** Test coverage for this network utility is now verified, ensuring greater confidence in the device connectivity checks.

---
*PR created automatically by Jules for task [412152075078452266](https://jules.google.com/task/412152075078452266) started by @dogi*