### PR TITLE
🧪 Add tests for DeviceUtils.getDeviceName

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 274
-        versionName = "0.2.74"
+        versionCode = 279
+        versionName = "0.2.79"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DeviceUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DeviceUtilsTest.kt
@@ -1,0 +1,87 @@
+package org.ole.planet.myplanet.lite.util
+
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceUtilsTest {
+
+    @Test
+    fun getDeviceName_returnsManufacturerAndModel() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Sony")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Xperia Z5")
+
+        assertEquals("Sony Xperia Z5", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_manufacturerIsEmpty_returnsModel() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Pixel 6")
+
+        assertEquals("Pixel 6", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_modelIsEmpty_returnsManufacturer() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Google")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "")
+
+        assertEquals("Google", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_manufacturerAndModelAreEmpty_returnsDevice() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "")
+        ReflectionHelpers.setStaticField(Build::class.java, "DEVICE", "Custom Device")
+
+        assertEquals("Custom Device", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_manufacturerModelAndDeviceAreEmpty_returnsDefault() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "")
+        ReflectionHelpers.setStaticField(Build::class.java, "DEVICE", "")
+
+        assertEquals("Android Device", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_modelStartsWithManufacturer_returnsModel() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Samsung")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Samsung Galaxy S22")
+
+        assertEquals("Samsung Galaxy S22", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_modelStartsWithManufacturerIgnoreCase_returnsModel() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "samsung")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Samsung Galaxy S22")
+
+        assertEquals("Samsung Galaxy S22", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_trimsWhitespace() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "  Google  ")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "  Pixel 6  ")
+
+        assertEquals("Google Pixel 6", DeviceUtils.getDeviceName())
+    }
+
+    @Test
+    fun getDeviceName_nullManufacturerAndModel_returnsDefault() {
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", null)
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", null)
+        ReflectionHelpers.setStaticField(Build::class.java, "DEVICE", null)
+
+        assertEquals("Android Device", DeviceUtils.getDeviceName())
+    }
+}


### PR DESCRIPTION
🎯 **What:** Adding comprehensive unit tests for `DeviceUtils.getDeviceName` to cover all scenarios for returning the device name based on `Build` properties.
📊 **Coverage:** Covered normal cases, empty/null values, whitespace trimming, and the case where the model begins with the manufacturer name.
✨ **Result:** Improved test coverage and ensured deterministic behavior for device naming.

---
*PR created automatically by Jules for task [3690142911954113497](https://jules.google.com/task/3690142911954113497) started by @dogi*