### PR TITLE
🧪 Add unit tests for SharedBitmapDependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 284
-        versionName = "0.2.84"
+        versionCode = 285
+        versionName = "0.2.85"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/SharedBitmapDependenciesTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/SharedBitmapDependenciesTest.kt
@@ -1,0 +1,28 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SharedBitmapDependenciesTest {
+
+    @Test
+    fun clientIsNotNull() {
+        assertNotNull(SharedBitmapDependencies.client)
+    }
+
+    @Test
+    fun clientIsOkHttpClient() {
+        @Suppress("USELESS_IS_CHECK")
+        assertTrue(SharedBitmapDependencies.client is OkHttpClient)
+    }
+
+    @Test
+    fun clientIsSingleton() {
+        val client1 = SharedBitmapDependencies.client
+        val client2 = SharedBitmapDependencies.client
+        assertSame(client1, client2)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for `SharedBitmapDependencies` to ensure lazy initialization and singleton behavior of the `OkHttpClient`.
📊 **Coverage:** Covered happy path (initialization) and singleton property.
✨ **Result:** Improved test coverage for core dependency objects.

---
*PR created automatically by Jules for task [14743169123315455179](https://jules.google.com/task/14743169123315455179) started by @dogi*