### PR TITLE
🧹 Refactor video estimate text functions to use parameter object

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -312,26 +312,23 @@ object DashboardResourcesMediaUtils {
         }.getOrNull()
     }
 
+    data class VideoEstimateParams(
+        val sourceSizeBytes: Long?,
+        val sourceHeight: Int,
+        val selectedHeight: Int,
+        val sourceDurationMs: Long,
+        val selectedStartMs: Long,
+        val selectedEndMs: Long
+    )
+
     fun buildVideoSizeEstimateText(
         context: Context,
         unknownText: String,
         estimateFormat: String,
-        sourceSizeBytes: Long?,
-        sourceHeight: Int,
-        selectedHeight: Int,
-        sourceDurationMs: Long,
-        selectedStartMs: Long,
-        selectedEndMs: Long
+        params: VideoEstimateParams
     ): String {
-        if (sourceSizeBytes == null || sourceSizeBytes <= 0L) return unknownText
-        val estimatedBytes = estimateVideoUploadSizeBytes(
-            sourceSizeBytes,
-            sourceHeight,
-            selectedHeight,
-            sourceDurationMs,
-            selectedStartMs,
-            selectedEndMs
-        )
+        if (params.sourceSizeBytes == null || params.sourceSizeBytes <= 0L) return unknownText
+        val estimatedBytes = estimateVideoUploadSizeBytes(params)
         val formattedSize = Formatter.formatShortFileSize(context, estimatedBytes)
         return estimateFormat.format(formattedSize)
     }
@@ -350,22 +347,16 @@ object DashboardResourcesMediaUtils {
         return (bytes * 1.05).toLong().coerceAtLeast(1024L)
     }
 
