### PR TITLE
🔒 Fix sensitive exception logging in MyPlanetLite

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 364
-        versionName = "0.3.64"
+        versionCode = 365
+        versionName = "0.3.65"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -587,7 +587,7 @@ class MyPlanetLite : BaseActivity() {
                     maybeAutoLogin()
                 }
             } catch (e: Exception) {
-                Log.e("MyPlanetLite", "Error during session restore", e)
+                Log.e("MyPlanetLite", "Error during session restore")
                 setLoadingState(isLoading = false, loginButton = loginButtonView, progress = loginProgressView)
                 maybeAutoLogin()
             } finally {


### PR DESCRIPTION
🎯 **What:** Removed exception trace (`e`) from `Log.e` in `MyPlanetLite.kt` to prevent logging stacktraces.

⚠️ **Risk:** Catching an exception and logging it directly with `Log.e` can expose sensitive data if the exception message contains API keys or user data. This could be exploited to gather sensitive session or authorization material.

🛡️ **Solution:** Removed the `e` parameter to log a generic error message, mitigating the risk of sensitive data leakage while maintaining the necessary error flow in the application.

---
*PR created automatically by Jules for task [17661816569965581713](https://jules.google.com/task/17661816569965581713) started by @dogi*