### PR TITLE
🧹 Refactor SurveyWizardActivity intent creation using Builder pattern

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -539,13 +539,11 @@ class CourseWizardActivity : BaseActivity() {
         iconView.contentDescription = getString(R.string.dashboard_surveys_title)
         playButton.contentDescription = getString(R.string.course_wizard_open_survey)
         val openSurvey = {
-            SurveyWizardActivity.newIntent(
-                this,
-                survey,
-                survey.teamId,
-                null,
-                courseId
-            ).also { startActivity(it) }
+            SurveyWizardActivity.IntentBuilder(this, survey)
+                .teamId(survey.teamId)
+                .courseId(courseId)
+                .build()
+                .also { startActivity(it) }
         }
         itemView.setOnClickListener { openSurvey() }
         playButton.setOnClickListener { openSurvey() }
@@ -576,14 +574,12 @@ class CourseWizardActivity : BaseActivity() {
         playButton.contentDescription = getString(R.string.course_wizard_open_exam)
         val openExam = {
             pendingExamStepIndex = currentIndex
-            SurveyWizardActivity.newIntent(
-                this,
-                exam,
-                exam.teamId,
-                null,
-                courseId,
-                isExam = true
-            ).also { examLauncher.launch(it) }
+            SurveyWizardActivity.IntentBuilder(this, exam)
+                .teamId(exam.teamId)
+                .courseId(courseId)
+                .isExam(true)
+                .build()
+                .also { examLauncher.launch(it) }
         }
         itemView.setOnClickListener { openExam() }
         playButton.setOnClickListener { openExam() }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
@@ -318,12 +318,10 @@ class DashboardTeamSurveysFragment : Fragment(R.layout.fragment_dashboard_team_s
 
         document.id?.let { statusStore.markViewed(it) }
         startActivity(
-            SurveyWizardActivity.newIntent(
-                requireContext(),
-                document,
-                teamId,
-                teamName,
-            ),
+            SurveyWizardActivity.IntentBuilder(requireContext(), document)
+                .teamId(teamId)
+                .teamName(teamName)
+                .build()
         )
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardActivity.kt
@@ -56,21 +56,21 @@ class SurveyWizardActivity : AppCompatActivity() {
         }
     }
 
-    companion object {
-        const val EXTRA_DOCUMENT = "extra_document"
-        private const val EXTRA_TEAM_ID = "extra_team_id"
-        private const val EXTRA_TEAM_NAME = "extra_team_name"
-        private const val EXTRA_COURSE_ID = "extra_course_id"
-        private const val EXTRA_IS_EXAM = "extra_is_exam"
+    class IntentBuilder(
+        private val context: Context,
+        private val document: SurveyDocument,
+    ) {
+        private var teamId: String? = null
+        private var teamName: String? = null
+        private var courseId: String? = null
+        private var isExam: Boolean = false
 
-        fun newIntent(
-            context: Context,
-            document: SurveyDocument,
-            teamId: String?,
-            teamName: String?,
-            courseId: String? = null,
-            isExam: Boolean = false,
-        ): Intent {
+        fun teamId(teamId: String?) = apply { this.teamId = teamId }
+        fun teamName(teamName: String?) = apply { this.teamName = teamName }
+        fun courseId(courseId: String?) = apply { this.courseId = courseId }
+        fun isExam(isExam: Boolean) = apply { this.isExam = isExam }
+
+        fun build(): Intent {
             return Intent(context, SurveyWizardActivity::class.java).apply {
                 putExtra(EXTRA_DOCUMENT, document)
                 putExtra(EXTRA_TEAM_ID, teamId)
@@ -79,5 +79,13 @@ class SurveyWizardActivity : AppCompatActivity() {
                 putExtra(EXTRA_IS_EXAM, isExam)
             }
         }
+    }
+
+    companion object {
+        const val EXTRA_DOCUMENT = "extra_document"
+        private const val EXTRA_TEAM_ID = "extra_team_id"
+        private const val EXTRA_TEAM_NAME = "extra_team_name"
+        private const val EXTRA_COURSE_ID = "extra_course_id"
+        private const val EXTRA_IS_EXAM = "extra_is_exam"
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardActivityTest.kt
@@ -48,14 +48,12 @@ class SurveyWizardActivityTest {
     @Test
     fun `onCreate with survey sets up toolbar and fragment`() {
         val surveyDocument = SurveyDocument(id = "survey123", name = "Test Survey")
-        val intent = SurveyWizardActivity.newIntent(
-            context = ApplicationProvider.getApplicationContext(),
-            document = surveyDocument,
-            teamId = "team1",
-            teamName = "Test Team",
-            courseId = "course1",
-            isExam = true
-        )
+        val intent = SurveyWizardActivity.IntentBuilder(ApplicationProvider.getApplicationContext(), surveyDocument)
+            .teamId("team1")
+            .teamName("Test Team")
+            .courseId("course1")
+            .isExam(true)
+            .build()
         val controller = Robolectric.buildActivity(SurveyWizardActivity::class.java, intent)
         val activity = controller.create().start().resume().visible().get()
         assertFalse(activity.isFinishing)
@@ -71,14 +69,12 @@ class SurveyWizardActivityTest {
     fun `newIntent creates correct intent`() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val surveyDocument = SurveyDocument(id = "survey123", name = "Test Survey")
-        val intent = SurveyWizardActivity.newIntent(
-            context = context,
-            document = surveyDocument,
-            teamId = "team1",
-            teamName = "Test Team",
-            courseId = "course1",
-            isExam = true
-        )
+        val intent = SurveyWizardActivity.IntentBuilder(context, surveyDocument)
+            .teamId("team1")
+            .teamName("Test Team")
+            .courseId("course1")
+            .isExam(true)
+            .build()
         assertEquals(SurveyWizardActivity::class.java.name, intent.component?.className)
         assertTrue(intent.hasExtra(SurveyWizardActivity.EXTRA_DOCUMENT))
         val extraDoc = IntentCompat.getSerializableExtra(intent, SurveyWizardActivity.EXTRA_DOCUMENT, SurveyDocument::class.java)!!


### PR DESCRIPTION
🎯 **What:** The `newIntent` function in `SurveyWizardActivity` was refactored to use the Builder pattern (`IntentBuilder`), eliminating a method with 6 parameters.
💡 **Why:** Reduces parameter list complexity and improves readability at call sites, making intent creation fluent and maintainable.
✅ **Verification:** Re-ran all unit tests specifically for `SurveyWizardActivityTest`, followed by the full `testDebugUnitTest` suite to ensure no regressions were introduced.
✨ **Result:** A more readable, robust, and scalable way to construct intents for `SurveyWizardActivity` without modifying its external behavior.

---
*PR created automatically by Jules for task [7807329505263486243](https://jules.google.com/task/7807329505263486243) started by @dogi*