### PR TITLE
🧹 Refactor setupRecyclerView in DashboardVoicesFragment for better maintainability

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 397
+        versionName = "0.3.97"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -149,7 +149,15 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
 
     private fun setupRecyclerView() {
         markwon = Markwon.builder(requireContext()).build()
-        adapter = DashboardNewsAdapter(
+        adapter = createDashboardNewsAdapter()
+
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = adapter
+        setupScrollListener()
+    }
+
+    private fun createDashboardNewsAdapter(): DashboardNewsAdapter {
+        return DashboardNewsAdapter(
             markwon,
             avatarBinder = { imageView, username, hasAvatar ->
                 avatarLoader?.bind(imageView, username, hasAvatar)
@@ -182,9 +190,9 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
                 openTeamMemberProfile(item)
             }
         )
+    }
 
-        recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.adapter = adapter
+    private fun setupScrollListener() {
         recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)


### PR DESCRIPTION
🎯 **What:** Extracted the excessively long inline adapter initialization and scroll listener setup in `setupRecyclerView` into two new private helper functions: `createDashboardNewsAdapter()` and `setupScrollListener()`.
💡 **Why:** `setupRecyclerView` was previously very long and deeply nested due to numerous lambda implementations for the adapter's click listeners. Extracting these into separate functions improves modularity, testability, and adherence to the single-responsibility principle, making the core initialization flow of `setupRecyclerView` much easier to read.
✅ **Verification:** Compiled the module successfully and ran both the specific `DashboardVoicesFragment` test suite and the complete unit test suite, confirming no behavior changes or regressions were introduced.
✨ **Result:** Improved maintainability of `DashboardVoicesFragment.kt` by separating complex initializations into highly cohesive helper methods.

---
*PR created automatically by Jules for task [1954815876304390395](https://jules.google.com/task/1954815876304390395) started by @dogi*