### PR TITLE
🧹 Refactor media size estimation logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 326
-        versionName = "0.3.26"
+        versionCode = 334
+        versionName = "0.3.34"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -304,9 +304,7 @@ object DashboardResourcesMediaUtils {
     }
 
     fun estimateAudioUploadSizeBytes(bitrateKbps: Int, durationMs: Long): Long {
-        val durationSeconds = durationMs / 1000.0
-        val bitsPerSecond = bitrateKbps * 1000.0
-        val bytes = (bitsPerSecond * durationSeconds) / 8.0
+        val bytes = (bitrateKbps.toDouble() * durationMs.toDouble()) / 8.0
         return (bytes * 1.05).toLong().coerceAtLeast(1024L)
     }
 
@@ -319,13 +317,12 @@ object DashboardResourcesMediaUtils {
         selectedEndMs: Long
     ): Long {
         val durationFactor = if (sourceDurationMs <= 0L) 1.0 else {
-            val selectedDuration = (selectedEndMs - selectedStartMs).coerceAtLeast(0L)
-            (selectedDuration.toDouble() / sourceDurationMs.toDouble()).coerceIn(0.0, 1.0)
+            ((selectedEndMs - selectedStartMs).toDouble() / sourceDurationMs.toDouble()).coerceIn(0.0, 1.0)
         }
-        val resolutionFactor = if (sourceHeight <= 0 || selectedHeight >= sourceHeight) 1.0 else {
+        val resolutionFactor = if (sourceHeight > 0 && selectedHeight < sourceHeight) {
             val ratio = selectedHeight.toDouble() / sourceHeight.toDouble()
             ratio * ratio
-        }
+        } else 1.0
         val estimated = (sourceSizeBytes * resolutionFactor * durationFactor * 0.95).toLong()
         return estimated.coerceAtLeast(64L * 1024L)
     }


### PR DESCRIPTION
🎯 **What:** Simplified the arithmetic and logical expressions used for estimating audio and video upload sizes in `DashboardResourcesMediaUtils.kt`.

💡 **Why:** The previous implementation had redundant intermediate variables and repetitive arithmetic (e.g., multiplying by 1000 then dividing by 1000). Using Kotlin's `coerceIn` and simplifying the conditional logic makes the code more idiomatic and easier to read.

✅ **Verification:** Verified that the new logic produces identical results to the old logic using a Python script covering various edge cases (negative durations, zero heights, etc.). Performed manual syntax verification of the Kotlin file.

✨ **Result:** Improved maintainability and readability of the media utility functions while preserving exact functional parity.

---
*PR created automatically by Jules for task [6299636398231447581](https://jules.google.com/task/6299636398231447581) started by @dogi*