-    fun estimateVideoUploadSizeBytes(
-        sourceSizeBytes: Long,
-        sourceHeight: Int,
-        selectedHeight: Int,
-        sourceDurationMs: Long,
-        selectedStartMs: Long,
-        selectedEndMs: Long
-    ): Long {
-        val durationFactor = if (sourceDurationMs <= 0L) 1.0 else {
-            ((selectedEndMs - selectedStartMs).toDouble() / sourceDurationMs.toDouble()).coerceIn(0.0, 1.0)
+    fun estimateVideoUploadSizeBytes(params: VideoEstimateParams): Long {
+        val durationFactor = if (params.sourceDurationMs <= 0L) 1.0 else {
+            ((params.selectedEndMs - params.selectedStartMs).toDouble() / params.sourceDurationMs.toDouble()).coerceIn(0.0, 1.0)
         }
-        val resolutionFactor = if (sourceHeight > 0 && selectedHeight < sourceHeight) {
-            val ratio = selectedHeight.toDouble() / sourceHeight.toDouble()
+        val resolutionFactor = if (params.sourceHeight > 0 && params.selectedHeight < params.sourceHeight) {
+            val ratio = params.selectedHeight.toDouble() / params.sourceHeight.toDouble()
             ratio * ratio
         } else 1.0
-        val estimated = (sourceSizeBytes * resolutionFactor * durationFactor * 0.95).toLong()
+        val sourceSize = params.sourceSizeBytes ?: 0L
+        val estimated = (sourceSize * resolutionFactor * durationFactor * 0.95).toLong()
         return estimated.coerceAtLeast(64L * 1024L)
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadVideoExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadVideoExtensions.kt
@@ -119,12 +119,14 @@ internal fun DashboardResourcesPageFragment.showVideoMetadataPopup(uri: Uri) {
         }
         val sizeEstimateValue = TextView(context).apply {
             text = DashboardResourcesMediaUtils.buildVideoSizeEstimateText(requireContext(), getString(R.string.dashboard_resources_video_size_unknown), getString(R.string.dashboard_resources_video_size_estimate), 
-                sourceSizeBytes = sourceFileSizeBytes,
-                sourceHeight = sourceHeight,
-                selectedHeight = allowedHeights.getOrElse(defaultIndex) { defaultHeight },
-                sourceDurationMs = sourceDurationMs,
-                selectedStartMs = selectedStartMs,
-                selectedEndMs = selectedEndMs
+                DashboardResourcesMediaUtils.VideoEstimateParams(
+                    sourceSizeBytes = sourceFileSizeBytes,
+                    sourceHeight = sourceHeight,
+                    selectedHeight = allowedHeights.getOrElse(defaultIndex) { defaultHeight },
+                    sourceDurationMs = sourceDurationMs,
+                    selectedStartMs = selectedStartMs,
+                    selectedEndMs = selectedEndMs
+                )
             )
         }
         val previewTitle = TextView(context).apply {
@@ -292,12 +294,14 @@ internal fun DashboardResourcesPageFragment.showVideoMetadataPopup(uri: Uri) {
                     DashboardResourcesMediaUtils.formatDurationMs((selectedEndMs - selectedStartMs).coerceAtLeast(0L))
                 )
                 sizeEstimateValue.text = DashboardResourcesMediaUtils.buildVideoSizeEstimateText(requireContext(), getString(R.string.dashboard_resources_video_size_unknown), getString(R.string.dashboard_resources_video_size_estimate), 
-                    sourceSizeBytes = sourceFileSizeBytes,
-                    sourceHeight = sourceHeight,
-                    selectedHeight = selectedHeightForEstimate,
-                    sourceDurationMs = sourceDurationMs,
-                    selectedStartMs = selectedStartMs,
-                    selectedEndMs = selectedEndMs
+                    DashboardResourcesMediaUtils.VideoEstimateParams(
+                        sourceSizeBytes = sourceFileSizeBytes,
+                        sourceHeight = sourceHeight,
+                        selectedHeight = selectedHeightForEstimate,
+                        sourceDurationMs = sourceDurationMs,
+                        selectedStartMs = selectedStartMs,
+                        selectedEndMs = selectedEndMs
+                    )
                 )
             }
         }
@@ -315,12 +319,14 @@ internal fun DashboardResourcesPageFragment.showVideoMetadataPopup(uri: Uri) {
                 selectedHeightForEstimate = selectedHeight
                 resolutionValue.text = getString(R.string.dashboard_resources_video_resolution_value, selectedHeight)
                 sizeEstimateValue.text = DashboardResourcesMediaUtils.buildVideoSizeEstimateText(requireContext(), getString(R.string.dashboard_resources_video_size_unknown), getString(R.string.dashboard_resources_video_size_estimate), 
-                    sourceSizeBytes = sourceFileSizeBytes,
-                    sourceHeight = sourceHeight,
-                    selectedHeight = selectedHeight,
-                    sourceDurationMs = sourceDurationMs,
-                    selectedStartMs = selectedStartMs,
-                    selectedEndMs = selectedEndMs
+                    DashboardResourcesMediaUtils.VideoEstimateParams(
+                        sourceSizeBytes = sourceFileSizeBytes,
+                        sourceHeight = sourceHeight,
+                        selectedHeight = selectedHeight,
+                        sourceDurationMs = sourceDurationMs,
+                        selectedStartMs = selectedStartMs,
+                        selectedEndMs = selectedEndMs
+                    )
                 )
             }
         }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -305,14 +305,14 @@ class DashboardResourcesMediaUtilsTest {
         assertEquals(
             211111L,
             DashboardResourcesMediaUtils.estimateVideoUploadSizeBytes(
-                1000000L, 1080, 720, 10000L, 0L, 5000L
+                DashboardResourcesMediaUtils.VideoEstimateParams(1000000L, 1080, 720, 10000L, 0L, 5000L)
             )
         )
 
         assertEquals(
             65536L,
             DashboardResourcesMediaUtils.estimateVideoUploadSizeBytes(
-                1L, 1080, 720, 10000L, 0L, 5000L
+                DashboardResourcesMediaUtils.VideoEstimateParams(1L, 1080, 720, 10000L, 0L, 5000L)
             )
         )
     }
@@ -357,12 +357,14 @@ class DashboardResourcesMediaUtilsTest {
             context = context,
             unknownText = "Unknown",
             estimateFormat = "Est: %s",
-            sourceSizeBytes = null,
-            sourceHeight = 1080,
-            selectedHeight = 720,
-            sourceDurationMs = 10000L,
-            selectedStartMs = 0L,
-            selectedEndMs = 5000L
+            DashboardResourcesMediaUtils.VideoEstimateParams(
+                sourceSizeBytes = null,
+                sourceHeight = 1080,
+                selectedHeight = 720,
+                sourceDurationMs = 10000L,
+                selectedStartMs = 0L,
+                selectedEndMs = 5000L
+            )
         )
 
         assertEquals("Unknown", result)
@@ -376,12 +378,14 @@ class DashboardResourcesMediaUtilsTest {
             context = context,
             unknownText = "Unknown",
             estimateFormat = "Est: %s",
-            sourceSizeBytes = 0L,
-            sourceHeight = 1080,
-            selectedHeight = 720,
-            sourceDurationMs = 10000L,
-            selectedStartMs = 0L,
-            selectedEndMs = 5000L
+            DashboardResourcesMediaUtils.VideoEstimateParams(
+                sourceSizeBytes = 0L,
+                sourceHeight = 1080,
+                selectedHeight = 720,
+                sourceDurationMs = 10000L,
+                selectedStartMs = 0L,
+                selectedEndMs = 5000L
+            )
         )
 
         assertEquals("Unknown", result)
@@ -391,7 +395,7 @@ class DashboardResourcesMediaUtilsTest {
     fun buildVideoSizeEstimateText_validSize_returnsFormattedEstimate() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val estimatedBytes = DashboardResourcesMediaUtils.estimateVideoUploadSizeBytes(
+        val params = DashboardResourcesMediaUtils.VideoEstimateParams(
             sourceSizeBytes = 1000000L,
             sourceHeight = 1080,
             selectedHeight = 720,
@@ -399,6 +403,7 @@ class DashboardResourcesMediaUtilsTest {
             selectedStartMs = 0L,
             selectedEndMs = 5000L
         )
+        val estimatedBytes = DashboardResourcesMediaUtils.estimateVideoUploadSizeBytes(params)
 
         val expectedFormattedSize = Formatter.formatShortFileSize(context, estimatedBytes)
         val expectedOutput = "Est: $expectedFormattedSize"
@@ -407,12 +412,7 @@ class DashboardResourcesMediaUtilsTest {
             context = context,
             unknownText = "Unknown",
             estimateFormat = "Est: %s",
-            sourceSizeBytes = 1000000L,
-            sourceHeight = 1080,
-            selectedHeight = 720,
-            sourceDurationMs = 10000L,
-            selectedStartMs = 0L,
-            selectedEndMs = 5000L
+            params = params
         )
 
         assertEquals(expectedOutput, result)


### PR DESCRIPTION
🎯 **What:** The `buildVideoSizeEstimateText` function in `DashboardResourcesMediaUtils.kt` had too many parameters, making it difficult to read and maintain. This PR introduces a `VideoEstimateParams` data class to encapsulate the six video estimate parameters (`sourceSizeBytes`, `sourceHeight`, `selectedHeight`, `sourceDurationMs`, `selectedStartMs`, `selectedEndMs`) and updates the function signatures to use this object. It also applies the same object to `estimateVideoUploadSizeBytes`.
💡 **Why:** Encapsulating related parameters into a single object reduces function signature complexity, improves readability, and makes call sites cleaner and less prone to parameter ordering errors.
✅ **Verification:** Verified by ensuring the code compiles and running both the specific `DashboardResourcesMediaUtilsTest` and the full test suite (`testDebugUnitTest`). All tests passed.
✨ **Result:** A much cleaner function signature in `DashboardResourcesMediaUtils` and cleaner usage in `DashboardResourcesUploadVideoExtensions`, maintaining full functionality with improved code health.

---
*PR created automatically by Jules for task [14845836545070257439](https://jules.google.com/task/14845836545070257439) started by @dogi*