### PR TITLE
🧹 Refactor runRemoveTeamMember to use parameter object

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -450,10 +450,12 @@ class DashboardTeamMembersFragment : Fragment() {
     }
 
     private fun confirmMemberRemoval(member: TeamMemberDetails) = confirmMemberRemovalDialog(this, member) { selectedMember, displayName ->
-        runRemoveTeamMember(this, repository, currentTeamId, baseUrl, credentials, sessionCookie, selectedMember, displayName,
+        runRemoveTeamMember(RemoveTeamMemberParams(
+            this, repository, currentTeamId, baseUrl, credentials, sessionCookie, selectedMember, displayName,
             onStart = { binding.dashboardTeamMembersSwipeRefresh.isRefreshing = true },
             onStop = { binding.dashboardTeamMembersSwipeRefresh.isRefreshing = false },
-            onReload = { currentTeamId?.let(::loadTeamMembers) })
+            onReload = { currentTeamId?.let(::loadTeamMembers) }
+        ))
     }
 
     private fun showInviteMembersDialog() {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupport.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupport.kt
@@ -158,19 +158,33 @@ internal fun runRejectJoinRequest(
     }
 }
 
-internal fun runRemoveTeamMember(
-    fragment: Fragment,
-    repository: DashboardTeamsRepository,
-    teamId: String?,
-    baseUrl: String?,
-    credentials: StoredCredentials?,
-    sessionCookie: String?,
-    member: TeamMemberDetails,
-    displayName: String,
-    onStart: () -> Unit,
-    onStop: () -> Unit,
-    onReload: () -> Unit,
-) {
+internal data class RemoveTeamMemberParams(
+    val fragment: Fragment,
+    val repository: DashboardTeamsRepository,
+    val teamId: String?,
+    val baseUrl: String?,
+    val credentials: StoredCredentials?,
+    val sessionCookie: String?,
+    val member: TeamMemberDetails,
+    val displayName: String,
+    val onStart: () -> Unit,
+    val onStop: () -> Unit,
+    val onReload: () -> Unit,
+)
+
+internal fun runRemoveTeamMember(params: RemoveTeamMemberParams) {
+    val fragment = params.fragment
+    val repository = params.repository
+    val teamId = params.teamId
+    val baseUrl = params.baseUrl
+    val credentials = params.credentials
+    val sessionCookie = params.sessionCookie
+    val member = params.member
+    val displayName = params.displayName
+    val onStart = params.onStart
+    val onStop = params.onStop
+    val onReload = params.onReload
+
     val membership = member.membership
     if (teamId.isNullOrBlank() || baseUrl.isNullOrBlank() || credentials == null || membership == null) {
         Toast.makeText(fragment.requireContext(), fragment.getString(R.string.dashboard_team_members_remove_error, displayName), Toast.LENGTH_SHORT).show()

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupportTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupportTest.kt
@@ -128,7 +128,7 @@ class DashboardTeamMembersSupportTest {
             membership = null // Invalid
         )
 
-        runRemoveTeamMember(
+        runRemoveTeamMember(RemoveTeamMemberParams(
             fragment = fragment,
             repository = repository,
             teamId = null, // Invalid
@@ -140,7 +140,7 @@ class DashboardTeamMembersSupportTest {
             onStart = {},
             onStop = {},
             onReload = {}
-        )
+        ))
 
         val latestToast = ShadowToast.getLatestToast()
         assertNotNull(latestToast)


### PR DESCRIPTION
🎯 **What:** Addressed a code health issue where the `runRemoveTeamMember` function in `DashboardTeamMembersSupport.kt` had an excessive number of parameters (11 parameters). Introduced a `RemoveTeamMemberParams` data class to act as a parameter object and refactored the function and its callsites.
💡 **Why:** Having too many parameters in a single function call makes the code harder to read, maintain, and test. Grouping related parameters into a dedicated data class simplifies the signature, provides better organization, and makes it easier to extend if necessary in the future without altering the function's base signature.
✅ **Verification:** Verified by executing the specific unit test class (`DashboardTeamMembersSupportTest`) which targets the refactored code, followed by a full run of the Android unit test suite (`./gradlew testDebugUnitTest`) to ensure no regressions were introduced.
✨ **Result:** A cleaner, more maintainable `runRemoveTeamMember` API, resolving the original code health warning while preserving identical behavior.

---
*PR created automatically by Jules for task [1157947413819463457](https://jules.google.com/task/1157947413819463457) started by @dogi*