### PR TITLE
🧹 Fix empty catch block in DashboardResourcesRecordAudioExtensions.kt

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
@@ -92,7 +92,8 @@ internal fun DashboardResourcesPageFragment.showRecordAudioPopup() {
         waveformView.clear()
         try {
             mediaRecorder?.stop()
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
         mediaRecorder?.release()
         mediaRecorder = null


### PR DESCRIPTION
🎯 **What:** Handled an empty catch block around `mediaRecorder?.stop()` in `DashboardResourcesRecordAudioExtensions.kt`.
💡 **Why:** Empty catch blocks hide potential errors, such as `IllegalStateException` which can occur if `stop()` is called in an invalid state. Printing the stack trace makes these errors visible during debugging, improving code maintainability.
✅ **Verification:** Verified the fix by running the unit test suite (`./gradlew testDebugUnitTest`), confirming the build passes and no functionality is broken.
✨ **Result:** Improved code health and diagnostic capabilities for media recording without changing runtime behavior.

---
*PR created automatically by Jules for task [16985176639519497146](https://jules.google.com/task/16985176639519497146) started by @dogi*