### PR TITLE
🧪 Add tests for ProfileCredentialsStore temporary password handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 }
 
 tasks.withType<Test>().configureEach {
+    jvmArgs("-Xshare:off")
     systemProperty("robolectric.logging", "none")
     systemProperty("robolectric.logging.enabled", "false")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 274
-        versionName = "0.2.74"
+        versionCode = 280
+        versionName = "0.2.80"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/ProfileCredentialsStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/ProfileCredentialsStoreTest.kt
@@ -9,7 +9,10 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
@@ -17,14 +20,19 @@ class ProfileCredentialsStoreTest {
     private lateinit var mockContext: Context
     private lateinit var mockAppContext: Context
     private lateinit var mockPrefs: SharedPreferences
+    private lateinit var mockEditor: SharedPreferences.Editor
 
     @Before
     fun setup() {
         mockContext = mock()
         mockAppContext = mock()
         mockPrefs = mock()
+        mockEditor = mock()
 
         whenever(mockContext.applicationContext).thenReturn(mockAppContext)
+        whenever(mockPrefs.edit()).thenReturn(mockEditor)
+        whenever(mockEditor.putString(any(), any())).thenReturn(mockEditor)
+        whenever(mockEditor.remove(any())).thenReturn(mockEditor)
         SecurePreferencesProvider.resetForTesting()
         SecurePreferencesProvider.injectedPreferences = mockPrefs
 
@@ -88,5 +96,39 @@ class ProfileCredentialsStoreTest {
         val result = ProfileCredentialsStore.getStoredCredentials(mockContext)
 
         assertNull(result)
+    }
+
+    @Test
+    fun `test saveTemporarySignUpPassword stores password correctly`() {
+        val password = "tempPassword123"
+
+        ProfileCredentialsStore.saveTemporarySignUpPassword(mockContext, password)
+
+        verify(mockPrefs).edit()
+        verify(mockEditor).putString(eq("temp_signup_password"), eq(password))
+        verify(mockEditor).apply()
+    }
+
+    @Test
+    fun `test consumeTemporarySignUpPassword returns value and clears when present`() {
+        val password = "tempPassword123"
+        whenever(mockPrefs.getString(eq("temp_signup_password"), eq(null))).thenReturn(password)
+
+        val result = ProfileCredentialsStore.consumeTemporarySignUpPassword(mockContext)
+
+        assertEquals(password, result)
+        verify(mockPrefs).edit()
+        verify(mockEditor).remove(eq("temp_signup_password"))
+        verify(mockEditor).apply()
+    }
+
+    @Test
+    fun `test consumeTemporarySignUpPassword returns null and does not clear when absent`() {
+        whenever(mockPrefs.getString(eq("temp_signup_password"), eq(null))).thenReturn(null)
+
+        val result = ProfileCredentialsStore.consumeTemporarySignUpPassword(mockContext)
+
+        assertNull(result)
+        verify(mockPrefs, never()).edit()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -Xshare:off
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing unit tests for the saving and consumption of temporary signup passwords in `ProfileCredentialsStore`.
📊 **Coverage:** What scenarios are now tested: Storing passwords correctly, consuming them and clearing preferences when present, and correctly returning null (and not clearing) when absent.
✨ **Result:** The improvement in test coverage: Improved robustness of authentication flow and preventing regressions.

---
*PR created automatically by Jules for task [9476118239148721013](https://jules.google.com/task/9476118239148721013) started by @dogi*