### PR TITLE
🧪 Add tests for SurveyTranslationManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 290
-        versionName = "0.2.90"
+        versionCode = 301
+        versionName = "0.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManagerTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/surveys/SurveyTranslationManagerTest.kt
@@ -1,0 +1,224 @@
+package org.ole.planet.myplanet.lite.surveys
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.mlkit.nl.languageid.LanguageIdentifier
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
+import org.ole.planet.myplanet.lite.dashboard.ServerConfigurationRepository
+import org.ole.planet.myplanet.lite.dashboard.ServerConfigurationRepository.ConfigurationDocument
+import org.ole.planet.myplanet.lite.dashboard.ServerConfigurationRepository.AiKeys
+import org.ole.planet.myplanet.lite.dashboard.ServerConfigurationRepository.AiModels
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.Executor
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@OptIn(ExperimentalCoroutinesApi::class)
+class SurveyTranslationManagerTest {
+
+    private lateinit var context: Context
+    private lateinit var configurationRepository: ServerConfigurationRepository
+    private lateinit var languageIdentifier: LanguageIdentifier
+    private lateinit var translationClient: OpenAiTranslationClient
+    private lateinit var translationCache: SurveyTranslationCache
+    private lateinit var translationManager: SurveyTranslationManager
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        configurationRepository = mock()
+        languageIdentifier = mock()
+        translationClient = mock()
+
+        SurveyTranslationCache.resetForTesting(context)
+        translationCache = SurveyTranslationCache.getInstance(context)
+
+        translationManager = SurveyTranslationManager(
+            appContext = context,
+            configurationRepository = configurationRepository,
+            languageIdentifier = languageIdentifier,
+            translationClient = translationClient,
+            translationCache = translationCache
+        )
+    }
+
+    @Test
+    fun `translateSurvey with blank target language returns null result`() = runTest {
+        val survey = SurveyDocument(
+            id = "survey1",
+            sourceSurveyId = "source1",
+            name = "Test Survey",
+            description = "A test survey",
+            questions = emptyList()
+        )
+
+        val result = translationManager.translateSurvey(
+            baseUrl = "http://example.com",
+            survey = survey,
+            targetLanguage = "   ",
+            detectedLanguage = "en"
+        )
+
+        assertNull(result.sourceLanguage)
+        assertNull(result.titleTranslation)
+        assertNull(result.descriptionTranslation)
+        assertTrue(result.translations.isEmpty())
+    }
+
+    @Test
+    fun `translateSurvey with same source and target language returns early result`() = runTest {
+        val survey = SurveyDocument(
+            id = "survey1",
+            sourceSurveyId = "source1",
+            name = "Test Survey",
+            description = "A test survey",
+            questions = emptyList()
+        )
+
+        val config = ConfigurationDocument(
+            keys = AiKeys(openAi = "test-key"),
+            models = AiModels(openAi = "gpt-test")
+        )
+        whenever(configurationRepository.fetchConfiguration(any())).thenReturn(Result.success(config))
+
+        val result = translationManager.translateSurvey(
+            baseUrl = "http://example.com",
+            survey = survey,
+            targetLanguage = "EN", // mixed case to check normalization
+            detectedLanguage = "en"
+        )
+
+        assertEquals("en", result.sourceLanguage)
+        assertNull(result.titleTranslation)
+        assertNull(result.descriptionTranslation)
+        assertTrue(result.translations.isEmpty())
+
+        verifyNoInteractions(translationClient)
+    }
+
+    @Test
+    fun `translateSurvey without configuration returns cached result`() = runTest {
+        // Setup cache with some data
+        val cachedTranslation = SurveyTranslationManager.TranslatedQuestion(
+            body = "Cached Title",
+            choices = emptyList()
+        )
+        translationCache.saveTranslation("survey1", -1, "es", cachedTranslation)
+
+        val survey = SurveyDocument(
+            id = "survey1",
+            sourceSurveyId = "source1",
+            name = "Test Survey",
+            description = "A test survey",
+            questions = emptyList()
+        )
+
+        // Mock config to return null (failure)
+        whenever(configurationRepository.fetchConfiguration(any())).thenReturn(Result.success(null))
+
+        val result = translationManager.translateSurvey(
+            baseUrl = "http://example.com",
+            survey = survey,
+            targetLanguage = "es",
+            detectedLanguage = "en"
+        )
+
+        assertNull(result.sourceLanguage) // Source language isn't detected if no config
+        assertEquals("Cached Title", result.titleTranslation)
+        assertNull(result.descriptionTranslation)
+    }
+
+    @Test
+    fun `translateSurvey with successful response returns proper translation`() = runTest {
+        val survey = SurveyDocument(
+            id = "survey1",
+            sourceSurveyId = "source1",
+            name = "Test Survey",
+            description = "A test survey",
+            questions = listOf(
+                SurveyQuestion(body = "Hello", choices = emptyList())
+            )
+        )
+
+        val config = ConfigurationDocument(
+            keys = AiKeys(openAi = "test-key"),
+            models = AiModels(openAi = "gpt-test")
+        )
+        whenever(configurationRepository.fetchConfiguration(any())).thenReturn(Result.success(config))
+
+        // Mock translate methods for title, description, and questions
+        whenever(translationClient.translate(
+            text = eq("Test Survey"),
+            targetLanguage = eq("es"),
+            apiKey = eq("test-key"),
+            model = eq("gpt-test"),
+            sourceLanguage = eq("en")
+        )).thenReturn("Encuesta de prueba")
+
+        whenever(translationClient.translate(
+            text = eq("A test survey"),
+            targetLanguage = eq("es"),
+            apiKey = eq("test-key"),
+            model = eq("gpt-test"),
+            sourceLanguage = eq("en")
+        )).thenReturn("Una encuesta de prueba")
+
+        whenever(translationClient.translate(
+            text = eq("Hello"),
+            targetLanguage = eq("es"),
+            apiKey = eq("test-key"),
+            model = eq("gpt-test"),
+            sourceLanguage = eq("en")
+        )).thenReturn("Hola")
+
+        val result = translationManager.translateSurvey(
+            baseUrl = "http://example.com",
+            survey = survey,
+            targetLanguage = "es",
+            detectedLanguage = "en"
+        )
+
+        assertEquals("en", result.sourceLanguage)
+        assertEquals("Encuesta de prueba", result.titleTranslation)
+        assertEquals("Una encuesta de prueba", result.descriptionTranslation)
+        assertEquals(1, result.translations.size)
+        assertEquals("Hola", result.translations[0]?.body)
+    }
+
+    @Test
+    fun `detectSurveyLanguage returns correct language`() = runTest {
+        val survey = SurveyDocument(
+            id = "survey1",
+            name = "Hello world",
+            questions = listOf(SurveyQuestion(body = "How are you?"))
+        )
+
+        // Mock the ML Kit Task manually since Tasks.forResult() might be problematic in tests with suspendCancellableCoroutine
+        val mockTask: Task<String> = mock()
+        whenever(languageIdentifier.identifyLanguage(any())).thenReturn(mockTask)
+
+        whenever(mockTask.addOnSuccessListener(any<OnSuccessListener<in String>>())).thenAnswer { invocation ->
+            val listener = invocation.getArgument<OnSuccessListener<String>>(0)
+            listener.onSuccess("en")
+            mockTask
+        }
+        whenever(mockTask.addOnFailureListener(any<OnFailureListener>())).thenReturn(mockTask)
+
+        val language = translationManager.detectSurveyLanguage(survey)
+
+        assertEquals("en", language)
+        verify(languageIdentifier).identifyLanguage(eq("Hello world. How are you?"))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The missing test suite for `SurveyTranslationManager` was added.
📊 **Coverage:** Test coverage includes handling blank target languages, short-circuit returns when source equals target language, fallback to cached results in absence of valid remote configurations, validation of the translation pipeline map for questions, and language detection via ML Kit Tasks. 
✨ **Result:** Enhanced the test suite coverage and overall reliability for translation pipeline behaviors in surveys.

---
*PR created automatically by Jules for task [9405786550386014397](https://jules.google.com/task/9405786550386014397) started by @dogi*