### PR TITLE
939 add deep link survey flow for logged out users

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 390
-        versionName = "0.3.90"
+        versionCode = 391
+        versionName = "0.3.91"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 390
+        versionName = "0.3.90"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
         <activity
             android:name=".DeepLinkResolverActivity"
             android:exported="true"
-            android:theme="@android:style/Theme.NoDisplay">
+            android:theme="@style/Theme.MyPlanetLite.DeepLinkResolver">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
@@ -53,6 +53,63 @@
                     android:pathPrefix="/post"
                     android:scheme="https" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="planet.learning.ole.org"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="planet.gt"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+                <data
+                    android:host="sanpablo.planet.gt"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+                <data
+                    android:host="planet.somalia.ole.org"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+                <data
+                    android:host="planet.earth.ole.org"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+                <data
+                    android:host="planet.vi.ole.org"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+                <data
+                    android:host="planet.uriur.ole.org"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="*"
+                    android:pathPrefix="/survey"
+                    android:scheme="http" />
+                <data
+                    android:host="*"
+                    android:pathPrefix="/survey"
+                    android:scheme="https" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -61,6 +118,16 @@
 
                 <data
                     android:host="post"
+                    android:scheme="myplanetlite" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="survey"
                     android:scheme="myplanetlite" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,17 +49,6 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="midominio.com"
-                    android:pathPrefix="/post"
-                    android:scheme="https" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
                     android:host="planet.learning.ole.org"
                     android:pathPrefix="/survey"
                     android:scheme="https" />

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivity.kt
@@ -8,19 +8,37 @@ package org.ole.planet.myplanet.lite
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.lite.dashboard.DashboardServerCatalog
+import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository
 import org.ole.planet.myplanet.lite.util.IntentUtils
 
