### PR TITLE
🧪 Add unit tests for ResourceMenuAction

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 305
-        versionName = "0.3.5"
+        versionCode = 306
+        versionName = "0.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,13 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-<<<<<<< test-resource-menu-action-15139186218567397580
         versionCode = 306
         versionName = "0.3.6"
-=======
-        versionCode = 305
-        versionName = "0.3.5"
->>>>>>> main
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 290
-        versionName = "0.2.90"
+        versionCode = 305
+        versionName = "0.3.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/ResourceMenuActionTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/ResourceMenuActionTest.kt
@@ -1,0 +1,36 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ResourceMenuActionTest {
+
+    @Test
+    fun testFromMenuItemId_validIds() {
+        assertEquals(ResourceMenuAction.AddPdf, ResourceMenuAction.fromMenuItemId(R.id.action_add_pdf))
+        assertEquals(ResourceMenuAction.AddImage, ResourceMenuAction.fromMenuItemId(R.id.action_add_image))
+        assertEquals(ResourceMenuAction.AddVideo, ResourceMenuAction.fromMenuItemId(R.id.action_add_video))
+        assertEquals(ResourceMenuAction.AddAudio, ResourceMenuAction.fromMenuItemId(R.id.action_add_audio))
+        assertEquals(ResourceMenuAction.TakePhoto, ResourceMenuAction.fromMenuItemId(R.id.action_take_photo))
+        assertEquals(ResourceMenuAction.TakeVideo, ResourceMenuAction.fromMenuItemId(R.id.action_take_video))
+        assertEquals(ResourceMenuAction.RecordAudio, ResourceMenuAction.fromMenuItemId(R.id.action_record_audio))
+    }
+
+    @Test
+    fun testFromMenuItemId_invalidId() {
+        assertNull(ResourceMenuAction.fromMenuItemId(-1))
+        assertNull(ResourceMenuAction.fromMenuItemId(0))
+    }
+
+    @Test
+    fun testEnumProperties() {
+        assertEquals(R.id.action_add_pdf, ResourceMenuAction.AddPdf.menuItemId)
+        assertEquals(R.id.action_add_image, ResourceMenuAction.AddImage.menuItemId)
+        assertEquals(R.id.action_add_video, ResourceMenuAction.AddVideo.menuItemId)
+        assertEquals(R.id.action_add_audio, ResourceMenuAction.AddAudio.menuItemId)
+        assertEquals(R.id.action_take_photo, ResourceMenuAction.TakePhoto.menuItemId)
+        assertEquals(R.id.action_take_video, ResourceMenuAction.TakeVideo.menuItemId)
+        assertEquals(R.id.action_record_audio, ResourceMenuAction.RecordAudio.menuItemId)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `ResourceMenuAction` enum, specifically covering the `fromMenuItemId` method and property assignments.
📊 **Coverage:** The new `ResourceMenuActionTest` completely covers all valid enum mappings to their respective `R.id.*` constants, verifies correct handling of invalid input IDs (-1, 0), and ensures each enum value has the correct `menuItemId` property.
✨ **Result:** Increased test coverage for UI resource menu actions, providing a safety net against accidental modifications to the ID mappings or enum values.

---
*PR created automatically by Jules for task [15139186218567397580](https://jules.google.com/task/15139186218567397580) started by @dogi*