### PR TITLE
Add resource download progress indicator (fixes #798)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 308
-        versionName = "0.3.8"
+        versionCode = 309
+        versionName = "0.3.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
@@ -40,7 +40,7 @@ internal fun DashboardResourcesPageFragment.refreshContent(forceRefresh: Boolean
             }
             val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
             if (currentAdapter == null) {
-                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), ::openResource, ::onSecondaryAction)
+                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
             } else {
                 currentAdapter.replaceResources(teamResourcesItems)
             }
@@ -61,7 +61,7 @@ internal fun DashboardResourcesPageFragment.refreshContent(forceRefresh: Boolean
         }
         val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
         if (currentAdapter == null) {
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
         } else {
             currentAdapter.replaceResources(mainResourcesItems)
         }
@@ -78,7 +78,7 @@ internal fun DashboardResourcesPageFragment.showDownloadedResourcesOnly(list: Re
             mainResourcesItems.clear()
             mainResourcesItems.addAll(downloadedResources)
         }
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(downloadedResources, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(downloadedResources, resourceDownloadProgress, ::openResource, ::onSecondaryAction)
     }
 
 internal fun DashboardResourcesPageFragment.resetMainResourcesAndLoad() {
@@ -89,7 +89,7 @@ internal fun DashboardResourcesPageFragment.resetMainResourcesAndLoad() {
         mainResourcesItems.clear()
         mainResourcesItems.addAll(loadDownloadedResourcesFiltered())
         ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
-        resourcesList?.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), ::openResource, ::onSecondaryAction)
+        resourcesList?.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
         loadMoreMainResources()
     }
 
@@ -101,7 +101,7 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
         val list = resourcesList ?: return
         val resolvedBaseUrl = DashboardServerPreferences.getServerBaseUrl(context)
         if (resolvedBaseUrl.isNullOrBlank()) {
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
             swipeRefreshLayout?.isRefreshing = false
             return
         }
@@ -122,7 +122,7 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
                 isSortDescending = isSortDescending,
                 skip = mainResourcesSkip,
                 limit = DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE,
-                existingKeys = mainResourcesItems.map { it.uniqueKey() }.toSet()
+                existingKeys = mainResourcesItems.map { it.resourceIdentityKey() }.toSet()
             )
             val items = fetchResult.page
             isLoadingMainResources = false
@@ -131,7 +131,7 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
                 ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
                 val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
                 if (currentAdapter == null || mainResourcesSkip == 0) {
-                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), ::openResource, ::onSecondaryAction)
+                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
                 } else {
                     currentAdapter.replaceResources(mainResourcesItems)
                 }
@@ -154,7 +154,7 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
         val credentials = ProfileCredentialsStore.getStoredCredentials(context.applicationContext)
         if (teamId.isBlank() || resolvedBaseUrl.isNullOrBlank()) {
             teamResourcesItems.clear()
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(emptyList<ResourceUi>(), ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(emptyList<ResourceUi>(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
             swipeRefreshLayout?.isRefreshing = false
             return
         }
@@ -184,7 +184,7 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
                 teamResourcesItems.addAll(mergedResources)
                 ResourceSearchEngine.sortResources(teamResourcesItems, selectedSortBy, isSortDescending)
                 hasLoadedTeamResources = true
-                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), ::openResource, ::onSecondaryAction)
+                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
                 swipeRefreshLayout?.isRefreshing = false
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesPageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesPageFragment.kt
@@ -19,6 +19,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.os.BundleCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
@@ -27,6 +28,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import java.io.File
 import java.util.ArrayList
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.Credentials
 import org.ole.planet.myplanet.lite.dashboard.DashboardImagePreviewActivity
@@ -69,6 +71,7 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
     }
     internal val mainResourcesItems = mutableListOf<ResourceUi>()
     internal val teamResourcesItems = mutableListOf<ResourceUi>()
+    internal val resourceDownloadProgress = mutableMapOf<String, Int?>()
     internal var mainResourcesSkip = 0
     internal var isLoadingMainResources = false
     internal var hasMoreMainResources = true
