### PR TITLE
🧪 Test edge cases for ServerConnectivityRepository checkServerConnectivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 392
+        versionName = "0.3.92"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConnectivityRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/ServerConnectivityRepositoryTest.kt
@@ -130,4 +130,50 @@ class ServerConnectivityRepositoryTest {
         assertNull(result.parentCode)
         assertNull(result.code)
     }
+
+    @Test
+    fun checkServerConnectivity_http200_onlyParentCode_returnsReachableWithParentCode() {
+        val json = """
+            {
+                "rows": [
+                    {
+                        "doc": {
+                            "parentCode": "pCode"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(json))
+        val baseUrl = mockWebServer.url("/").toString()
+
+        val result = repository.checkServerConnectivity(baseUrl)
+
+        assertTrue(result.reachable)
+        assertEquals("pCode", result.parentCode)
+        assertNull(result.code)
+    }
+
+    @Test
+    fun checkServerConnectivity_http200_onlyCode_returnsReachableWithCode() {
+        val json = """
+            {
+                "rows": [
+                    {
+                        "doc": {
+                            "code": "mCode"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(json))
+        val baseUrl = mockWebServer.url("/").toString()
+
+        val result = repository.checkServerConnectivity(baseUrl)
+
+        assertTrue(result.reachable)
+        assertNull(result.parentCode)
+        assertEquals("mCode", result.code)
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added tests for `ServerConnectivityRepository.checkServerConnectivity()` to cover edge cases where the parsed `doc` object contains only `parentCode` or only `code`.

📊 **Coverage:** The tests `checkServerConnectivity_http200_onlyParentCode_returnsReachableWithParentCode` and `checkServerConnectivity_http200_onlyCode_returnsReachableWithCode` now explicitly verify partial metadata parsing via `MockWebServer`.

✨ **Result:** Improved test coverage and reliability for metadata parsing in server connectivity checks.

---
*PR created automatically by Jules for task [12761103520528788756](https://jules.google.com/task/12761103520528788756) started by @dogi*