### PR TITLE
🧪 Add error path test for UserProfileSync unsuccessful network response

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 393
+        versionName = "0.3.93"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileSyncTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/profile/UserProfileSyncTest.kt
@@ -194,6 +194,26 @@ class UserProfileSyncTest {
     }
 
     @Test
+    fun `refreshProfile with mocked OkHttpClient unsuccessful response returns false`() = runTest {
+        val mockClient: OkHttpClient = mock()
+        val mockCall: okhttp3.Call = mock()
+        val mockResponse = okhttp3.Response.Builder()
+            .request(okhttp3.Request.Builder().url("http://localhost").build())
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .code(500)
+            .message("Server Error")
+            .build()
+
+        org.mockito.kotlin.whenever(mockClient.newCall(org.mockito.kotlin.any())).thenReturn(mockCall)
+        org.mockito.kotlin.whenever(mockCall.execute()).thenReturn(mockResponse)
+
+        val sync = UserProfileSync(mockClient, mockDatabase)
+        val result = sync.refreshProfile("http://localhost", "testuser", null)
+
+        assertFalse(result)
+    }
+
+    @Test
     fun `refreshProfile with exception returns false`() = runTest {
         val failingClient = OkHttpClient.Builder()
             .addInterceptor { chain ->


### PR DESCRIPTION
🎯 **What:** Missing error path test for `UserProfileSync` network failure when the `OkHttpClient` request returns an unsuccessful HTTP response code.
📊 **Coverage:** Added test coverage for the scenario where `response.isSuccessful` evaluates to false immediately after the profile network request.
✨ **Result:** Improved test coverage and reliability by ensuring that unsuccessful network responses are correctly processed and return `false` without throwing an exception or parsing errors.

---
*PR created automatically by Jules for task [16615130356506713584](https://jules.google.com/task/16615130356506713584) started by @dogi*