### PR TITLE
🧹 Refactor Team Join Actions with Context Parameter Object

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 401
+        versionName = "0.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -437,20 +437,24 @@ class DashboardTeamMembersFragment : Fragment() {
         binding.dashboardTeamJoinRequestsList.isVisible = hasRequests
     }
 
-    private fun acceptJoinRequest(request: TeamJoinRequestUiModel) = runAcceptJoinRequest(this, repository, baseUrl, credentials, sessionCookie, request, currentTeamPlanetCode, serverPlanetCode) { currentTeamId?.let(::loadTeamMembers) }
+    private fun createActionContext(): DashboardTeamActionContext {
+        return DashboardTeamActionContext(this, repository, baseUrl, credentials, sessionCookie)
+    }
+
+    private fun acceptJoinRequest(request: TeamJoinRequestUiModel) = runAcceptJoinRequest(createActionContext(), request, currentTeamPlanetCode, serverPlanetCode) { currentTeamId?.let(::loadTeamMembers) }
 
     private fun confirmAcceptJoinRequest(request: TeamJoinRequestUiModel) {
         confirmAcceptJoinRequestDialog(this, request) { acceptJoinRequest(it) }
     }
 
-    private fun rejectJoinRequest(request: TeamJoinRequestUiModel) = runRejectJoinRequest(this, repository, baseUrl, credentials, sessionCookie, request) { currentTeamId?.let(::loadTeamMembers) }
+    private fun rejectJoinRequest(request: TeamJoinRequestUiModel) = runRejectJoinRequest(createActionContext(), request) { currentTeamId?.let(::loadTeamMembers) }
 
     private fun confirmRejectJoinRequest(request: TeamJoinRequestUiModel) {
         confirmRejectJoinRequestDialog(this, request) { rejectJoinRequest(it) }
     }
 
     private fun confirmMemberRemoval(member: TeamMemberDetails) = confirmMemberRemovalDialog(this, member) { selectedMember, displayName ->
-        runRemoveTeamMember(this, repository, currentTeamId, baseUrl, credentials, sessionCookie, selectedMember, displayName,
+        runRemoveTeamMember(createActionContext(), currentTeamId, selectedMember, displayName,
             onStart = { binding.dashboardTeamMembersSwipeRefresh.isRefreshing = true },
             onStop = { binding.dashboardTeamMembersSwipeRefresh.isRefreshing = false },
             onReload = { currentTeamId?.let(::loadTeamMembers) })

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupport.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupport.kt
@@ -45,6 +45,14 @@ internal fun confirmAcceptJoinRequestDialog(fragment: Fragment, request: TeamJoi
         .show()
 }
 
+internal data class DashboardTeamActionContext(
+    val fragment: Fragment,
+    val repository: DashboardTeamsRepository,
+    val baseUrl: String?,
+    val credentials: StoredCredentials?,
+    val sessionCookie: String?
+)
+
 internal fun confirmRejectJoinRequestDialog(fragment: Fragment, request: TeamJoinRequestUiModel, onReject: (TeamJoinRequestUiModel) -> Unit) {
     val displayName = request.fullName.ifBlank { request.username }
     AlertDialog.Builder(fragment.requireContext())
@@ -72,18 +80,14 @@ internal fun confirmMemberRemovalDialog(fragment: Fragment, member: TeamMemberDe
 }
 
 internal fun runAcceptJoinRequest(
-    fragment: Fragment,
-    repository: DashboardTeamsRepository,
-    baseUrl: String?,
-    credentials: StoredCredentials?,
-    sessionCookie: String?,
+    context: DashboardTeamActionContext,
     request: TeamJoinRequestUiModel,
     currentTeamPlanetCode: String?,
     serverPlanetCode: String?,
     onReload: () -> Unit,
 ) {
-    val base = baseUrl
-    val creds = credentials
+    val base = context.baseUrl
+    val creds = context.credentials
     val teamId = request.request.teamId
     val userId = request.request.userId
     val teamPlanetCode = request.request.teamPlanetCode ?: currentTeamPlanetCode ?: serverPlanetCode
@@ -97,15 +101,15 @@ internal fun runAcceptJoinRequest(
         teamPlanetCode.isNullOrBlank() || userPlanetCode.isNullOrBlank() ||
         requestId.isNullOrBlank() || requestRevision.isNullOrBlank()
     ) {
-        Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_invite_members_add_error_generic), Toast.LENGTH_SHORT).show()
+        Toast.makeText(context.fragment.requireContext(), context.fragment.getString(R.string.dashboard_invite_members_add_error_generic), Toast.LENGTH_SHORT).show()
         return
     }
 
-    fragment.viewLifecycleOwner.lifecycleScope.launch {
-        val addResult = repository.addTeamMember(
+    context.fragment.viewLifecycleOwner.lifecycleScope.launch {
+        val addResult = context.repository.addTeamMember(
             baseUrl = base,
             credentials = creds,
-            sessionCookie = sessionCookie,
+            sessionCookie = context.sessionCookie,
             teamId = teamId,
             teamPlanetCode = teamPlanetCode,
             teamType = request.request.teamType ?: "local",
@@ -113,18 +117,18 @@ internal fun runAcceptJoinRequest(
             userPlanetCode = userPlanetCode,
         )
         addResult.onSuccess {
-            repository.cancelJoinRequest(
+            context.repository.cancelJoinRequest(
                 baseUrl = base,
                 credentials = creds,
-                sessionCookie = sessionCookie,
+                sessionCookie = context.sessionCookie,
                 documentId = requestId,
                 revision = requestRevision,
             )
             onReload()
         }.onFailure {
             Toast.makeText(
-                fragment.requireContext(),
-                fragment.getString(R.string.dashboard_invite_members_add_error, request.fullName),
+                context.fragment.requireContext(),
+                context.fragment.getString(R.string.dashboard_invite_members_add_error, request.fullName),
                 Toast.LENGTH_SHORT,
             ).show()
         }
@@ -132,39 +136,31 @@ internal fun runAcceptJoinRequest(
 }
 
 internal fun runRejectJoinRequest(
-    fragment: Fragment,
-    repository: DashboardTeamsRepository,
-    baseUrl: String?,
-    credentials: StoredCredentials?,
-    sessionCookie: String?,
+    context: DashboardTeamActionContext,
     request: TeamJoinRequestUiModel,
     onReload: () -> Unit,
 ) {
-    val base = baseUrl
-    val creds = credentials
+    val base = context.baseUrl
+    val creds = context.credentials
     val requestId = request.request.id
     val requestRevision = request.request.revision
     if (base.isNullOrBlank() || creds == null || requestId.isNullOrBlank() || requestRevision.isNullOrBlank()) {
-        Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_invite_members_add_error_generic), Toast.LENGTH_SHORT).show()
+        Toast.makeText(context.fragment.requireContext(), context.fragment.getString(R.string.dashboard_invite_members_add_error_generic), Toast.LENGTH_SHORT).show()
         return
     }
 
-    fragment.viewLifecycleOwner.lifecycleScope.launch {
-        val result = repository.cancelJoinRequest(base, creds, sessionCookie, requestId, requestRevision)
+    context.fragment.viewLifecycleOwner.lifecycleScope.launch {
+        val result = context.repository.cancelJoinRequest(base, creds, context.sessionCookie, requestId, requestRevision)
         result.onSuccess { onReload() }
             .onFailure {
-                Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_invite_members_add_error_generic), Toast.LENGTH_SHORT).show()
+                Toast.makeText(context.fragment.requireContext(), context.fragment.getString(R.string.dashboard_invite_members_add_error_generic), Toast.LENGTH_SHORT).show()
             }
     }
 }
 
 internal fun runRemoveTeamMember(
-    fragment: Fragment,
-    repository: DashboardTeamsRepository,
+    context: DashboardTeamActionContext,
     teamId: String?,
-    baseUrl: String?,
-    credentials: StoredCredentials?,
-    sessionCookie: String?,
     member: TeamMemberDetails,
     displayName: String,
     onStart: () -> Unit,
@@ -172,19 +168,19 @@ internal fun runRemoveTeamMember(
     onReload: () -> Unit,
 ) {
     val membership = member.membership
-    if (teamId.isNullOrBlank() || baseUrl.isNullOrBlank() || credentials == null || membership == null) {
-        Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_team_members_remove_error, displayName), Toast.LENGTH_SHORT).show()
+    if (teamId.isNullOrBlank() || context.baseUrl.isNullOrBlank() || context.credentials == null || membership == null) {
+        Toast.makeText(context.fragment.requireContext(), context.fragment.getString(R.string.dashboard_team_members_remove_error, displayName), Toast.LENGTH_SHORT).show()
         return
     }
 
     onStart()
-    fragment.viewLifecycleOwner.lifecycleScope.launch {
-        val result = repository.removeTeamMember(baseUrl, credentials, sessionCookie, membership)
+    context.fragment.viewLifecycleOwner.lifecycleScope.launch {
+        val result = context.repository.removeTeamMember(context.baseUrl, context.credentials, context.sessionCookie, membership)
         result.onSuccess {
-            Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_team_members_remove_success, displayName), Toast.LENGTH_SHORT).show()
+            Toast.makeText(context.fragment.requireContext(), context.fragment.getString(R.string.dashboard_team_members_remove_success, displayName), Toast.LENGTH_SHORT).show()
             onReload()
         }.onFailure {
-            Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_team_members_remove_error, displayName), Toast.LENGTH_SHORT).show()
+            Toast.makeText(context.fragment.requireContext(), context.fragment.getString(R.string.dashboard_team_members_remove_error, displayName), Toast.LENGTH_SHORT).show()
             onStop()
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupportTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupportTest.kt
@@ -67,12 +67,16 @@ class DashboardTeamMembersSupportTest {
             )
         )
 
-        runAcceptJoinRequest(
+        val context = DashboardTeamActionContext(
             fragment = fragment,
             repository = repository,
             baseUrl = null, // Invalid
             credentials = null, // Invalid
-            sessionCookie = null,
+            sessionCookie = null
+        )
+
+        runAcceptJoinRequest(
+            context = context,
             request = request,
             currentTeamPlanetCode = null,
             serverPlanetCode = null,
@@ -103,12 +107,16 @@ class DashboardTeamMembersSupportTest {
             )
         )
 
-        runRejectJoinRequest(
+        val context = DashboardTeamActionContext(
             fragment = fragment,
             repository = repository,
             baseUrl = null, // Invalid
             credentials = null, // Invalid
-            sessionCookie = null,
+            sessionCookie = null
+        )
+
+        runRejectJoinRequest(
+            context = context,
             request = request,
             onReload = {}
         )
@@ -128,13 +136,17 @@ class DashboardTeamMembersSupportTest {
             membership = null // Invalid
         )
 
-        runRemoveTeamMember(
+        val context = DashboardTeamActionContext(
             fragment = fragment,
             repository = repository,
-            teamId = null, // Invalid
             baseUrl = null, // Invalid
             credentials = null, // Invalid
-            sessionCookie = null,
+            sessionCookie = null
+        )
+
+        runRemoveTeamMember(
+            context = context,
+            teamId = null, // Invalid
             member = member,
             displayName = "User",
             onStart = {},


### PR DESCRIPTION
🎯 **What:** Introduced a `DashboardTeamActionContext` data class to encapsulate `fragment`, `repository`, `baseUrl`, `credentials`, and `sessionCookie` parameters, significantly reducing the parameter count in `runAcceptJoinRequest`, `runRejectJoinRequest`, and `runRemoveTeamMember`.

💡 **Why:** These five parameters were consistently passed together across multiple functions. Grouping them into a single context object improves code readability, simplifies call sites in `DashboardTeamMembersFragment`, and enhances maintainability.

✅ **Verification:** 
- Modified test cases in `DashboardTeamMembersSupportTest` to use the new parameter object context.
- All modifications compile without error (`compileDebugKotlin`, `compileDebugUnitTestKotlin`).
- Ran specifically the modified tests (`./gradlew testDebugUnitTest --tests "*DashboardTeamMembersSupportTest*"`).
- Ran the full test suite (`./gradlew testDebugUnitTest`) and confirmed no regressions were introduced.

✨ **Result:** Cleaner function signatures in `DashboardTeamMembersSupport.kt` and simplified, more readable invocations in `DashboardTeamMembersFragment.kt`.

---
*PR created automatically by Jules for task [10627083320959256405](https://jules.google.com/task/10627083320959256405) started by @dogi*