### PR TITLE
🧪 Improve test coverage for GenderTranslator.toLocalized

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 290
-        versionName = "0.2.90"
+        versionCode = 297
+        versionName = "0.2.97"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
@@ -422,7 +422,7 @@ class OpenAiTranslationClient(
                             if (!response.isSuccessful) {
                                 throw IOException("Translation request failed with ${response.code}")
                             }
-                            val body = response.body.string() ?: ""
+                            val body = response.body.string()
                             val result = responseAdapter.fromJson(body)?.choices?.firstOrNull()?.message?.content?.trim()
                             if (continuation.isActive) {
                                 continuation.resume(result)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManager.kt
@@ -422,7 +422,7 @@ class OpenAiTranslationClient(
                             if (!response.isSuccessful) {
                                 throw IOException("Translation request failed with ${response.code}")
                             }
-                            val body = response.body?.string() ?: ""
+                            val body = response.body.string() ?: ""
                             val result = responseAdapter.fromJson(body)?.choices?.firstOrNull()?.message?.content?.trim()
                             if (continuation.isActive) {
                                 continuation.resume(result)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/GenderTranslatorTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/GenderTranslatorTest.kt
@@ -84,10 +84,28 @@ class GenderTranslatorTest {
     }
 
     @Test
+    fun testToLocalized_EnglishToEnglish() {
+        assertEquals("Male", GenderTranslator.toLocalized(context, "Male", R.array.signup_gender_options_language_en))
+        assertEquals("Female", GenderTranslator.toLocalized(context, "Female", R.array.signup_gender_options_language_en))
+    }
+
+    @Test
     fun testToLocalized_FromLocalized() {
         assertEquals("Masculin", GenderTranslator.toLocalized(context, "Masculino", R.array.signup_gender_options_language_fr))
         assertEquals("Feminino", GenderTranslator.toLocalized(context, "Féminin", R.array.signup_gender_options_language_pt))
         assertEquals("أنثى", GenderTranslator.toLocalized(context, "Femenino", R.array.signup_gender_options_language_ar))
+    }
+
+    @Test
+    fun testToLocalized_LocalizedToSameLocalized() {
+        assertEquals("Masculino", GenderTranslator.toLocalized(context, "Masculino", R.array.signup_gender_options_language_es))
+        assertEquals("Féminin", GenderTranslator.toLocalized(context, "Féminin", R.array.signup_gender_options_language_fr))
+    }
+
+    @Test
+    fun testToLocalized_LocalizedToEnglish() {
+        assertEquals("Male", GenderTranslator.toLocalized(context, "Masculino", R.array.signup_gender_options_language_en))
+        assertEquals("Female", GenderTranslator.toLocalized(context, "Féminin", R.array.signup_gender_options_language_en))
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The `toLocalized` method in `GenderTranslator` lacked comprehensive test coverage for translations within the same language and translating back to English.
📊 **Coverage:** Added explicit scenarios for English-to-English, Spanish-to-Spanish, French-to-French, Spanish-to-English, and French-to-English.
✨ **Result:** Enhanced the unit test suite for `GenderTranslator.kt` allowing safer refactoring and preventing logic regressions across all translation directions while maintaining previous out-of-bound edge cases via the Mockito setup.

---
*PR created automatically by Jules for task [3507597496146332405](https://jules.google.com/task/3507597496146332405) started by @dogi*