### PR TITLE
🧹 Refactor renderLanguageLevelStep in SurveyWizardFragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 389
-        versionName = "0.3.89"
+        versionCode = 406
+        versionName = "0.4.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardFragment.kt
@@ -1229,6 +1229,56 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         }
     }
 
+    private fun updateLevelOptions(
+        context: android.content.Context,
+        levelInput: AutoCompleteTextView,
+        languageLabel: String?
+    ): List<String> {
+        val arrayRes = levelArrayForLanguage(languageLabel)
+        val options = resources.getStringArray(arrayRes).toList()
+        val adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, options)
+        levelInput.setAdapter(adapter)
+        val localizedLevel = LearningLevelTranslator.toLocalized(context, respondent.level, arrayRes)
+        if (!localizedLevel.isNullOrBlank() && options.contains(localizedLevel)) {
+            levelInput.setText(localizedLevel, false)
+        } else {
+            levelInput.setText("", false)
+        }
+        return options
+    }
+
+    private fun setupLanguageInput(
+        context: android.content.Context,
+        languageInput: AutoCompleteTextView,
+        languages: List<String>
+    ): ArrayAdapter<String> {
+        val languageAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, languages)
+        languageInput.setAdapter(languageAdapter)
+        respondent.language?.let { languageInput.setText(it, false) }
+        return languageAdapter
+    }
+
+    private fun createLanguageLevelCollector(
+        context: android.content.Context,
+        languageInput: AutoCompleteTextView,
+        levelInput: AutoCompleteTextView,
+        languages: List<String>,
+        currentLevelOptionsProvider: () -> List<String>
+    ): () -> Boolean {
+        return {
+            val selectedLanguage = languageInput.text?.toString()?.trim().orEmpty()
+            respondent.language = selectedLanguage.takeIf { languages.contains(it) }
+
+            val levelText = levelInput.text?.toString()?.trim().orEmpty()
+            respondent.level = if (currentLevelOptionsProvider().contains(levelText)) {
+                LearningLevelTranslator.toEnglish(context, levelText)
+            } else {
+                null
+            }
+            true
+        }
+    }
+
     private fun renderLanguageLevelStep(): Pair<View, () -> Boolean> {
         val context = requireContext()
         val container = LinearLayout(context).apply {
@@ -1249,48 +1299,27 @@ class SurveyWizardFragment : Fragment(R.layout.fragment_survey_wizard) {
         )
 
         val languages = resources.getStringArray(R.array.signup_language_options).toList()
-        val languageAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, languages)
-        languageInput.setAdapter(languageAdapter)
-        respondent.language?.let { languageInput.setText(it, false) }
+        val languageAdapter = setupLanguageInput(context, languageInput, languages)
 
         var currentLevelOptions: List<String> = emptyList()
 
-        fun updateLevelOptions(languageLabel: String?) {
-            val arrayRes = levelArrayForLanguage(languageLabel)
-            val options = resources.getStringArray(arrayRes).toList()
-            currentLevelOptions = options
-            val adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, options)
-            levelInput.setAdapter(adapter)
-            val localizedLevel = LearningLevelTranslator.toLocalized(context, respondent.level, arrayRes)
-            if (!localizedLevel.isNullOrBlank() && options.contains(localizedLevel)) {
-                levelInput.setText(localizedLevel, false)
-            } else {
-                levelInput.setText("", false)
-            }
-        }
-
         languageInput.setOnItemClickListener { _, _, position, _ ->
             val selected = languageAdapter.getItem(position)
-            updateLevelOptions(selected)
+            currentLevelOptions = updateLevelOptions(context, levelInput, selected)
         }
 
-        updateLevelOptions(respondent.language)
+        currentLevelOptions = updateLevelOptions(context, levelInput, respondent.language)
 
         container.addView(languageLayout)
         container.addView(levelLayout)
 
-        val collector = {
-            val selectedLanguage = languageInput.text?.toString()?.trim().orEmpty()
-            respondent.language = selectedLanguage.takeIf { languages.contains(it) }
-
-            val levelText = levelInput.text?.toString()?.trim().orEmpty()
-            respondent.level = if (currentLevelOptions.contains(levelText)) {
-                LearningLevelTranslator.toEnglish(context, levelText)
-            } else {
-                null
-            }
-            true
-        }
+        val collector = createLanguageLevelCollector(
+            context,
+            languageInput,
+            levelInput,
+            languages,
+            { currentLevelOptions }
+        )
         return container to collector
     }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the excessive length and complexity of the `renderLanguageLevelStep` function within `SurveyWizardFragment.kt`.

💡 **Why:** By extracting logical blocks—specifically language input setup, level options updating, and collector creation—into their own distinct, smaller helper functions (`setupLanguageInput`, `updateLevelOptions`, and `createLanguageLevelCollector`), the overall modularity and readability of the codebase are significantly improved. This makes the primary rendering function much cleaner and easier to maintain, adhering better to the Single Responsibility Principle.

✅ **Verification:** I confirmed that the extraction correctly maintained the local state variables, particularly by using a closure for the `currentLevelOptions` in the collector. I also successfully executed the local unit test for `SurveyWizardFragment` using `./gradlew testDebugUnitTest --tests "*SurveyWizardFragment*"` ensuring no functional regressions were introduced.

✨ **Result:** A simplified `renderLanguageLevelStep` function and a cleaner overall class structure within `SurveyWizardFragment.kt`.

---
*PR created automatically by Jules for task [16531571666640073094](https://jules.google.com/task/16531571666640073094) started by @dogi*