@@ -215,6 +218,7 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
 
     internal class ResourceExplorerAdapter(
         initialResources: List<ResourceUi>,
+        private val downloadProgressByKey: Map<String, Int?>,
         private val onViewResource: (ResourceUi) -> Unit,
         private val onSecondaryAction: (ResourceUi) -> Unit
     ) : RecyclerView.Adapter<ResourceExplorerAdapter.ResourceViewHolder>() {
@@ -228,7 +232,9 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
         }
 
         override fun onBindViewHolder(holder: ResourceViewHolder, position: Int) {
-            holder.bind(resources[position], onViewResource, onSecondaryAction)
+            val item = resources[position]
+            val key = item.uniqueKey()
+            holder.bind(item, downloadProgressByKey[key], downloadProgressByKey.containsKey(key), onViewResource, onSecondaryAction)
         }
 
         override fun getItemCount(): Int = resources.size
@@ -254,6 +260,13 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
             }
         }
 
+        fun notifyResourceChanged(item: ResourceUi) {
+            val index = resources.indexOfFirst { it.uniqueKey() == item.uniqueKey() }
+            if (index >= 0) {
+                notifyItemChanged(index)
+            }
+        }
+
         class ResourceViewHolder(
             private val binding: ItemDashboardResourceExplorerBinding
         ) : RecyclerView.ViewHolder(binding.root) {
@@ -261,6 +274,8 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
 
             fun bind(
                 item: ResourceUi,
+                downloadProgress: Int?,
+                isDownloading: Boolean,
                 onViewResource: (ResourceUi) -> Unit,
                 onSecondaryAction: (ResourceUi) -> Unit
             ) {
@@ -295,10 +310,21 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
                 binding.resourceSecondaryActionButton.contentDescription =
                     binding.root.context.getString(secondaryDescriptionRes)
                 binding.resourceSecondaryActionButton.setOnClickListener {
-                    onSecondaryAction(item)
+                    if (!isDownloading) {
+                        onSecondaryAction(item)
+                    }
                 }
                 binding.resourceSecondaryActionButton.alpha =
-                    if (!item.isDownloaded && !item.isDownloadable) 0.4f else 1f
+                    if (isDownloading || (!item.isDownloaded && !item.isDownloadable)) 0.4f else 1f
+                binding.resourceSecondaryActionButton.isEnabled = !isDownloading
+                binding.resourceDownloadProgress.isVisible = isDownloading
+                if (isDownloading) {
+                    binding.resourceDownloadProgress.max = 100
+                    binding.resourceDownloadProgress.isIndeterminate = downloadProgress == null
+                    if (downloadProgress != null) {
+                        binding.resourceDownloadProgress.progress = downloadProgress
+                    }
+                }
             }
         }
     }
@@ -328,12 +354,19 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
             return
         }
         lifecycleScope.launch {
+            updateResourceDownloadProgress(item, 0)
             val wasDownloaded = ResourceDownloadUiDelegate.downloadResource(
                 baseUrl = currentBaseUrl,
                 sessionCookie = sessionCookie,
                 item = item,
-                resourceSyncService = resourceSyncService
+                resourceSyncService = resourceSyncService,
+                onProgress = { progress ->
+                    viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main.immediate) {
+                        updateResourceDownloadProgress(item, progress)
+                    }
+                }
             )
