### PR TITLE
🧪 Add tests for ResourceDownloadUiDelegate

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 290
-        versionName = "0.2.90"
+        versionCode = 304
+        versionName = "0.3.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/ResourceDownloadUiDelegateTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/ResourceDownloadUiDelegateTest.kt
@@ -1,0 +1,157 @@
+package org.ole.planet.myplanet.lite
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+import org.mockito.kotlin.*
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResourceDownloadUiDelegateTest {
+
+    private val mockResourceSyncService: ResourceSyncService = mock()
+    private val mockResourceDownloadService: ResourceDownloadService = mock()
+
+    private val sampleResource = ResourceUi(
+        id = "1",
+        filename = "test.pdf",
+        name = "Test Resource",
+        type = "PDF",
+        date = "2023-01-01",
+        createdDate = 1000L,
+        isDownloaded = false,
+        isDownloadable = true,
+        isTeamResource = false
+    )
+
+    @Test
+    fun `test downloadResource calls service`() = runTest {
+        whenever(mockResourceSyncService.downloadResource("http://base", "cookie", sampleResource))
+            .thenReturn(true)
+
+        val result = ResourceDownloadUiDelegate.downloadResource(
+            baseUrl = "http://base",
+            sessionCookie = "cookie",
+            item = sampleResource,
+            resourceSyncService = mockResourceSyncService
+        )
+
+        assertTrue(result)
+        verify(mockResourceSyncService).downloadResource("http://base", "cookie", sampleResource)
+    }
+
+    @Test
+    fun `test deleteDownloadedResource`() {
+        val tempFile = File.createTempFile("test", ".txt")
+        assertTrue(tempFile.exists())
+
+        whenever(mockResourceDownloadService.findLocalResourceFile(
+            sampleResource.id,
+            sampleResource.filename,
+            sampleResource.isTeamResource
+        )).thenReturn(tempFile)
+
+        ResourceDownloadUiDelegate.deleteDownloadedResource(mockResourceDownloadService, sampleResource)
+
+        assertFalse(tempFile.exists())
+        verify(mockResourceDownloadService).removeDownloadedResource(sampleResource)
+    }
+
+    @Test
+    fun `test updateDownloadStateInList existing item`() {
+        val list = mutableListOf(sampleResource.copy(), sampleResource.copy(id = "2"))
+
+        ResourceDownloadUiDelegate.updateDownloadStateInList(
+            items = list,
+            target = sampleResource,
+            downloaded = true,
+            selectedSortBy = ResourceSortBy.NAME,
+            isSortDescending = false
+        )
+
+        assertEquals(2, list.size)
+        val updatedItem = list.find { it.uniqueKey() == sampleResource.uniqueKey() }
+        assertNotNull(updatedItem)
+        assertTrue(updatedItem!!.isDownloaded)
+    }
+
+    @Test
+    fun `test updateDownloadStateInList new item`() {
+        val list = mutableListOf<ResourceUi>()
+
+        ResourceDownloadUiDelegate.updateDownloadStateInList(
+            items = list,
+            target = sampleResource,
+            downloaded = true,
+            selectedSortBy = ResourceSortBy.NAME,
+            isSortDescending = false
+        )
+
+        assertEquals(1, list.size)
+        assertTrue(list[0].isDownloaded)
+        assertEquals(sampleResource.id, list[0].id)
+    }
+
+    @Test
+    fun `test updateDownloadStateInList new item not downloaded`() {
+        val list = mutableListOf<ResourceUi>()
+
+        ResourceDownloadUiDelegate.updateDownloadStateInList(
+            items = list,
+            target = sampleResource,
+            downloaded = false,
+            selectedSortBy = ResourceSortBy.NAME,
+            isSortDescending = false
+        )
+
+        assertEquals(0, list.size)
+    }
+
+    @Test
+    fun `test markResourceDownloadState`() {
+        val mainList = mutableListOf(sampleResource.copy())
+        val teamList = mutableListOf(sampleResource.copy())
+
+        ResourceDownloadUiDelegate.markResourceDownloadState(
+            mainResourcesItems = mainList,
+            teamResourcesItems = teamList,
+            item = sampleResource,
+            downloaded = true,
+            selectedSortBy = ResourceSortBy.NAME,
+            isSortDescending = false
+        )
+
+        assertTrue(mainList[0].isDownloaded)
+        assertTrue(teamList[0].isDownloaded)
+    }
+
+    @Test
+    fun `test loadDownloadedResourcesFiltered`() {
+        val resources = listOf(
+            sampleResource.copy(isDownloaded = true),
+            sampleResource.copy(id = "2", name = "Team Resource", isTeamResource = true, isDownloaded = true)
+        )
+        whenever(mockResourceDownloadService.loadDownloadedResources()).thenReturn(resources)
+
+        val result = ResourceDownloadUiDelegate.loadDownloadedResourcesFiltered(
+            downloadService = mockResourceDownloadService,
+            isTeamResourcesTab = false,
+            searchQuery = "",
+            selectedMediaType = null
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(sampleResource.id, result[0].id)
+
+        val teamResult = ResourceDownloadUiDelegate.loadDownloadedResourcesFiltered(
+            downloadService = mockResourceDownloadService,
+            isTeamResourcesTab = true,
+            searchQuery = "",
+            selectedMediaType = null
+        )
+
+        assertEquals(1, teamResult.size)
+        assertEquals("2", teamResult[0].id)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing test file for `ResourceDownloadUiDelegate`
📊 **Coverage:** Covered all functionality including `downloadResource`, `deleteDownloadedResource`, `updateDownloadStateInList`, `markResourceDownloadState`, and `loadDownloadedResourcesFiltered`.
✨ **Result:** Improved test coverage and reliability for resource download UI delegation logic, enabling confident future refactoring.

---
*PR created automatically by Jules for task [1489329791725816977](https://jules.google.com/task/1489329791725816977) started by @dogi*