### PR TITLE
🧪 test: Add missing error test for SurveyTranslationCache database insert failure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 395
+        versionName = "0.3.95"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/survey/SurveyTranslationCacheTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/survey/SurveyTranslationCacheTest.kt
@@ -2,6 +2,7 @@ package org.ole.planet.myplanet.lite.survey
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteStatement
 import androidx.test.core.app.ApplicationProvider
 import kotlin.system.measureTimeMillis
 import kotlinx.coroutines.runBlocking
@@ -33,7 +34,9 @@ class SurveyTranslationCacheTest {
         val cache = spy(SurveyTranslationCache.getInstance(context))
         doReturn(mockDb).whenever(cache).writableDatabase
 
-        whenever(mockDb.insertWithOnConflict(any(), anyOrNull(), any(), any())).thenThrow(RuntimeException("DB Error"))
+        val mockStatement = mock(SQLiteStatement::class.java)
+        whenever(mockDb.compileStatement(any())).thenReturn(mockStatement)
+        whenever(mockStatement.executeInsert()).thenThrow(RuntimeException("DB Error"))
 
         val translations = mapOf(1 to SurveyTranslationManager.TranslatedQuestion("body", listOf("a")))
 


### PR DESCRIPTION
🎯 **What:** Added a missing error handling test case for `SurveyTranslationCache` during bulk translation insertion (`saveTranslations`). The existing error test mistakenly mocked `insertWithOnConflict`, which is not used in the bulk insert transaction.
📊 **Coverage:** Covered the `RuntimeException` database insertion failure path when executing `executeInsert()` via a compiled SQLite statement. Verified that transaction state is correctly handled (e.g. `endTransaction()` is called, `setTransactionSuccessful()` is skipped).
✨ **Result:** Improved robustness by correctly validating the failure recovery semantics for the `SurveyTranslationCache` database.

---
*PR created automatically by Jules for task [16369500041971844474](https://jules.google.com/task/16369500041971844474) started by @dogi*