### PR TITLE
Suppress OpenJDK Sharing warnings in Gradle and tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 }
 
 tasks.withType<Test>().configureEach {
+    jvmArgs("-Xshare:off")
     systemProperty("robolectric.logging", "none")
     systemProperty("robolectric.logging.enabled", "false")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -Xshare:off
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
This change disables Class Data Sharing (CDS) to suppress the 'OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended' warning seen in GitHub Actions. CDS is disabled for the Gradle daemon in 'gradle.properties' and for test worker processes in 'app/build.gradle.kts'.

---
*PR created automatically by Jules for task [18306845960052400061](https://jules.google.com/task/18306845960052400061) started by @PlataformasInformaticas*