### PR TITLE
🧪 Improve test coverage for AuthUtils.isSecureAndTrustedUrl

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 290
-        versionName = "0.2.90"
+        versionCode = 294
+        versionName = "0.2.94"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/AuthUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/AuthUtilsTest.kt
@@ -120,4 +120,58 @@ class AuthUtilsTest {
         val url = "http://192.168.256.0/db/resources"
         assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
     }
+
+    @Test
+    fun isSecureAndTrustedUrl_malformedBaseUrl_returnsFalse() {
+        val base = "not_a_valid_url"
+        val url = "https://example.com/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_baseNoHost_returnsFalse() {
+        val base = "file:///path/to/local/file"
+        val url = "https://example.com/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_urlNoScheme_returnsFalse() {
+        val base = "http://10.0.2.2:5984"
+        val url = "10.0.2.2:5984/db/resources"
+        assertFalse(AuthUtils.isSecureAndTrustedUrl(url, base))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_privateIpClassABoundaries_returnsTrue() {
+        val base1 = "http://10.0.0.0:5984"
+        val url1 = "http://10.0.0.0:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url1, base1))
+
+        val base2 = "http://10.255.255.255:5984"
+        val url2 = "http://10.255.255.255:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url2, base2))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_privateIpClassBBoundaries_returnsTrue() {
+        val base1 = "http://172.16.0.0:5984"
+        val url1 = "http://172.16.0.0:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url1, base1))
+
+        val base2 = "http://172.31.255.255:5984"
+        val url2 = "http://172.31.255.255:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url2, base2))
+    }
+
+    @Test
+    fun isSecureAndTrustedUrl_privateIpClassCBoundaries_returnsTrue() {
+        val base1 = "http://192.168.0.0:5984"
+        val url1 = "http://192.168.0.0:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url1, base1))
+
+        val base2 = "http://192.168.255.255:5984"
+        val url2 = "http://192.168.255.255:5984/db/resources"
+        assertTrue(AuthUtils.isSecureAndTrustedUrl(url2, base2))
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `isSecureAndTrustedUrl` function in `AuthUtils` lacked tests for specific edge cases, including malformed base URLs, URLs without a host or scheme, and the exact boundary limits of private IP ranges.
📊 **Coverage:** Added coverage for exceptions thrown by `URI.create` when the base URL is malformed, cases where `baseUri.host` is null, cases where `url` has no scheme, and edge boundary values for private IPv4 ranges (e.g., 10.0.0.0, 10.255.255.255, 172.16.0.0, 172.31.255.255, 192.168.0.0, 192.168.255.255).
✨ **Result:** Improved test reliability and comprehensive coverage of the URL verification logic, ensuring credential leakage prevention is robustly validated against edge case inputs.

---
*PR created automatically by Jules for task [6710424465621652391](https://jules.google.com/task/6710424465621652391) started by @dogi*