### PR TITLE
🧹 [Code Health] Extract helper functions from downloadCourse

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 402
+        versionName = "0.4.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -712,56 +712,85 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         val markdownImageSources = extractMarkdownImageSources(course)
 
         val job = viewLifecycleOwner.lifecycleScope.launch {
-            val totalInventoryItems = resources.size + markdownImageSources.size
-            adapter.updateDownloadProgress(course.id, 0, totalInventoryItems)
-            val estimatedSize = estimateResourcesSize(base, creds, resources) +
-                estimateMarkdownImagesSize(base, creds, markdownImageSources)
-            val available = OfflineCourseStorage.availableStorageBytes(requireContext())
-            val required = estimatedSize + MIN_DOWNLOAD_BUFFER_BYTES
-            if (available <= required) {
-                adapter.updateDownloadProgress(course.id, null, null)
-                Toast.makeText(
-                    requireContext(),
-                    getString(R.string.dashboard_course_insufficient_storage),
-                    Toast.LENGTH_SHORT
-                ).show()
-                activeDownloads.remove(course.id)
-                return@launch
-            }
-
-            val result = withContext(Dispatchers.IO) {
-                downloadCourseResources(
-                    base,
-                    creds,
-                    course,
-                    resources,
-                    markdownImageSources
-                ) { percent ->
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        adapter.updateDownloadProgress(course.id, percent.first, percent.second)
-                    }
-                }
-            }
-            if (result) {
-                val source = if (tabPosition == 2) {
-                    OfflineCourseStorage.DownloadSource.TEAM_COURSES
-                } else {
-                    OfflineCourseStorage.DownloadSource.MY_COURSES
-                }
-                OfflineCourseStorage.saveCourseManifest(requireContext(), course, source)
-                adapter.updateDownloadProgress(course.id, null, null)
-                adapter.updateDownloadedCourses(OfflineCourseStorage.downloadedCourseIds(requireContext()))
-            } else {
-                adapter.updateDownloadProgress(course.id, null, null)
-                Toast.makeText(
-                    requireContext(),
-                    getString(R.string.dashboard_courses_loading_error),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-            activeDownloads.remove(course.id)
+            performCourseDownload(course, base, creds, resources, markdownImageSources)
         }
         activeDownloads[course.id] = job
+    }
+
+    private suspend fun performCourseDownload(
+        course: CourseItem,
+        base: String,
+        creds: StoredCredentials,
+        resources: List<CourseItem.LessonResource>,
+        markdownImageSources: List<String>
+    ) {
+        val totalInventoryItems = resources.size + markdownImageSources.size
+        adapter.updateDownloadProgress(course.id, 0, totalInventoryItems)
+
+        if (!hasSufficientStorage(course, base, creds, resources, markdownImageSources)) {
+            activeDownloads.remove(course.id)
+            return
+        }
+
+        val result = withContext(Dispatchers.IO) {
+            downloadCourseResources(
+                base,
+                creds,
+                course,
+                resources,
+                markdownImageSources
+            ) { percent ->
+                viewLifecycleOwner.lifecycleScope.launch {
+                    adapter.updateDownloadProgress(course.id, percent.first, percent.second)
+                }
+            }
+        }
+
+        handleDownloadResult(course, result)
+        activeDownloads.remove(course.id)
+    }
+
+    private suspend fun hasSufficientStorage(
+        course: CourseItem,
+        base: String,
+        creds: StoredCredentials,
+        resources: List<CourseItem.LessonResource>,
+        markdownImageSources: List<String>
+    ): Boolean {
+        val estimatedSize = estimateResourcesSize(base, creds, resources) +
+            estimateMarkdownImagesSize(base, creds, markdownImageSources)
+        val available = OfflineCourseStorage.availableStorageBytes(requireContext())
+        val required = estimatedSize + MIN_DOWNLOAD_BUFFER_BYTES
+        if (available <= required) {
+            adapter.updateDownloadProgress(course.id, null, null)
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.dashboard_course_insufficient_storage),
+                Toast.LENGTH_SHORT
+            ).show()
+            return false
+        }
+        return true
+    }
+
+    private fun handleDownloadResult(course: CourseItem, result: Boolean) {
+        if (result) {
+            val source = if (tabPosition == 2) {
+                OfflineCourseStorage.DownloadSource.TEAM_COURSES
+            } else {
+                OfflineCourseStorage.DownloadSource.MY_COURSES
+            }
+            OfflineCourseStorage.saveCourseManifest(requireContext(), course, source)
+            adapter.updateDownloadProgress(course.id, null, null)
+            adapter.updateDownloadedCourses(OfflineCourseStorage.downloadedCourseIds(requireContext()))
+        } else {
+            adapter.updateDownloadProgress(course.id, null, null)
+            Toast.makeText(
+                requireContext(),
+                getString(R.string.dashboard_courses_loading_error),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
     }
 
     private fun confirmDeleteDownloadedCourse(course: CourseItem) {


### PR DESCRIPTION
🎯 **What:** Extracted three smaller helper functions (`performCourseDownload`, `hasSufficientStorage`, and `handleDownloadResult`) from the `downloadCourse` function in `DashboardCoursePageFragment.kt`.

💡 **Why:** The original `downloadCourse` function was quite long and handled several distinct responsibilities, including UI updates, storage checks, and dispatching coroutines for I/O operations. By separating these concerns into smaller functions, the code is easier to read, maintain, and unit-test.

✅ **Verification:** Verified the refactoring by running `./gradlew compileDebugKotlin` to ensure syntax correctness, running targeted lint (`./gradlew lint app:lintDebug`), and executing the full unit test suite (`./gradlew testDebugUnitTest`). Code review was also requested and passed.

✨ **Result:** A more modular and readable `DashboardCoursePageFragment.kt` file with a refactored `downloadCourse` that strictly adheres to the Single Responsibility Principle without altering the existing logic or user behavior.

---
*PR created automatically by Jules for task [14888535666902745998](https://jules.google.com/task/14888535666902745998) started by @dogi*