### PR TITLE
🧹 Fix empty catch block in resolveAudioBitrate

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -155,7 +155,8 @@ object DashboardResourcesMediaUtils {
         return try {
             retriever.setDataSource(context, uri)
             retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()?.let { it / 1000 }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            e.printStackTrace()
             null
         } finally {
             runCatching { retriever.release() }


### PR DESCRIPTION
🎯 **What:** Modified `resolveAudioBitrate` in `DashboardResourcesMediaUtils` to call `e.printStackTrace()` when an exception occurs during media metadata extraction.
💡 **Why:** Silently catching an exception makes debugging difficult when specific audio files cause crashes or fail to extract correctly. Adding logging aids in diagnosis.
✅ **Verification:** Ran `testDebugUnitTest` for `DashboardResourcesMediaUtils`. Output confirms tests run and tests pass.
✨ **Result:** Enhanced visibility for diagnosing issues with media metadata retrieval.

---
*PR created automatically by Jules for task [10731710379166820376](https://jules.google.com/task/10731710379166820376) started by @dogi*