### PR TITLE
🧪 Add missing tests for toLocalized in LearningLevelTranslator

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 290
-        versionName = "0.2.90"
+        versionCode = 295
+        versionName = "0.2.95"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 295
-        versionName = "0.2.95"
+        versionCode = 296
+        versionName = "0.2.96"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/LearningLevelTranslatorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/LearningLevelTranslatorTest.kt
@@ -65,10 +65,26 @@ class LearningLevelTranslatorTest {
     }
 
     @Test
+    fun testToLocalized_ReturnsNullForEmptyInput() {
+        assertNull(LearningLevelTranslator.toLocalized(context, "", R.array.signup_level_options_language_es))
+        assertNull(LearningLevelTranslator.toLocalized(context, null, R.array.signup_level_options_language_es))
+        assertNull(LearningLevelTranslator.toLocalized(context, "   ", R.array.signup_level_options_language_es))
+    }
+
+    @Test
     fun testToLocalized_TranslatesEnglishToSpanish() {
         assertEquals("Principiante", LearningLevelTranslator.toLocalized(context, "Beginner", R.array.signup_level_options_language_es))
         assertEquals("Intermedio", LearningLevelTranslator.toLocalized(context, "Intermediate", R.array.signup_level_options_language_es))
         assertEquals("Avanzado", LearningLevelTranslator.toLocalized(context, "Advanced", R.array.signup_level_options_language_es))
+        assertEquals("Experto", LearningLevelTranslator.toLocalized(context, "Expert", R.array.signup_level_options_language_es))
+    }
+
+    @Test
+    fun testToLocalized_TranslatesLocalizedToAnotherLocalized() {
+        // Translates French to Spanish
+        assertEquals("Principiante", LearningLevelTranslator.toLocalized(context, "Débutant", R.array.signup_level_options_language_es))
+        assertEquals("Intermedio", LearningLevelTranslator.toLocalized(context, "Intermédiaire", R.array.signup_level_options_language_es))
+        assertEquals("Avanzado", LearningLevelTranslator.toLocalized(context, "Avancé", R.array.signup_level_options_language_es))
         assertEquals("Experto", LearningLevelTranslator.toLocalized(context, "Expert", R.array.signup_level_options_language_es))
     }
 


### PR DESCRIPTION
🎯 **What:** The previous testing suite missed coverage for the `toLocalized` public function within `LearningLevelTranslator.kt`. 
📊 **Coverage:** Added test scenarios for `toLocalized` to correctly handle `null` strings, empty strings, blank strings, as well as testing standard translations between various localized string files (e.g. French to Spanish).
✨ **Result:** Enhanced the unit test coverage of `LearningLevelTranslator.kt`, increasing reliability and safety when dealing with string localization logic.

---
*PR created automatically by Jules for task [16687867266891574238](https://jules.google.com/task/16687867266891574238) started by @dogi*