-class DeepLinkResolverActivity : AppCompatActivity() {
+class DeepLinkResolverActivity : ComponentActivity() {
+    private val surveysRepository = DashboardSurveysRepository()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val postId = IntentUtils.extractDeepLinkPostId(intent)
-        if (postId == null) {
-            finish()
+        if (postId != null) {
+            openPost(postId)
             return
         }
 
+        val survey = IntentUtils.extractDeepLinkSurvey(intent)
+        if (survey != null) {
+            openSurvey(survey)
+            return
+        }
+
+        finish()
+    }
+
+    private fun openPost(postId: String) {
         val nextIntent = Intent(this, SplashScreen::class.java).apply {
             putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
@@ -28,5 +46,45 @@ class DeepLinkResolverActivity : AppCompatActivity() {
 
         startActivity(nextIntent)
         finish()
+    }
+
+    private fun openSurvey(link: IntentUtils.DeepLinkSurvey) {
+        lifecycleScope.launch {
+            val storedBaseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
+            val includeUserContext = IntentUtils.sameServer(storedBaseUrl, link.baseUrl)
+            val result = surveysRepository.fetchPublicSurvey(
+                baseUrl = link.baseUrl,
+                teamId = link.teamId,
+                surveyId = link.surveyId,
+            )
+            val publicSurvey = result.getOrNull()
+            val document = publicSurvey?.survey
+            if (document == null) {
+                Toast.makeText(
+                    this@DeepLinkResolverActivity,
+                    getString(R.string.dashboard_surveys_error_loading),
+                    Toast.LENGTH_SHORT,
+                ).show()
+                finish()
+                return@launch
+            }
+            DashboardServerCatalog.addObservedServer(
+                context = applicationContext,
+                baseUrl = link.baseUrl,
+                displayName = DashboardServerCatalog.displayNameFromBaseUrl(link.baseUrl),
+            )
+            val nextIntent = SurveyWizardActivity.newIntent(
+                context = this@DeepLinkResolverActivity,
+                document = document,
+                teamId = link.teamId,
+                teamName = publicSurvey.team?.name,
+                baseUrl = link.baseUrl,
+                includeUserContext = includeUserContext,
+            ).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            startActivity(nextIntent)
+            finish()
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardActivity.kt
@@ -50,6 +50,8 @@ class SurveyWizardActivity : AppCompatActivity() {
                         intent.getStringExtra(EXTRA_TEAM_NAME),
                         intent.getStringExtra(EXTRA_COURSE_ID),
                         intent.getBooleanExtra(EXTRA_IS_EXAM, false),
+                        intent.getStringExtra(EXTRA_BASE_URL),
+                        intent.getBooleanExtra(EXTRA_INCLUDE_USER_CONTEXT, true),
                     ),
                 )
                 .commit()
@@ -62,6 +64,8 @@ class SurveyWizardActivity : AppCompatActivity() {
         private const val EXTRA_TEAM_NAME = "extra_team_name"
         private const val EXTRA_COURSE_ID = "extra_course_id"
         private const val EXTRA_IS_EXAM = "extra_is_exam"
+        private const val EXTRA_BASE_URL = "extra_base_url"
+        private const val EXTRA_INCLUDE_USER_CONTEXT = "extra_include_user_context"
 
         fun newIntent(
             context: Context,
@@ -70,6 +74,8 @@ class SurveyWizardActivity : AppCompatActivity() {
             teamName: String?,
             courseId: String? = null,
             isExam: Boolean = false,
+            baseUrl: String? = null,
+            includeUserContext: Boolean = true,
         ): Intent {
             return Intent(context, SurveyWizardActivity::class.java).apply {
                 putExtra(EXTRA_DOCUMENT, document)
@@ -77,6 +83,8 @@ class SurveyWizardActivity : AppCompatActivity() {
                 putExtra(EXTRA_TEAM_NAME, teamName)
                 putExtra(EXTRA_COURSE_ID, courseId)
                 putExtra(EXTRA_IS_EXAM, isExam)
+                putExtra(EXTRA_BASE_URL, baseUrl)
+                putExtra(EXTRA_INCLUDE_USER_CONTEXT, includeUserContext)
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
@@ -85,6 +85,8 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
     private var teamId: String? = null
     private var teamName: String? = null
     private var courseId: String? = null
+    private var baseUrlOverride: String? = null
+    private var includeUserContext: Boolean = true
     private var steps: List<WizardStep> = emptyList()
     private var currentIndex = 0
     private val answers: MutableMap<Int, SurveyAnswer> = mutableMapOf()
@@ -132,6 +134,8 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         teamName = arguments?.getString(ARG_TEAM_NAME)
         courseId = arguments?.getString(ARG_COURSE_ID)
         isExam = arguments?.getBoolean(ARG_IS_EXAM) == true
+        baseUrlOverride = arguments?.getString(ARG_BASE_URL)?.trim()?.trimEnd('/')?.takeIf { it.isNotBlank() }
+        includeUserContext = arguments?.getBoolean(ARG_INCLUDE_USER_CONTEXT, true) != false
         questions = document?.questions.orEmpty()
         applyProfileDefaultsForCourseContent()
         birthDateSelection = respondent.birthDate?.let { parseBirthDateIso(it) } ?: birthDateSelection
@@ -152,7 +156,9 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         lifecycleScope.launch {
             initializeSession()
             attemptSurveyTranslation()
-            flushPendingSurveySubmissions()
+            if (baseUrlOverride == null) {
+                flushPendingSurveySubmissions()
+            }
         }
 
         val survey = document
@@ -235,17 +241,23 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
     override fun onStart() {
         super.onStart()
         viewLifecycleOwner.lifecycleScope.launch {
-            flushPendingSurveySubmissions()
+            if (baseUrlOverride == null) {
+                flushPendingSurveySubmissions()
+            }
         }
     }
 
     private suspend fun initializeSession() {
         val context = requireContext().applicationContext
-        baseUrl = DashboardServerPreferences.getServerBaseUrl(context)
-        credentials = ProfileCredentialsStore.getStoredCredentials(context)
-        serverCode = DashboardServerPreferences.getServerCode(context)
-        parentCode = DashboardServerPreferences.getServerParentCode(context)
-        baseUrl?.let { base ->
+        baseUrl = baseUrlOverride ?: DashboardServerPreferences.getServerBaseUrl(context)
+        credentials = if (includeUserContext) {
+            ProfileCredentialsStore.getStoredCredentials(context)
+        } else {
+            null
+        }
+        serverCode = if (includeUserContext) DashboardServerPreferences.getServerCode(context) else null
+        parentCode = if (includeUserContext) DashboardServerPreferences.getServerParentCode(context) else null
+        baseUrl?.takeIf { includeUserContext }?.let { base ->
             val authService = AuthDependencies.provideAuthService(context, base)
             sessionCookie = authService.getStoredToken()
         }
@@ -537,9 +549,19 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
             return
         }
 
-        val profile = UserProfileDatabase.getInstance(requireContext()).getProfile()
-        val username = profile?.username ?: credentials?.username
-        if (username.isNullOrBlank()) {
+        if (baseUrlOverride != null && !includeUserContext) {
+            submitPublicSurvey(base, survey, answersPayload)
+            return
+        }
+
+        val profile = if (includeUserContext) {
+            UserProfileDatabase.getInstance(requireContext()).getProfile()
+        } else {
+            null
+        }
+        val username = (profile?.username ?: credentials?.username)
+            ?.takeIf { includeUserContext }
+        if (username.isNullOrBlank() && isExam) {
             showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
             return
         }
@@ -548,6 +570,7 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
             .trim()
             .takeIf { it.isNotBlank() }
             ?: username
+            ?: ANONYMOUS_RESPONDENT_NAME
 
         val parentId = buildSubmissionParentId(survey)
         if (parentId == null) {
@@ -566,12 +589,48 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         }
     }
 
+    private fun submitPublicSurvey(
+        base: String,
+        survey: SurveyDocument,
+        answersPayload: List<SubmissionAnswer>,
+    ) {
+        val publicTeamId = teamId ?: survey.teamId
+        val publicSurveyId = survey.id
+        if (publicTeamId.isNullOrBlank() || publicSurveyId.isNullOrBlank()) {
+            showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
+            return
+        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            setSubmitting(true)
+            val result = submissionRepository.submitPublicSurvey(
+                baseUrl = base,
+                teamId = publicTeamId,
+                surveyId = publicSurveyId,
+                answers = answersPayload.map { it.value },
+            )
+            setSubmitting(false)
+            if (result.isSuccess) {
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.dashboard_survey_wizard_completed),
+                    Toast.LENGTH_SHORT,
+                ).show()
+                finishWithResult()
+            } else {
+                showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
+            }
+        }
+    }
+
     private suspend fun fetchExistingSubmissionOrNull(
         base: String,
-        username: String,
+        username: String?,
         parentId: String,
         survey: SurveyDocument
     ): DashboardSurveySubmissionsRepository.SubmissionLookup? {
+        if (username.isNullOrBlank()) {
+            return null
+        }
         return courseId?.let {
             submissionRepository.fetchExistingSubmission(
                 base,
@@ -589,7 +648,7 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
     private fun buildSurveySubmission(
         survey: SurveyDocument,
         existingSubmission: DashboardSurveySubmissionsRepository.SubmissionLookup?,
-        username: String,
+        username: String?,
         fullName: String,
         parentId: String,
         answersPayload: List<SubmissionAnswer>,
@@ -597,7 +656,7 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         profile: UserProfile?
     ): SurveySubmission {
         val rawProfile = parseProfileRawDocument(profile?.rawDocument)
-        val fallbackUserId = "org.couchdb.user:$username"
+        val fallbackUserId = username?.let { "org.couchdb.user:$it" }
         val resolvedUserId = rawProfile?.optString("_id").takeIf { !it.isNullOrBlank() } ?: fallbackUserId
         val resolvedUserName = rawProfile?.optString("name").takeIf { !it.isNullOrBlank() }
             ?: listOfNotNull(respondent.firstName, respondent.middleName, respondent.lastName)
@@ -676,11 +735,15 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         base: String,
         submission: SurveySubmission,
         survey: SurveyDocument,
-        username: String
+        username: String?
     ) {
         val isOnline = NetworkUtils.isDeviceOnline(requireContext())
         if (!isOnline) {
             setSubmitting(false)
+            if (baseUrlOverride != null) {
+                showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
+                return
+            }
             queueSubmissionForOutbox(submission, survey)
             return
         }
@@ -705,6 +768,10 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
             ).show()
             finishWithResult()
         } else {
+            if (baseUrlOverride != null) {
+                showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
+                return
+            }
             queueSubmissionForOutbox(submission, survey)
         }
     }
@@ -1757,11 +1824,14 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         private const val ARG_TEAM_NAME = "arg_team_name"
         private const val ARG_COURSE_ID = "arg_course_id"
         private const val ARG_IS_EXAM = "arg_is_exam"
+        private const val ARG_BASE_URL = "arg_base_url"
+        private const val ARG_INCLUDE_USER_CONTEXT = "arg_include_user_context"
         private const val OTHER_CHOICE_TAG = "other_choice"
         private const val BIRTH_DATE_PICKER_TAG = "survey_birth_date_picker"
         private const val DEFAULT_RATING_SCALE_MAX = 9
         private const val DEFAULT_EXAM_PASSING_PERCENTAGE = 100
         private const val KEY_DEVICE_CUSTOM_DEVICE_NAME = "device_custom_device_name"
+        private const val ANONYMOUS_RESPONDENT_NAME = "Anonymous"
 
         fun newInstance(
             document: SurveyDocument,
@@ -1769,6 +1839,8 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
             teamName: String?,
             courseId: String?,
             isExam: Boolean = false,
+            baseUrl: String? = null,
+            includeUserContext: Boolean = true,
         ): SurveyWizardFragment {
             return SurveyWizardFragment().apply {
                 arguments = Bundle().apply {
@@ -1777,6 +1849,8 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
                     putString(ARG_TEAM_NAME, teamName)
                     putString(ARG_COURSE_ID, courseId)
                     putBoolean(ARG_IS_EXAM, isExam)
+                    putString(ARG_BASE_URL, baseUrl)
+                    putBoolean(ARG_INCLUDE_USER_CONTEXT, includeUserContext)
                 }
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardServerCatalog.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardServerCatalog.kt
@@ -1,0 +1,106 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import android.content.Context
+import java.util.Locale
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
+
+object DashboardServerCatalog {
+    private const val KEY_CUSTOM_SERVERS = "custom_servers"
+    private const val DEFAULT_COUNTRY_CODE = "GT"
+
+    fun addObservedServer(
+        context: Context,
+        baseUrl: String,
+        displayName: String? = null,
+        countryCode: String = DEFAULT_COUNTRY_CODE,
+    ): Boolean {
+        val sanitizedUrl = normalizeServerUrl(baseUrl)
+        if (sanitizedUrl.isEmpty()) return false
+        val key = baseUrlKey(sanitizedUrl)
+        if (key.isEmpty()) return false
+
+        val servers = loadCustomServers(context).toMutableList()
+        if (servers.any { baseUrlKey(it.baseUrl) == key }) {
+            return false
+        }
+
+        servers.add(
+            CustomServer(
+                displayName = displayName?.trim()?.takeIf { it.isNotBlank() }
+                    ?: displayNameFromBaseUrl(sanitizedUrl),
+                baseUrl = sanitizedUrl,
+                countryCode = countryCode.uppercase(Locale.ROOT),
+            ),
+        )
+        persistCustomServers(context, servers)
+        return true
+    }
+
+    fun normalizeServerUrl(input: String): String {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) return ""
+        val withScheme = if (trimmed.contains("://")) trimmed else "http://$trimmed"
+        val normalized = withScheme.toHttpUrlOrNull() ?: return ""
+        return normalized.newBuilder().build().toString().trimEnd('/')
+    }
+
+    fun baseUrlKey(url: String): String {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty()) return ""
+        return trimmed.trimEnd('/').lowercase(Locale.ROOT)
+    }
+
+    fun displayNameFromBaseUrl(baseUrl: String): String {
+        return baseUrl.toHttpUrlOrNull()?.host?.takeIf { it.isNotBlank() }
+            ?: baseUrl.trim().trimEnd('/')
+    }
+
+    private fun loadCustomServers(context: Context): List<CustomServer> {
+        val prefs = SecurePreferencesProvider.getServerPreferences(context.applicationContext)
+        val raw = prefs.getString(KEY_CUSTOM_SERVERS, null) ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val item = array.optJSONObject(index) ?: continue
+                    val baseUrl = item.optString("baseUrl").trim()
+                    val countryCode = item.optString("countryCode").trim()
+                    if (baseUrl.isBlank() || countryCode.isBlank()) continue
+                    add(
+                        CustomServer(
+                            displayName = item.optString("displayName").trim()
+                                .ifBlank { baseUrl },
+                            baseUrl = baseUrl,
+                            countryCode = countryCode.uppercase(Locale.ROOT),
+                        ),
+                    )
+                }
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun persistCustomServers(context: Context, servers: List<CustomServer>) {
+        val prefs = SecurePreferencesProvider.getServerPreferences(context.applicationContext)
+        val array = JSONArray()
+        servers.forEach { server ->
+            array.put(
+                JSONObject()
+                    .put("displayName", server.displayName)
+                    .put("baseUrl", server.baseUrl)
+                    .put("countryCode", server.countryCode),
+            )
+        }
+        prefs.edit()
+            .putString(KEY_CUSTOM_SERVERS, array.toString())
+            .apply()
+    }
+
+    private data class CustomServer(
+        val displayName: String,
+        val baseUrl: String,
+        val countryCode: String,
+    )
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveySubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveySubmissionsRepository.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -32,6 +33,7 @@ class DashboardSurveySubmissionsRepository(
 ) {
 
     private val submissionAdapter = moshi.adapter(SurveySubmission::class.java)
+    private val publicSubmissionAdapter = moshi.adapter(PublicSurveySubmissionRequest::class.java)
     private val lookupRequestAdapter = moshi.adapter(SubmissionLookupRequest::class.java)
     private val lookupResponseAdapter = moshi.adapter(SubmissionLookupResponse::class.java)
 
@@ -59,6 +61,50 @@ class DashboardSurveySubmissionsRepository(
                     requestBuilder.addHeader("Cookie", cookie)
                 }
                 client.newCall(requestBuilder.build()).execute().use { response ->
+                    val responseBody = response.body.string()
+                    if (!response.isSuccessful) {
+                        throw IOException("Unexpected response ${response.code}. body=$responseBody")
+                    }
+                    Unit
+                }
+            }
+        }
+    }
+
+    suspend fun submitPublicSurvey(
+        baseUrl: String,
+        teamId: String,
+        surveyId: String,
+        answers: List<Any?>,
+    ): Result<Unit> {
+        return withContext(dispatcher) {
+            runCatching {
+                val normalizedBase = baseUrl.trim().trimEnd('/')
+                if (normalizedBase.isEmpty()) {
+                    throw IOException("Missing server base URL")
+                }
+                if (teamId.isBlank()) {
+                    throw IOException("Missing team id")
+                }
+                if (surveyId.isBlank()) {
+                    throw IOException("Missing survey id")
+                }
+                val base = normalizedBase.toHttpUrlOrNull()
+                    ?: throw IOException("Invalid server base URL")
+                val endpoint = base.newBuilder()
+                    .addPathSegment("api")
+                    .addPathSegment("public")
+                    .addPathSegment("surveys")
+                    .addPathSegment(teamId)
+                    .addPathSegment(surveyId)
+                    .addPathSegment("submissions")
+                    .build()
+                val payload = publicSubmissionAdapter.toJson(PublicSurveySubmissionRequest(answers))
+                val request = Request.Builder()
+                    .url(endpoint)
+                    .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+                    .build()
+                client.newCall(request).execute().use { response ->
                     val responseBody = response.body.string()
                     if (!response.isSuccessful) {
                         throw IOException("Unexpected response ${response.code}. body=$responseBody")
@@ -188,6 +234,11 @@ class DashboardSurveySubmissionsRepository(
         @param:Json(name = "mistakes") val mistakes: Int = 0,
         @param:Json(name = "passed") val passed: Boolean = true,
         @param:Json(name = "grade") val grade: Int = 0,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class PublicSurveySubmissionRequest(
+        @param:Json(name = "answers") val answers: List<Any?>,
     )
 
     @JsonClass(generateAdapter = true)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Credentials
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -44,6 +45,8 @@ class DashboardSurveysRepository(
     private val findResponseAdapter = moshi.adapter(SurveysFindResponse::class.java)
     private val completionsRequestAdapter = moshi.adapter(SurveyCompletionsRequest::class.java)
     private val completionsResponseAdapter = moshi.adapter(SurveyCompletionsResponse::class.java)
+    private val surveyDocumentAdapter = moshi.adapter(SurveyDocument::class.java)
+    private val publicSurveyResponseAdapter = moshi.adapter(PublicSurveyResponse::class.java)
 
     suspend fun fetchTeamSurveys(
         baseUrl: String,
@@ -87,6 +90,89 @@ class DashboardSurveysRepository(
         }
     }
 
+    suspend fun fetchSurveyById(
+        baseUrl: String,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        surveyId: String,
+    ): Result<SurveyDocument> {
+        return withContext(dispatcher) {
+            runCatching {
+                val normalizedBase = baseUrl.trim().trimEnd('/')
+                if (normalizedBase.isEmpty()) {
+                    throw IOException("Missing server base URL")
+                }
+                if (surveyId.isBlank()) {
+                    throw IOException("Missing survey id")
+                }
+                val base = normalizedBase.toHttpUrlOrNull()
+                    ?: throw IOException("Invalid server base URL")
+                val endpoint = base.newBuilder()
+                    .addPathSegment("db")
+                    .addPathSegment("exams")
+                    .addPathSegment(surveyId)
+                    .build()
+                val requestBuilder = Request.Builder().url(endpoint)
+                credentials?.let { creds ->
+                    requestBuilder.addHeader("Authorization", Credentials.basic(creds.username, creds.password))
+                }
+                sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
+                    requestBuilder.addHeader("Cookie", cookie)
+                }
+                client.newCall(requestBuilder.build()).await().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IOException("Unexpected response ${response.code}")
+                    }
+                    val body = response.body.string()
+                    surveyDocumentAdapter.fromJson(body)
+                        ?: throw IOException("Invalid survey response")
+                }
+            }
+        }
+    }
+
+    suspend fun fetchPublicSurvey(
+        baseUrl: String,
+        teamId: String,
+        surveyId: String,
+    ): Result<PublicSurveyResponse> {
+        return withContext(dispatcher) {
+            runCatching {
+                val normalizedBase = baseUrl.trim().trimEnd('/')
+                if (normalizedBase.isEmpty()) {
+                    throw IOException("Missing server base URL")
+                }
+                if (teamId.isBlank()) {
+                    throw IOException("Missing team id")
+                }
+                if (surveyId.isBlank()) {
+                    throw IOException("Missing survey id")
+                }
+                val base = normalizedBase.toHttpUrlOrNull()
+                    ?: throw IOException("Invalid server base URL")
+                val endpoint = base.newBuilder()
+                    .addPathSegment("api")
+                    .addPathSegment("public")
+                    .addPathSegment("surveys")
+                    .addPathSegment(teamId)
+                    .addPathSegment(surveyId)
+                    .build()
+                val request = Request.Builder()
+                    .url(endpoint)
+                    .get()
+                    .build()
+                client.newCall(request).await().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IOException("Unexpected response ${response.code}")
+                    }
+                    val body = response.body.string()
+                    publicSurveyResponseAdapter.fromJson(body)
+                        ?: throw IOException("Invalid public survey response")
+                }
+            }
+        }
+    }
+
     @JsonClass(generateAdapter = true)
     data class SurveysFindRequest(
         @param:Json(name = "selector") val selector: SurveySelector,
@@ -117,6 +203,19 @@ class DashboardSurveysRepository(
         @param:Json(name = "questions") val questions: List<SurveyQuestion>? = null,
         @param:Json(name = "totalMarks") @param:FlexibleInt val totalMarks: Int? = null,
     ) : java.io.Serializable
+
+    @JsonClass(generateAdapter = true)
+    data class PublicSurveyResponse(
+        @param:Json(name = "survey") val survey: SurveyDocument,
+        @param:Json(name = "team") val team: PublicSurveyTeam? = null,
+    )
+
+    @JsonClass(generateAdapter = true)
+    data class PublicSurveyTeam(
+        @param:Json(name = "_id") val id: String? = null,
+        @param:Json(name = "name") val name: String? = null,
+        @param:Json(name = "type") val type: String? = null,
+    )
 
     @JsonClass(generateAdapter = true)
     data class SurveyQuestion(

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
@@ -15,8 +15,8 @@ object IntentUtils {
 
         val scheme = data.scheme
         val host = data.host
-        val isValidDeepLink = (scheme == "https" && host == "midominio.com" && data.path?.lowercase()?.startsWith("/post") == true) ||
-                              (scheme == "myplanetlite" && host == "post")
+        val isValidDeepLink = scheme == "myplanetlite" &&
+            host?.equals("post", ignoreCase = true) == true
         if (!isValidDeepLink) return null
 
         val queryPostId = data.getQueryParameter("postId")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/IntentUtils.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.lite.util
 
 import android.content.Intent
+import org.ole.planet.myplanet.lite.dashboard.DashboardServerCatalog
 
 object IntentUtils {
     private val ID_PATTERN = Regex("^[a-zA-Z0-9_\\-:@.]+$")
@@ -36,4 +37,75 @@ object IntentUtils {
         val id = candidate.takeIf { it.isNotBlank() }
         return if (id != null && id.matches(ID_PATTERN)) id else null
     }
+
+    fun extractDeepLinkSurvey(intent: Intent?): DeepLinkSurvey? {
+        if (intent?.action != Intent.ACTION_VIEW) {
+            return null
+        }
+        val data = intent.data ?: return null
+        if (data.isOpaque) return null
+
+        val scheme = data.scheme
+        val host = data.host
+        val segments = data.pathSegments
+
+        val isWebSurvey = (scheme == "https" || scheme == "http") &&
+            !host.isNullOrBlank() &&
+            segments.firstOrNull()?.equals("survey", ignoreCase = true) == true
+        val isCustomSurvey = scheme == "myplanetlite" &&
+            host?.equals("survey", ignoreCase = true) == true
+        if (!isWebSurvey && !isCustomSurvey) {
+            return null
+        }
+
+        val baseUrl = if (isWebSurvey) {
+            "${data.scheme}://${data.encodedAuthority}"
+        } else {
+            data.getQueryParameter("server").orEmpty().trim()
+        }.let { DashboardServerCatalog.normalizeServerUrl(it) }
+
+        val teamId = data.getQueryParameter("teamId")
+            ?: segments.getOrNull(if (isWebSurvey) 1 else 0)
+        val surveyId = data.getQueryParameter("surveyId")
+            ?: segments.getOrNull(if (isWebSurvey) 2 else 1)
+
+        val cleanTeamId = teamId?.takeIf { it.isNotBlank() && it.matches(ID_PATTERN) }
+        val cleanSurveyId = surveyId?.takeIf { it.isNotBlank() && it.matches(ID_PATTERN) }
+        if (baseUrl.isBlank() || cleanTeamId == null || cleanSurveyId == null) {
+            return null
+        }
+
+        return DeepLinkSurvey(
+            baseUrl = baseUrl,
+            teamId = cleanTeamId,
+            surveyId = cleanSurveyId,
+        )
+    }
+
+    fun sameServer(left: String?, right: String?): Boolean {
+        val normalizedLeft = normalizeServerKey(left)
+        val normalizedRight = normalizeServerKey(right)
+        return normalizedLeft != null && normalizedLeft == normalizedRight
+    }
+
+    private fun normalizeServerKey(value: String?): String? {
+        val trimmed = DashboardServerCatalog.normalizeServerUrl(value.orEmpty())
+            .takeIf { it.isNotEmpty() } ?: return null
+        return runCatching {
+            val uri = android.net.Uri.parse(trimmed)
+            val scheme = uri.scheme?.lowercase()
+            val authority = uri.authority?.lowercase()
+            if (scheme.isNullOrBlank() || authority.isNullOrBlank()) {
+                trimmed.lowercase()
+            } else {
+                "$scheme://$authority"
+            }
+        }.getOrDefault(trimmed.lowercase())
+    }
+
+    data class DeepLinkSurvey(
+        val baseUrl: String,
+        val teamId: String,
+        val surveyId: String,
+    )
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,6 +19,16 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
+    <style name="Theme.MyPlanetLite.DeepLinkResolver" parent="Theme.Material3.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
+
     <style name="Widget.MyPlanet.PopupMenu" parent="@style/ThemeOverlay.AppCompat.Light">
         <item name="popupMenuStyle">@style/Widget.MyPlanet.PopupMenuStyle</item>
     </style>

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivityTest.kt
@@ -17,8 +17,8 @@ import org.robolectric.annotation.Config
 class DeepLinkResolverActivityTest {
 
     @Test
-    fun `test valid https deep link starts SplashScreen`() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://midominio.com/post/123"))
+    fun `test valid post deep link starts SplashScreen`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("myplanetlite://post/123"))
 
         val controller = Robolectric.buildActivity(DeepLinkResolverActivity::class.java, intent)
         controller.create()
@@ -32,7 +32,7 @@ class DeepLinkResolverActivityTest {
 
     @Test
     fun `test invalid deep link scheme finishes activity without starting next`() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://midominio.com/post/123"))
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://example.com/post/123"))
 
         val controller = Robolectric.buildActivity(DeepLinkResolverActivity::class.java, intent)
         controller.create()

--- a/app/src/test/java/org/ole/planet/myplanet/lite/IntentSecurityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/IntentSecurityTest.kt
@@ -23,7 +23,7 @@ class IntentSecurityTest {
 
     @Test
     fun extractDeepLinkPostId_withValidHierarchicalUri_returnsPostId() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://midominio.com/post?postId=12345"))
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("myplanetlite://post?postId=12345"))
         val result = IntentUtils.extractDeepLinkPostId(intent)
         assertEquals("12345", result)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveySubmissionsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveySubmissionsRepositoryTest.kt
@@ -73,6 +73,27 @@ class DashboardSurveySubmissionsRepositoryTest {
     }
 
     @Test
+    fun `submitPublicSurvey success posts answers to public endpoint`() = runTest {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(201).setBody("""{"ok":true}""")
+        )
+
+        val result = repository.submitPublicSurvey(
+            baseUrl = mockWebServer.url("/").toString(),
+            teamId = "team1",
+            surveyId = "survey1",
+            answers = listOf("Yes", 7, null),
+        )
+
+        assertTrue(result.isSuccess)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/api/public/surveys/team1/survey1/submissions", request.path)
+        assertEquals("POST", request.method)
+        assertEquals("""{"answers":["Yes",7,null]}""", request.body.readUtf8())
+    }
+
+    @Test
     fun `submitSurvey missing base url returns failure`() = runTest {
         val submission = createSubmission()
         val invalidUrls = listOf("", "   ", "/", " / ")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepositoryTest.kt
@@ -82,6 +82,49 @@ class DashboardSurveysRepositoryTest {
     }
 
     @Test
+    fun fetchPublicSurvey_success() = runTest {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """
+                {
+                  "survey": {
+                    "_id": "survey1",
+                    "name": "Public Survey",
+                    "questions": [
+                      {
+                        "body": "How are you?",
+                        "type": "input",
+                        "choices": []
+                      }
+                    ]
+                  },
+                  "team": {
+                    "_id": "team1",
+                    "name": "Public Team",
+                    "type": "team"
+                  }
+                }
+                """.trimIndent()
+            )
+        )
+
+        val result = repository.fetchPublicSurvey(
+            baseUrl = mockWebServer.url("/").toString(),
+            teamId = "team1",
+            surveyId = "survey1",
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("survey1", result.getOrNull()?.survey?.id)
+        assertEquals("Public Survey", result.getOrNull()?.survey?.name)
+        assertEquals("Public Team", result.getOrNull()?.team?.name)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/api/public/surveys/team1/survey1", request.path)
+        assertEquals("GET", request.method)
+    }
+
+    @Test
     fun fetchTeamSurveys_parsesMixedSurveyFieldTypes() = runTest {
         val jsonResponse = """
             {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/IntentUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/IntentUtilsTest.kt
@@ -41,7 +41,7 @@ class IntentUtilsTest {
     @Test
     fun `extractDeepLinkPostId returns postId from query parameter`() {
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://midominio.com/post/path?postId=12345")
+            data = Uri.parse("myplanetlite://post/path?postId=12345")
         }
         assertEquals("12345", IntentUtils.extractDeepLinkPostId(intent))
     }
@@ -49,7 +49,7 @@ class IntentUtilsTest {
     @Test
     fun `extractDeepLinkPostId returns postId from query parameter even if blank`() {
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://midominio.com/post/path?postId=")
+            data = Uri.parse("myplanetlite://post/path?postId=")
         }
         // Will fallback to segments
         assertEquals("path", IntentUtils.extractDeepLinkPostId(intent))
@@ -58,23 +58,23 @@ class IntentUtilsTest {
     @Test
     fun `extractDeepLinkPostId returns null when there are no segments`() {
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://midominio.com")
+            data = Uri.parse("myplanetlite://post")
         }
         assertNull(IntentUtils.extractDeepLinkPostId(intent))
     }
 
     @Test
-    fun `extractDeepLinkPostId returns segment after post`() {
+    fun `extractDeepLinkPostId returns path segment`() {
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://midominio.com/post/67890/details")
+            data = Uri.parse("myplanetlite://post/67890")
         }
         assertEquals("67890", IntentUtils.extractDeepLinkPostId(intent))
     }
 
     @Test
-    fun `extractDeepLinkPostId returns segment after POST case insensitive`() {
+    fun `extractDeepLinkPostId accepts post host case insensitive`() {
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://midominio.com/PoSt/67890/details")
+            data = Uri.parse("myplanetlite://POST/67890")
         }
         assertEquals("67890", IntentUtils.extractDeepLinkPostId(intent))
     }
@@ -93,7 +93,7 @@ class IntentUtilsTest {
         // Let's create an explicit scenario where the final string is blank.
         // "takeIf { it.isNotBlank() }"
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse("https://midominio.com/post/%20/")
+            data = Uri.parse("myplanetlite://post/%20/")
         }
         assertNull(IntentUtils.extractDeepLinkPostId(intent))
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/IntentUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/IntentUtilsTest.kt
@@ -97,4 +97,60 @@ class IntentUtilsTest {
         }
         assertNull(IntentUtils.extractDeepLinkPostId(intent))
     }
+
+    @Test
+    fun `extractDeepLinkSurvey parses learning survey link`() {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse("https://planet.learning.ole.org/survey/c533316781dc0ed1f8d421ae4c5bc20d/00d2d353e83ebadf06f2051402d104a7")
+        }
+
+        val result = IntentUtils.extractDeepLinkSurvey(intent)
+
+        assertEquals("https://planet.learning.ole.org", result?.baseUrl)
+        assertEquals("c533316781dc0ed1f8d421ae4c5bc20d", result?.teamId)
+        assertEquals("00d2d353e83ebadf06f2051402d104a7", result?.surveyId)
+    }
+
+    @Test
+    fun `extractDeepLinkSurvey parses survey link from another server`() {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse("https://example.com/survey/team/survey")
+        }
+
+        val result = IntentUtils.extractDeepLinkSurvey(intent)
+
+        assertEquals("https://example.com", result?.baseUrl)
+        assertEquals("team", result?.teamId)
+        assertEquals("survey", result?.surveyId)
+    }
+
+    @Test
+    fun `extractDeepLinkSurvey rejects non survey web links`() {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse("https://example.com/news/team/survey")
+        }
+
+        assertNull(IntentUtils.extractDeepLinkSurvey(intent))
+    }
+
+    @Test
+    fun `extractDeepLinkSurvey parses custom scheme with server query`() {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = Uri.parse("myplanetlite://survey/team-1/survey-1?server=https%3A%2F%2Fplanet.learning.ole.org%2F")
+        }
+
+        val result = IntentUtils.extractDeepLinkSurvey(intent)
+
+        assertEquals("https://planet.learning.ole.org", result?.baseUrl)
+        assertEquals("team-1", result?.teamId)
+        assertEquals("survey-1", result?.surveyId)
+    }
+
+    @Test
+    fun `sameServer ignores trailing slash and case`() {
+        assertEquals(
+            true,
+            IntentUtils.sameServer("https://PLANET.learning.ole.org/", "https://planet.learning.ole.org"),
+        )
+    }
 }


### PR DESCRIPTION
# Support Deep Link Survey Submission for Logged-Out Users

## What

Add support for opening survey deep links in myPlanet Lite and allowing users to complete and submit the survey even when they are not logged in.

The flow should allow a user to:

- Open a survey link from the browser.
- Launch myPlanet Lite through the deep link.
- Load the survey data from the link/server.
- Fill out the survey without requiring authentication.
- Submit the completed survey back to the appropriate server.

## Why

Currently, survey completion may depend on the user being logged in. This limits the ability to share surveys externally or collect responses from users who do not have an active session in the app.

Supporting logged-out survey submission improves accessibility and allows surveys to be distributed through links while still collecting valid responses.

## Result

Users will be able to open survey links from the browser, complete the survey inside myPlanet Lite, and submit responses to the server even without being logged in.