### PR TITLE
🧹 Extract TimeUtils and remove duplicated formatRelativeTime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 415
-        versionName = "0.4.15"
+        versionCode = 419
+        versionName = "0.4.19"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -1,3 +1,4 @@
+
 /**
  * Author: Walfre López Prado
  * Email: loppra@plataformasinformaticas.com
@@ -6,6 +7,7 @@
 
 package org.ole.planet.myplanet.lite
 
+import org.ole.planet.myplanet.lite.util.TimeUtils
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -501,8 +503,8 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
             }
         } ?: (username ?: getString(R.string.dashboard_profile_name_placeholder))
         val timeMillis = document.time ?: 0L
-        val relativeTime = formatRelativeTime(timeMillis)
-        val metadata = buildMetadata(username, relativeTime)
+        val relativeTime = TimeUtils.formatRelativeTime(requireContext(), timeMillis)
+        val metadata = TimeUtils.buildMetadata(username, relativeTime)
         val rawMessage = document.message
         val messageImages = extractImagePaths(rawMessage)
         val documentImages = mapDocumentImages(document)
@@ -564,47 +566,6 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
             return null
         }
         return "resources/$id/$name"
-    }
-
-    private fun buildMetadata(username: String?, relativeTime: String): String {
-        return if (!username.isNullOrBlank()) {
-            "@${username.trim()} • $relativeTime"
-        } else {
-            relativeTime
-        }
-    }
-
-    private fun formatRelativeTime(timestamp: Long): String {
-        val now = System.currentTimeMillis()
-        val diffMillis = max(0L, now - timestamp)
-        val minutes = diffMillis / MINUTE_MILLIS
-        val hours = diffMillis / HOUR_MILLIS
-        val days = diffMillis / DAY_MILLIS
-        val months = diffMillis / MONTH_MILLIS
-        val years = diffMillis / YEAR_MILLIS
-        return when {
-            years >= 1 -> if (years == 1L) getString(R.string.dashboard_relative_time_year) else getString(
-                R.string.dashboard_relative_time_years,
-                years
-            )
-            months >= 1 -> if (months == 1L) getString(R.string.dashboard_relative_time_month) else getString(
-                R.string.dashboard_relative_time_months,
-                months
-            )
-            days >= 1 -> if (days == 1L) getString(R.string.dashboard_relative_time_day) else getString(
-                R.string.dashboard_relative_time_days,
-                days
-            )
-            hours >= 1 -> if (hours == 1L) getString(R.string.dashboard_relative_time_hour) else getString(
-                R.string.dashboard_relative_time_hours,
-                hours
-            )
-            minutes >= 1 -> if (minutes == 1L) getString(R.string.dashboard_relative_time_minute) else getString(
-                R.string.dashboard_relative_time_minutes,
-                minutes
-            )
-            else -> getString(R.string.dashboard_relative_time_seconds)
-        }
     }
 
     @androidx.annotation.VisibleForTesting
@@ -898,11 +859,6 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
             private const val ARG_TEAM_NAME = "arg_team_name"
             private const val LOAD_MORE_THRESHOLD = 3
             private val IMAGE_MARKDOWN_CAPTURE_REGEX = Regex("!\\[[^]]*]\\(([^)]+)\\)")
-        private const val MINUTE_MILLIS = 60_000L
-        private const val HOUR_MILLIS = 60 * MINUTE_MILLIS
-        private const val DAY_MILLIS = 24 * HOUR_MILLIS
-        private const val MONTH_MILLIS = 30 * DAY_MILLIS
-        private const val YEAR_MILLIS = 12 * MONTH_MILLIS
 
         fun newInstanceForTeam(teamId: String, teamName: String): DashboardVoicesFragment {
             return DashboardVoicesFragment().apply {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -6,6 +6,7 @@
 
 package org.ole.planet.myplanet.lite.dashboard
 
+import org.ole.planet.myplanet.lite.util.TimeUtils
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -1540,11 +1541,6 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
         const val EXTRA_DELETED_POST_ID = "extra_deleted_post_id"
 
         private const val COMMENTS_LIMIT = 50
-        private const val MINUTE_MILLIS = 60_000L
-        private const val HOUR_MILLIS = 60 * MINUTE_MILLIS
-        private const val DAY_MILLIS = 24 * HOUR_MILLIS
-        private const val MONTH_MILLIS = 30 * DAY_MILLIS
-        private const val YEAR_MILLIS = 12 * MONTH_MILLIS
         private const val PRIVATE_FOR_COMMUNITY = "community"
         private const val JPEG_QUALITY = 85
         private const val MAX_IMAGE_DIMENSION = 1280
@@ -1556,52 +1552,6 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
         private const val COLLAPSED_REPLY_MIN_LINES = 1
         private const val EXPANDED_REPLY_MIN_LINES = 3
         private const val MAX_HEADING_LEVEL = 6
-
-        internal fun formatRelativeTime(context: Context, timestamp: Long): String {
-            val now = System.currentTimeMillis()
-            val diffMillis = max(0L, now - timestamp)
-            val minutes = diffMillis / MINUTE_MILLIS
-            val hours = diffMillis / HOUR_MILLIS
-            val days = diffMillis / DAY_MILLIS
-            val months = diffMillis / MONTH_MILLIS
-            val years = diffMillis / YEAR_MILLIS
-            return when {
-                years >= 1 -> if (years == 1L) {
-                    context.getString(R.string.dashboard_relative_time_year)
-                } else {
-                    context.getString(R.string.dashboard_relative_time_years, years)
-                }
-                months >= 1 -> if (months == 1L) {
-                    context.getString(R.string.dashboard_relative_time_month)
-                } else {
-                    context.getString(R.string.dashboard_relative_time_months, months)
-                }
-                days >= 1 -> if (days == 1L) {
-                    context.getString(R.string.dashboard_relative_time_day)
-                } else {
-                    context.getString(R.string.dashboard_relative_time_days, days)
-                }
-                hours >= 1 -> if (hours == 1L) {
-                    context.getString(R.string.dashboard_relative_time_hour)
-                } else {
-                    context.getString(R.string.dashboard_relative_time_hours, hours)
-                }
-                minutes >= 1 -> if (minutes == 1L) {
-                    context.getString(R.string.dashboard_relative_time_minute)
-                } else {
-                    context.getString(R.string.dashboard_relative_time_minutes, minutes)
-                }
-                else -> context.getString(R.string.dashboard_relative_time_seconds)
-            }
-        }
-
-        internal fun buildMetadata(username: String?, relativeTime: String): String {
-            return if (!username.isNullOrBlank()) {
-                "@${username.trim()} • $relativeTime"
-            } else {
-                relativeTime
-            }
-        }
 
         private val NUMBERED_LIST_REGEX = Regex("^(\\d+)\\.\\s*(.*)$")
         private val IMAGE_MARKDOWN_REGEX = Regex("!\\[[^\\]]*\\]\\(([^)]+)\\)")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostDetailAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostDetailAdapter.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.lite.dashboard
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
+import org.ole.planet.myplanet.lite.util.TimeUtils
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -104,8 +105,8 @@ class PostDetailAdapter(
 
         fun bind(item: PostDetailItem.Header) {
             authorView.text = item.author
-            val relativeTime = DashboardPostDetailActivity.formatRelativeTime(itemView.context, item.timestamp)
-            metadataView.text = DashboardPostDetailActivity.buildMetadata(item.username, relativeTime)
+            val relativeTime = TimeUtils.formatRelativeTime(itemView.context, item.timestamp)
+            metadataView.text = TimeUtils.buildMetadata(item.username, relativeTime)
             if (item.message.isNullOrBlank()) {
                 bodyView.isVisible = false
                 bodyView.text = ""
@@ -218,8 +219,8 @@ class PostDetailAdapter(
 
         fun bind(item: PostDetailItem.Comment, isLast: Boolean) {
             authorView.text = item.author
-            val relativeTime = DashboardPostDetailActivity.formatRelativeTime(itemView.context, item.timestamp)
-            metadataView.text = DashboardPostDetailActivity.buildMetadata(item.username, relativeTime)
+            val relativeTime = TimeUtils.formatRelativeTime(itemView.context, item.timestamp)
+            metadataView.text = TimeUtils.buildMetadata(item.username, relativeTime)
             if (item.message.isNullOrBlank()) {
                 bodyView.isVisible = false
                 bodyView.text = ""

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/TimeUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/TimeUtils.kt
@@ -1,0 +1,60 @@
+package org.ole.planet.myplanet.lite.util
+
+import android.content.Context
+import org.ole.planet.myplanet.lite.R
+import kotlin.math.max
+
+object TimeUtils {
+
+    private const val MINUTE_MILLIS = 60_000L
+    private const val HOUR_MILLIS = 60 * MINUTE_MILLIS
+    private const val DAY_MILLIS = 24 * HOUR_MILLIS
+    private const val MONTH_MILLIS = 30 * DAY_MILLIS
+    private const val YEAR_MILLIS = 12 * MONTH_MILLIS
+
+    fun formatRelativeTime(context: Context, timestamp: Long): String {
+        val now = System.currentTimeMillis()
+        val diffMillis = max(0L, now - timestamp)
+        val minutes = diffMillis / MINUTE_MILLIS
+        val hours = diffMillis / HOUR_MILLIS
+        val days = diffMillis / DAY_MILLIS
+        val months = diffMillis / MONTH_MILLIS
+        val years = diffMillis / YEAR_MILLIS
+        return when {
+            years >= 1 -> if (years == 1L) {
+                context.getString(R.string.dashboard_relative_time_year)
+            } else {
+                context.getString(R.string.dashboard_relative_time_years, years)
+            }
+            months >= 1 -> if (months == 1L) {
+                context.getString(R.string.dashboard_relative_time_month)
+            } else {
+                context.getString(R.string.dashboard_relative_time_months, months)
+            }
+            days >= 1 -> if (days == 1L) {
+                context.getString(R.string.dashboard_relative_time_day)
+            } else {
+                context.getString(R.string.dashboard_relative_time_days, days)
+            }
+            hours >= 1 -> if (hours == 1L) {
+                context.getString(R.string.dashboard_relative_time_hour)
+            } else {
+                context.getString(R.string.dashboard_relative_time_hours, hours)
+            }
+            minutes >= 1 -> if (minutes == 1L) {
+                context.getString(R.string.dashboard_relative_time_minute)
+            } else {
+                context.getString(R.string.dashboard_relative_time_minutes, minutes)
+            }
+            else -> context.getString(R.string.dashboard_relative_time_seconds)
+        }
+    }
+
+    fun buildMetadata(username: String?, relativeTime: String): String {
+        return if (!username.isNullOrBlank()) {
+            "@${username.trim()} • $relativeTime"
+        } else {
+            relativeTime
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Extracted duplicated `formatRelativeTime` and `buildMetadata` functions, and their constants, from `DashboardVoicesFragment` and `DashboardPostDetailActivity` into a shared utility object `TimeUtils`.
💡 **Why:** This reduces code duplication and improves maintainability by centralizing common time formatting and metadata building logic into a single, reusable component. It aligns with DRY principles and improves code readability.
✅ **Verification:** Verified that changes compile correctly and all existing tests (`DashboardVoicesFragmentTest` and `DashboardPostDetailActivityRobolectricTest`) pass successfully.
✨ **Result:** Improved code health by eliminating redundant logic, ensuring future modifications to time formatting only need to be applied in one place.

---
*PR created automatically by Jules for task [1244570074338748007](https://jules.google.com/task/1244570074338748007) started by @dogi*