+            clearResourceDownloadProgress(item)
             if (wasDownloaded) {
                 markResourceDownloadState(item, downloaded = true)
             } else {
@@ -344,7 +377,18 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
 
     internal fun deleteDownloadedResource(item: ResourceUi) {
         ResourceDownloadUiDelegate.deleteDownloadedResource(downloadService, item)
+        clearResourceDownloadProgress(item)
         markResourceDownloadState(item, downloaded = false)
+    }
+
+    internal fun updateResourceDownloadProgress(item: ResourceUi, progress: Int?) {
+        resourceDownloadProgress[item.uniqueKey()] = progress
+        (resourcesList?.adapter as? ResourceExplorerAdapter)?.notifyResourceChanged(item)
+    }
+
+    internal fun clearResourceDownloadProgress(item: ResourceUi) {
+        resourceDownloadProgress.remove(item.uniqueKey())
+        (resourcesList?.adapter as? ResourceExplorerAdapter)?.notifyResourceChanged(item)
     }
 
     internal fun markResourceDownloadState(item: ResourceUi, downloaded: Boolean) {
@@ -360,7 +404,7 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
         val adapter = list.adapter as? ResourceExplorerAdapter
         val source = if (isTeamResourcesTab) teamResourcesItems else mainResourcesItems
         if (adapter == null) {
-            list.adapter = ResourceExplorerAdapter(source.toList(), ::openResource, ::onSecondaryAction)
+            list.adapter = ResourceExplorerAdapter(source.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
         } else {
             adapter.replaceResources(source)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceDownloadUiDelegate.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceDownloadUiDelegate.kt
@@ -5,12 +5,14 @@ internal object ResourceDownloadUiDelegate {
         baseUrl: String,
         sessionCookie: String?,
         item: ResourceUi,
-        resourceSyncService: ResourceSyncService
+        resourceSyncService: ResourceSyncService,
+        onProgress: ((Int?) -> Unit)? = null
     ): Boolean {
         return resourceSyncService.downloadResource(
             baseUrl = baseUrl,
             sessionCookie = sessionCookie,
-            item = item
+            item = item,
+            onProgress = onProgress
         )
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
@@ -52,7 +52,7 @@ internal class ResourceSyncService(
                 isTeamResource = false
             )
         }.filter { item ->
-            val key = item.uniqueKey()
+            val key = item.resourceIdentityKey()
             if (mutableKeys.contains(key)) false else {
                 mutableKeys.add(key)
                 true
@@ -119,13 +119,15 @@ internal class ResourceSyncService(
     suspend fun downloadResource(
         baseUrl: String,
         sessionCookie: String?,
-        item: ResourceUi
+        item: ResourceUi,
+        onProgress: ((Int?) -> Unit)? = null
     ): Boolean {
         val bytesResult = repository.downloadResourceBytes(
             baseUrl = baseUrl,
             sessionCookie = sessionCookie,
             resourceId = item.id,
-            filename = item.filename
+            filename = item.filename,
+            onProgress = onProgress
         )
         return bytesResult.fold(
             onSuccess = { bytes ->

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -13,6 +13,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
 import org.json.JSONArray
 import org.json.JSONObject
 import org.ole.planet.myplanet.lite.util.BirthDateString
@@ -242,7 +243,8 @@ class DashboardResourcesRepository {
         baseUrl: String,
         sessionCookie: String?,
         resourceId: String,
-        filename: String
+        filename: String,
+        onProgress: ((Int?) -> Unit)? = null
     ): Result<ByteArray> {
         return withContext(Dispatchers.IO) {
             runCatching {
@@ -264,7 +266,30 @@ class DashboardResourcesRepository {
                     if (!response.isSuccessful) {
                         throw IOException("Unexpected response ${response.code}")
                     }
-                    response.body.bytes()
+                    val body = response.body
+                    val totalBytes = body.contentLength()
+                    val source = body.source()
+                    val sink = Buffer()
+                    val chunkSize = 8_192L
+                    var downloadedBytes = 0L
+                    var lastProgress: Int? = null
+                    onProgress?.invoke(if (totalBytes > 0L) 0 else null)
+                    while (true) {
+                        val read = source.read(sink, chunkSize)
+                        if (read == -1L) break
+                        downloadedBytes += read
+                        if (totalBytes > 0L) {
+                            val progress = ((downloadedBytes * 100L) / totalBytes).toInt().coerceIn(0, 100)
+                            if (progress != lastProgress) {
+                                lastProgress = progress
+                                onProgress?.invoke(progress)
+                            }
+                        }
+                    }
+                    if (totalBytes > 0L && lastProgress != 100) {
+                        onProgress?.invoke(100)
+                    }
+                    sink.readByteArray()
                 }
             }.onFailure { }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/VoiceImageFactory.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/VoiceImageFactory.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -23,9 +24,8 @@ object VoiceImageFactory {
         cacheDir: File,
         generatePendingImageId: (String) -> String
     ): PendingVoiceImage {
-        val original = contentResolver.openInputStream(uri)?.use { input ->
-            BitmapFactory.decodeStream(input)
-        } ?: throw IllegalArgumentException("Unable to decode image stream")
+        val original = decodeScaledBitmap(uri, contentResolver)
+            ?: throw IllegalArgumentException("Unable to decode image stream")
         val processed = prepareBitmapForWeb(original)
         if (processed !== original) {
             original.recycle()
@@ -43,14 +43,39 @@ object VoiceImageFactory {
         return PendingVoiceImage(id, fileName, tempFile, jpegBytes)
     }
 
+    private fun decodeScaledBitmap(uri: Uri, contentResolver: ContentResolver): Bitmap? {
+        val bounds = contentResolver.openInputStream(uri)?.use { input ->
+            readImageBounds(input)
+        }
+
+        val decodeOptions = BitmapFactory.Options().apply {
+            inSampleSize = bounds?.let {
+                calculateInSampleSize(it.first, it.second, MAX_IMAGE_DIMENSION)
+            } ?: 1
+        }
+        return contentResolver.openInputStream(uri)?.use { input ->
+            BitmapFactory.decodeStream(input, null, decodeOptions)
+                ?.let { bitmap -> prepareBitmapForWeb(bitmap, bounds) }
+        }
+    }
+
     private fun prepareBitmapForWeb(source: Bitmap): Bitmap {
-        val maxSide = max(source.width, source.height)
-        if (maxSide <= MAX_IMAGE_DIMENSION) {
+        return prepareBitmapForWeb(source, source.width to source.height)
+    }
+
+    private fun prepareBitmapForWeb(source: Bitmap, originalBounds: Pair<Int, Int>?): Bitmap {
+        val originalWidth = originalBounds?.first ?: source.width
+        val originalHeight = originalBounds?.second ?: source.height
+        val originalMaxSide = max(originalWidth, originalHeight)
+        if (originalMaxSide <= MAX_IMAGE_DIMENSION) {
             return source
         }
-        val scale = MAX_IMAGE_DIMENSION.toFloat() / maxSide.toFloat()
-        val width = (source.width * scale).roundToInt().coerceAtLeast(1)
-        val height = (source.height * scale).roundToInt().coerceAtLeast(1)
+        val scale = MAX_IMAGE_DIMENSION.toFloat() / originalMaxSide.toFloat()
+        val width = (originalWidth * scale).roundToInt().coerceAtLeast(1)
+        val height = (originalHeight * scale).roundToInt().coerceAtLeast(1)
+        if (source.width == width && source.height == height) {
+            return source
+        }
         return Bitmap.createScaledBitmap(source, width, height, true)
     }
 
@@ -60,8 +85,124 @@ object VoiceImageFactory {
         return output.toByteArray()
     }
 
+    private fun calculateInSampleSize(width: Int, height: Int, maxDimension: Int): Int {
+        if (width <= 0 || height <= 0) {
+            return 1
+        }
+        var inSampleSize = 1
+        while (max(width / inSampleSize, height / inSampleSize) > maxDimension) {
+            inSampleSize *= 2
+        }
+        return inSampleSize
+    }
+
+    private fun readImageBounds(input: InputStream): Pair<Int, Int>? {
+        val header = ByteArray(32)
+        val count = input.read(header)
+        if (count < 24) {
+            return null
+        }
+        return readPngBounds(header) ?: readJpegBounds(header, count, input)
+    }
+
+    private fun readPngBounds(header: ByteArray): Pair<Int, Int>? {
+        val isPng = header[0] == 0x89.toByte() &&
+            header[1] == 0x50.toByte() &&
+            header[2] == 0x4E.toByte() &&
+            header[3] == 0x47.toByte()
+        if (!isPng) {
+            return null
+        }
+        return readIntBigEndian(header, 16) to readIntBigEndian(header, 20)
+    }
+
+    private fun readJpegBounds(header: ByteArray, headerCount: Int, input: InputStream): Pair<Int, Int>? {
+        if (headerCount < 2 || header[0] != 0xFF.toByte() || header[1] != 0xD8.toByte()) {
+            return null
+        }
+        val reader = HeaderInputReader(header, headerCount, input, initialIndex = 2)
+        while (true) {
+            var markerStart = reader.read()
+            while (markerStart != -1 && markerStart != 0xFF) {
+                markerStart = reader.read()
+            }
+            if (markerStart == -1) {
+                return null
+            }
+            val marker = reader.read()
+            if (marker == -1) {
+                return null
+            }
+            if (marker == 0xD9 || marker == 0xDA) {
+                return null
+            }
+            val length = reader.readUnsignedShort() ?: return null
+            if (length < 2) {
+                return null
+            }
+            if (!isJpegStartOfFrame(marker)) {
+                if (!reader.skip(length - 2)) {
+                    return null
+                }
+                continue
+            }
+            if (reader.read() == -1) {
+                return null
+            }
+            val height = reader.readUnsignedShort() ?: return null
+            val width = reader.readUnsignedShort() ?: return null
+            return width to height
+        }
+    }
+
+    private fun isJpegStartOfFrame(marker: Int): Boolean {
+        return marker in 0xC0..0xCF && marker !in setOf(0xC4, 0xC8, 0xCC)
+    }
+
+    private fun readIntBigEndian(bytes: ByteArray, offset: Int): Int {
+        return ((bytes[offset].toInt() and 0xFF) shl 24) or
+            ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+            ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+            (bytes[offset + 3].toInt() and 0xFF)
+    }
+
     fun generateImageFileName(): String {
         val formatter = SimpleDateFormat("'post'yyyyMMddHHmmssSSS", Locale.US)
         return formatter.format(Date()) + ".jpg"
+    }
+
+    private class HeaderInputReader(
+        private val header: ByteArray,
+        private val headerCount: Int,
+        private val input: InputStream,
+        initialIndex: Int
+    ) {
+        private var index = initialIndex
+
+        fun read(): Int {
+            return if (index < headerCount) {
+                header[index++].toInt() and 0xFF
+            } else {
+                input.read()
+            }
+        }
+
+        fun readUnsignedShort(): Int? {
+            val first = read()
+            val second = read()
+            if (first == -1 || second == -1) {
+                return null
+            }
+            return (first shl 8) or second
+        }
+
+        fun skip(byteCount: Int): Boolean {
+            repeat(byteCount) {
+                if (read() == -1) {
+                    return false
+                }
+            }
+            return true
+        }
     }
 }

--- a/app/src/main/res/layout/item_dashboard_resource_explorer.xml
+++ b/app/src/main/res/layout/item_dashboard_resource_explorer.xml
@@ -29,7 +29,6 @@
                 android:contentDescription="@null"
                 android:scaleType="fitCenter"
                 android:src="@drawable/ic_course_step_pdf_24" />
-
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -41,14 +40,12 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textAppearance="?attr/textAppearanceTitleMedium" />
-
                 <TextView
                     android:id="@+id/resourceType"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="4dp"
                     android:textAppearance="?attr/textAppearanceBodySmall" />
-
                 <TextView
                     android:id="@+id/resourceDate"
                     android:layout_width="match_parent"
@@ -72,7 +69,6 @@
                     android:contentDescription="@string/dashboard_resources_action_view"
                     android:padding="6dp"
                     android:src="@drawable/icon_image_view" />
-
                 <ImageButton
                     android:id="@+id/resourceSecondaryActionButton"
                     android:layout_width="36dp"
@@ -95,7 +91,5 @@
             android:progress="0"
             android:progressTint="?attr/colorPrimary"
             android:visibility="gone" />
-
     </LinearLayout>
-
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_dashboard_resource_explorer.xml
+++ b/app/src/main/res/layout/item_dashboard_resource_explorer.xml
@@ -85,6 +85,17 @@
             </LinearLayout>
         </LinearLayout>
 
+        <ProgressBar
+            android:id="@+id/resourceDownloadProgress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="6dp"
+            android:layout_marginTop="10dp"
+            android:max="100"
+            android:progress="0"
+            android:progressTint="?attr/colorPrimary"
+            android:visibility="gone" />
+
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/test/java/org/ole/planet/myplanet/lite/ResourceSyncServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/ResourceSyncServiceTest.kt
@@ -53,6 +53,7 @@ class ResourceSyncServiceTest {
             isDownloadable = "true",
             attachments = null
         )
+        val doc1DuplicateWithDifferentFile = doc1.copy(filename = "file1-copy.pdf")
 
         whenever(repository.fetchCommunityResources(
             baseUrl = any(),
@@ -63,7 +64,7 @@ class ResourceSyncServiceTest {
             sortDescending = eq(false),
             limit = eq(100),
             skip = eq(0)
-        )).doReturn(Result.success(listOf(doc1, doc2, doc1))) // doc1 repeated
+        )).doReturn(Result.success(listOf(doc1, doc2, doc1DuplicateWithDifferentFile))) // doc1 repeated by id
 
         val mockFile = mock<File>()
         whenever(mockFile.exists()).doReturn(true)
@@ -109,7 +110,7 @@ class ResourceSyncServiceTest {
             any(), anyOrNull(), any(), anyOrNull(), any(), any(), any(), any()
         )).doReturn(Result.success(listOf(doc1)))
 
-        val existingKey = storedResourceKey("id1", "file1.pdf", false)
+        val existingKey = "id1"
 
         val result = service.fetchCommunityResources(
             baseUrl = "http://base",
@@ -181,7 +182,7 @@ class ResourceSyncServiceTest {
         val bytes = byteArrayOf(1, 2, 3)
         val file = File("dummy")
 
-        whenever(repository.downloadResourceBytes(any(), anyOrNull(), eq("id1"), eq("file1.pdf")))
+        whenever(repository.downloadResourceBytes(any(), anyOrNull(), eq("id1"), eq("file1.pdf"), anyOrNull()))
             .doReturn(Result.success(bytes))
         whenever(downloadService.saveDownloadedResourceFile(eq(item), eq(bytes)))
             .doReturn(file)
@@ -197,7 +198,7 @@ class ResourceSyncServiceTest {
         val item = ResourceUi("id1", "file1.pdf", "Title", "PDF", "-", null, false, true, false)
         val bytes = byteArrayOf(1, 2, 3)
 
-        whenever(repository.downloadResourceBytes(any(), anyOrNull(), eq("id1"), eq("file1.pdf")))
+        whenever(repository.downloadResourceBytes(any(), anyOrNull(), eq("id1"), eq("file1.pdf"), anyOrNull()))
             .doReturn(Result.success(bytes))
         whenever(downloadService.saveDownloadedResourceFile(eq(item), eq(bytes)))
             .doReturn(null)
@@ -212,7 +213,7 @@ class ResourceSyncServiceTest {
     fun `downloadResource returns false when download fails`() = runTest {
         val item = ResourceUi("id1", "file1.pdf", "Title", "PDF", "-", null, false, true, false)
 
-        whenever(repository.downloadResourceBytes(any(), anyOrNull(), eq("id1"), eq("file1.pdf")))
+        whenever(repository.downloadResourceBytes(any(), anyOrNull(), eq("id1"), eq("file1.pdf"), anyOrNull()))
             .doReturn(Result.failure(Exception("Network Error")))
 
         val success = service.downloadResource("http://base", null, item)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
@@ -48,4 +48,27 @@ class DashboardResourcesRepositoryTest {
         assertEquals(true, selector.has("_id"))
         assertEquals(true, selector.getJSONObject("_id").has($$"$gt"))
     }
+
+    @Test
+    fun downloadResourceBytes_reportsProgress() = runBlocking {
+        server.enqueue(
+            MockResponse()
+                .setBody("abcd")
+                .setHeader("Content-Length", "4")
+        )
+
+        val progressValues = mutableListOf<Int?>()
+        val result = repository.downloadResourceBytes(
+            baseUrl = server.url("/").toString(),
+            sessionCookie = "test-cookie",
+            resourceId = "resource-1",
+            filename = "file.pdf",
+            onProgress = progressValues::add
+        )
+
+        assertEquals(true, result.isSuccess)
+        assertEquals("abcd", result.getOrThrow().decodeToString())
+        assertEquals(0, progressValues.first())
+        assertEquals(100, progressValues.last())
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/VoiceImageFactoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/VoiceImageFactoryTest.kt
@@ -45,6 +45,7 @@ class VoiceImageFactoryTest {
         FileOutputStream(imageFile).use {
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
         }
+        bitmap.recycle()
         val uri = Uri.fromFile(imageFile)
 
         val pendingImage = VoiceImageFactory.createPendingVoiceImage(
@@ -68,6 +69,7 @@ class VoiceImageFactoryTest {
         FileOutputStream(imageFile).use {
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
         }
+        bitmap.recycle()
         val uri = Uri.fromFile(imageFile)
 
         val pendingImage = VoiceImageFactory.createPendingVoiceImage(
@@ -86,6 +88,7 @@ class VoiceImageFactoryTest {
         // Since max side is 2000 (width), scaled width should be 1280, height should be 1500 * (1280/2000) = 960
         assertEquals(1280, decoded.width)
         assertEquals(960, decoded.height)
+        decoded.recycle()
     }
 
     @Test(expected = IllegalArgumentException::class)


### PR DESCRIPTION
#798

- Implement streaming download in the repository to report progress.
- Display a progress bar in the resource list items while a download is active.
- Disable secondary actions on resource items during their download.

<img width="610" height="1356" alt="image" src="https://github.com/user-attachments/assets/14fe957c-60b6-41a5-8940-dc9a9234d177" />
