### PR TITLE
🧹 Simplify extractWaveform method

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 326
-        versionName = "0.3.26"
+        versionCode = 337
+        versionName = "0.3.37"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -162,6 +162,26 @@ object DashboardResourcesMediaUtils {
         }
     }
 
+    private fun prepareAudioCodec(extractor: MediaExtractor): MediaCodec? {
+        var audioTrackIndex = -1
+        for (i in 0 until extractor.trackCount) {
+            val format = extractor.getTrackFormat(i)
+            val mime = format.getString(MediaFormat.KEY_MIME) ?: ""
+            if (mime.startsWith("audio/")) {
+                audioTrackIndex = i
+                break
+            }
+        }
+        if (audioTrackIndex == -1) return null
+        extractor.selectTrack(audioTrackIndex)
+        val format = extractor.getTrackFormat(audioTrackIndex)
+        val mime = format.getString(MediaFormat.KEY_MIME) ?: return null
+        val codec = MediaCodec.createDecoderByType(mime)
+        codec.configure(format, null, null, 0)
+        codec.start()
+        return codec
+    }
+
     suspend fun extractWaveform(context: Context, uri: Uri): FloatArray {
         return withContext(Dispatchers.IO) {
             val retriever = MediaMetadataRetriever()
@@ -172,22 +192,8 @@ object DashboardResourcesMediaUtils {
                 val durationMs = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLong() ?: 0L
                 if (durationMs <= 0) return@withContext floatArrayOf()
                 extractor.setDataSource(context, uri, null)
-                var audioTrackIndex = -1
-                for (i in 0 until extractor.trackCount) {
-                    val format = extractor.getTrackFormat(i)
-                    val mime = format.getString(MediaFormat.KEY_MIME) ?: ""
-                    if (mime.startsWith("audio/")) {
-                        audioTrackIndex = i
-                        break
-                    }
-                }
-                if (audioTrackIndex == -1) return@withContext floatArrayOf()
-                extractor.selectTrack(audioTrackIndex)
-                val format = extractor.getTrackFormat(audioTrackIndex)
-                val mime = format.getString(MediaFormat.KEY_MIME)!!
-                codec = MediaCodec.createDecoderByType(mime)
-                codec.configure(format, null, null, 0)
-                codec.start()
+                codec = prepareAudioCodec(extractor)
+                if (codec == null) return@withContext floatArrayOf()
                 val info = MediaCodec.BufferInfo()
                 val amplitudes = mutableListOf<Float>()
                 var sawOutputEOS = false


### PR DESCRIPTION
🎯 **What:** The `MediaCodec` initialization logic within the `extractWaveform` method of `DashboardResourcesMediaUtils.kt` has been extracted into a private helper method called `prepareAudioCodec`.
💡 **Why:** Extracting audio waveform data inherently requires setting up decoders, which takes space. Pulling out this initialization logic into a helper method significantly improves the readability of the main `extractWaveform` method without changing its behavior.
✅ **Verification:** Ran `./gradlew testDebugUnitTest --tests '*DashboardResourcesMediaUtilsTest*'` and the full test suite (`./gradlew testDebugUnitTest`) to ensure everything passes and no regressions were introduced.
✨ **Result:** The `extractWaveform` method is now shorter and much easier to read, and `prepareAudioCodec` is isolated for its specific setup logic.

---
*PR created automatically by Jules for task [16808805728558011855](https://jules.google.com/task/16808805728558011855) started by @dogi*