### PR TITLE
Prevent Future Dates in Date of Birth Selection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 440
-        versionName = "0.4.40"
+        versionCode = 441
+        versionName = "0.4.41"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivityFlowExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivityFlowExtensions.kt
@@ -13,6 +13,7 @@ import androidx.core.content.edit
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.lite.util.BirthDateConstraints
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
 internal fun SignupActivity.navigateBack() {
@@ -232,7 +233,8 @@ internal fun SignupActivity.showUsernameAvailabilityChecking(isChecking: Boolean
 }
 
 internal fun SignupActivity.validateBirthDate(): Boolean {
-    return if (birthDateSelection != null) {
+    val selection = birthDateSelection
+    return if (selection != null && !BirthDateConstraints.isFuture(selection)) {
         birthDateLayout.error = null
         true
     } else {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivityUiExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivityUiExtensions.kt
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import org.ole.planet.myplanet.lite.util.BirthDateConstraints
 
 internal fun SignupActivity.initializeViews() {
     scrollView = findViewById(R.id.signupScroll)
@@ -272,12 +273,16 @@ internal fun SignupActivity.showBirthDatePicker() {
 
     val picker = MaterialDatePicker.Builder.datePicker()
         .setTitleText(getString(R.string.signup_birth_date_picker_title))
+        .setCalendarConstraints(BirthDateConstraints.calendarConstraints())
         .apply {
-            birthDateSelection?.let { setSelection(it) }
+            setSelection(BirthDateConstraints.coerceSelection(birthDateSelection))
         }
         .build()
 
     picker.addOnPositiveButtonClickListener { selection ->
+        if (BirthDateConstraints.isFuture(selection)) {
+            return@addOnPositiveButtonClickListener
+        }
         birthDateSelection = selection
         birthDateInput.setText(formatBirthDate(selection))
         birthDateLayout.error = null

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardRespondentExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardRespondentExtensions.kt
@@ -74,6 +74,7 @@ import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository
 import org.ole.planet.myplanet.lite.surveys.SurveyTranslationManager
 import org.ole.planet.myplanet.lite.surveys.SurveyTranslationManager.TranslatedQuestion
+import org.ole.planet.myplanet.lite.util.BirthDateConstraints
 import org.ole.planet.myplanet.lite.util.NetworkUtils
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import androidx.core.graphics.toColorInt
@@ -101,9 +102,12 @@ internal fun SurveyWizardFragment.applyProfileDefaultsForCourseContent() {
     respondent.language = assignIfEmpty(respondent.language, profile.language)
     respondent.level = assignIfEmpty(respondent.level, profile.level)
     if (respondent.birthDate.isNullOrBlank() && !profile.birthDate.isNullOrBlank()) {
-        respondent.birthDate = profile.birthDate
-        birthDateSelection = parseBirthDateIso(profile.birthDate)
-        hasOptionalDetails = true
+        val profileBirthDateSelection = parseBirthDateIso(profile.birthDate)
+        if (profileBirthDateSelection != null && !BirthDateConstraints.isFuture(profileBirthDateSelection)) {
+            respondent.birthDate = profile.birthDate
+            birthDateSelection = profileBirthDateSelection
+            hasOptionalDetails = true
+        }
     }
     val birthDateMillis = birthDateSelection
     if (birthDateMillis != null) {
@@ -200,8 +204,9 @@ internal fun SurveyWizardFragment.scrollFocusedFieldIntoView(view: View) {
 
 internal fun SurveyWizardFragment.updateRespondentBirthYear(value: String?) {
     val year = value?.trim().orEmpty().toIntOrNull()
-    respondent.birthYear = year
-    respondent.age = year?.let { Calendar.getInstance().get(Calendar.YEAR) - it }
+    val nowYear = Calendar.getInstance().get(Calendar.YEAR)
+    respondent.birthYear = year?.takeIf { it <= nowYear }
+    respondent.age = respondent.birthYear?.let { nowYear - it }
 }
 
 internal fun SurveyWizardFragment.createAdditionalCheckBox(context: android.content.Context): CheckBox {
@@ -236,6 +241,9 @@ internal fun SurveyWizardFragment.renderBasicsStep(): Pair<View, () -> Boolean> 
         val year = yearText.toIntOrNull()
         if (yearText.isNotEmpty() && year == null) {
             showValidationMessage(R.string.dashboard_survey_wizard_birth_year_required)
+            false
+        } else if (year != null && year > Calendar.getInstance().get(Calendar.YEAR)) {
+            showValidationMessage(R.string.dashboard_survey_wizard_birth_year_future)
             false
         } else {
             val nowYear = Calendar.getInstance().get(Calendar.YEAR)
@@ -345,7 +353,9 @@ internal fun SurveyWizardFragment.renderBirthDateStep(): Pair<View, () -> Boolea
     container.addView(birthDateLayout)
 
     val collector = {
-        respondent.birthDate = birthDateSelection?.let { formatBirthDateIso(it) }
+        respondent.birthDate = birthDateSelection
+            ?.takeUnless { BirthDateConstraints.isFuture(it) }
+            ?.let { formatBirthDateIso(it) }
         true
     }
     return container to collector
@@ -358,12 +368,16 @@ internal fun SurveyWizardFragment.showBirthDatePicker(input: TextInputEditText) 
 
     val picker = MaterialDatePicker.Builder.datePicker()
         .setTitleText(getString(R.string.signup_birth_date_picker_title))
+        .setCalendarConstraints(BirthDateConstraints.calendarConstraints())
         .apply {
-            birthDateSelection?.let { setSelection(it) }
+            setSelection(BirthDateConstraints.coerceSelection(birthDateSelection))
         }
         .build()
 
     picker.addOnPositiveButtonClickListener { selection ->
+        if (BirthDateConstraints.isFuture(selection)) {
+            return@addOnPositiveButtonClickListener
+        }
         birthDateSelection = selection
         input.setText(formatBirthDateIso(selection))
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -61,6 +61,7 @@ import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.auth.AuthResult
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 import org.ole.planet.myplanet.lite.model.LanguageOption
+import org.ole.planet.myplanet.lite.util.BirthDateConstraints
 import org.ole.planet.myplanet.lite.util.nullIfBlank
 
 class ProfileActivity : BaseActivity() {
@@ -312,7 +313,7 @@ class ProfileActivity : BaseActivity() {
             lastNameInput.setText(profile?.lastName.orEmpty())
             emailInput.setText(profile?.email.orEmpty())
             phoneInput.setText(profile?.phoneNumber.orEmpty())
-            selectedBirthDateIso = profile?.birthDate
+            selectedBirthDateIso = normalizeBirthDateIso(profile?.birthDate)
             birthDateInput.setText(formatBirthDate(selectedBirthDateIso))
 
             applyAvatarBitmap(decodeAvatarBytes(profile?.avatarImage))
@@ -375,7 +376,7 @@ class ProfileActivity : BaseActivity() {
             else -> null
         }
 
-        val birthDateIso = selectedBirthDateIso
+        val birthDateIso = normalizeBirthDateIso(selectedBirthDateIso)
 
         return ProfileFormValues(
             firstName = firstNameInput.text?.toString()?.trim().nullIfBlank(),
@@ -725,12 +726,17 @@ class ProfileActivity : BaseActivity() {
     }
 
     private fun showBirthDatePicker(targetView: TextInputEditText) {
+        val selection = BirthDateConstraints.coerceSelection(parseBirthDateToMillis(selectedBirthDateIso))
         val picker = MaterialDatePicker.Builder.datePicker()
             .setTitleText(R.string.profile_birth_date_picker_title)
-            .setSelection(parseBirthDateToMillis(selectedBirthDateIso) ?: MaterialDatePicker.todayInUtcMilliseconds())
+            .setSelection(selection)
+            .setCalendarConstraints(BirthDateConstraints.calendarConstraints())
             .build()
 
         picker.addOnPositiveButtonClickListener { selection ->
+            if (BirthDateConstraints.isFuture(selection)) {
+                return@addOnPositiveButtonClickListener
+            }
             val iso = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 Instant.ofEpochMilli(selection).atZone(ZoneOffset.UTC).toInstant().toString()
             } else {
@@ -744,6 +750,11 @@ class ProfileActivity : BaseActivity() {
         }
 
         picker.show(supportFragmentManager, "birthDatePicker")
+    }
+
+    private fun normalizeBirthDateIso(raw: String?): String? {
+        val millis = parseBirthDateToMillis(raw)
+        return raw?.takeIf { millis != null && !BirthDateConstraints.isFuture(millis) }
     }
 
     private fun parseBirthDateToMillis(raw: String?): Long? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/BirthDateConstraints.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/BirthDateConstraints.kt
@@ -1,0 +1,24 @@
+package org.ole.planet.myplanet.lite.util
+
+import com.google.android.material.datepicker.CalendarConstraints
+import com.google.android.material.datepicker.DateValidatorPointBackward
+import com.google.android.material.datepicker.MaterialDatePicker
+
+object BirthDateConstraints {
+    fun calendarConstraints(): CalendarConstraints {
+        val today = MaterialDatePicker.todayInUtcMilliseconds()
+        return CalendarConstraints.Builder()
+            .setEnd(today)
+            .setValidator(DateValidatorPointBackward.now())
+            .build()
+    }
+
+    fun coerceSelection(selection: Long?): Long {
+        val today = MaterialDatePicker.todayInUtcMilliseconds()
+        return selection?.coerceAtMost(today) ?: today
+    }
+
+    fun isFuture(selection: Long): Boolean {
+        return selection > MaterialDatePicker.todayInUtcMilliseconds()
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -428,6 +428,7 @@
     <string name="dashboard_survey_wizard_gender_label">اختر جنس المستجيب</string>
     <string name="dashboard_survey_wizard_birth_year_label">سنة الميلاد</string>
     <string name="dashboard_survey_wizard_birth_year_required">أدخل سنة الميلاد للمتابعة.</string>
+    <string name="dashboard_survey_wizard_birth_year_future">لا يمكن أن تكون سنة الميلاد في المستقبل.</string>
     <string name="dashboard_survey_wizard_additional_info_label">تفاصيل إضافية (اختياري)</string>
     <string name="dashboard_survey_wizard_names_title">اسم المستجيب</string>
     <string name="dashboard_survey_wizard_first_name_label">الاسم الأول (اختياري)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -427,6 +427,7 @@ Si no está de acuerdo, debe seleccionar "Cancelar" y dejar de usar la aplicaci�
     <string name="dashboard_survey_wizard_gender_label">Selecciona el género del encuestado</string>
     <string name="dashboard_survey_wizard_birth_year_label">Año de nacimiento</string>
     <string name="dashboard_survey_wizard_birth_year_required">Ingresa el año de nacimiento para continuar.</string>
+    <string name="dashboard_survey_wizard_birth_year_future">El año de nacimiento no puede estar en el futuro.</string>
     <string name="dashboard_survey_wizard_additional_info_label">Detalles adicionales (opcional)</string>
     <string name="dashboard_survey_wizard_names_title">Nombre del encuestado</string>
     <string name="dashboard_survey_wizard_first_name_label">Nombre (opcional)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -424,6 +424,7 @@ Si vous n\'êtes pas d\'accord, vous devez sélectionner « Annuler » et cess
     <string name="dashboard_survey_wizard_gender_label">Sélectionnez le genre du répondant</string>
     <string name="dashboard_survey_wizard_birth_year_label">Année de naissance</string>
     <string name="dashboard_survey_wizard_birth_year_required">Saisissez l\'année de naissance pour continuer.</string>
+    <string name="dashboard_survey_wizard_birth_year_future">L\'année de naissance ne peut pas être dans le futur.</string>
     <string name="dashboard_survey_wizard_additional_info_label">Détails supplémentaires (facultatif)</string>
     <string name="dashboard_survey_wizard_names_title">Nom du répondant</string>
     <string name="dashboard_survey_wizard_first_name_label">Prénom (facultatif)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -444,6 +444,7 @@ Applications: Planet, myPlanet, और myPlanetLite</string>
     <string name="dashboard_survey_wizard_gender_label">प्रतिक्रिया देने वाले का लिंग चुनें</string>
     <string name="dashboard_survey_wizard_birth_year_label">जन्म वर्ष</string>
     <string name="dashboard_survey_wizard_birth_year_required">आगे बढ़ने के लिए जन्म वर्ष दर्ज करें।</string>
+    <string name="dashboard_survey_wizard_birth_year_future">जन्म वर्ष भविष्य में नहीं हो सकता।</string>
     <string name="dashboard_survey_wizard_additional_info_label">अतिरिक्त विवरण (वैकल्पिक)</string>
     <string name="dashboard_survey_wizard_names_title">प्रतिक्रिया देने वाले का नाम</string>
     <string name="dashboard_survey_wizard_first_name_label">पहला नाम (वैकल्पिक)</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -387,6 +387,7 @@
     <string name="dashboard_survey_wizard_gender_label">प्रतिवादीको लिङ्ग छान्नुहोस्</string>
     <string name="dashboard_survey_wizard_birth_year_label">जन्म वर्ष</string>
     <string name="dashboard_survey_wizard_birth_year_required">जारी राख्न जन्म वर्ष लेख्नुहोस्।</string>
+    <string name="dashboard_survey_wizard_birth_year_future">जन्म वर्ष भविष्यमा हुन सक्दैन।</string>
     <string name="dashboard_survey_wizard_additional_info_label">थप विवरण (वैकल्पिक)</string>
     <string name="dashboard_survey_wizard_names_title">प्रतिवादीको नाम</string>
     <string name="dashboard_survey_wizard_first_name_label">पहिलो नाम (वैकल्पिक)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -456,6 +456,7 @@ Se você não concordar, deve selecionar "Cancelar" e parar de usar o aplicativo
     <string name="dashboard_survey_wizard_gender_label">Selecione o gênero do respondente</string>
     <string name="dashboard_survey_wizard_birth_year_label">Ano de nascimento</string>
     <string name="dashboard_survey_wizard_birth_year_required">Digite um ano de nascimento para continuar.</string>
+    <string name="dashboard_survey_wizard_birth_year_future">O ano de nascimento não pode estar no futuro.</string>
     <string name="dashboard_survey_wizard_additional_info_label">Detalhes adicionais (opcional)</string>
     <string name="dashboard_survey_wizard_names_title">Nome do respondente</string>
     <string name="dashboard_survey_wizard_first_name_label">Nome (opcional)</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -387,6 +387,7 @@ Haddii aadan oggolayn, waa inaad doorataa "Jooji" oo aad joojisaa isticmaalka ba
     <string name="dashboard_survey_wizard_gender_label">Dooro jinsiga ka qaybgalaha</string>
     <string name="dashboard_survey_wizard_birth_year_label">Sanadka dhalashada</string>
     <string name="dashboard_survey_wizard_birth_year_required">Geli sanadka dhalashada si aad u socoto.</string>
+    <string name="dashboard_survey_wizard_birth_year_future">Sanadka dhalashadu mustaqbalka ma noqon karo.</string>
     <string name="dashboard_survey_wizard_additional_info_label">Faahfaahin dheeraad ah (ikhtiyaari)</string>
     <string name="dashboard_survey_wizard_names_title">Magaca ka qaybgalaha</string>
     <string name="dashboard_survey_wizard_first_name_label">Magaca koowaad (ikhtiyaari)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -459,6 +459,7 @@ If you do not agree, you must select "Cancel" and stop using the application.</s
     <string name="dashboard_survey_wizard_gender_label">Select respondent gender</string>
     <string name="dashboard_survey_wizard_birth_year_label">Year of birth</string>
     <string name="dashboard_survey_wizard_birth_year_required">Enter a birth year to continue.</string>
+    <string name="dashboard_survey_wizard_birth_year_future">Birth year cannot be in the future.</string>
     <string name="dashboard_survey_wizard_additional_info_label">Additional details (optional)</string>
     <string name="dashboard_survey_wizard_names_title">Respondent name</string>
     <string name="dashboard_survey_wizard_first_name_label">First name (optional)</string>


### PR DESCRIPTION
## Prevent Future Dates in Date of Birth Selection

🎯 What:
Updated the Date of Birth picker to enforce a maximum selectable date of the current day, preventing users from selecting future dates or years beyond the current year.

💡 Why:
A date of birth cannot occur in the future. The previous implementation allowed users to navigate to and select years beyond the current year, resulting in invalid profile or registration data.

🛠️ Solution:
- Configured the Date of Birth picker to use today's date as the maximum allowed date.
- Prevented selection of future years and dates through the date picker UI.
- Added validation to reject future dates if they are provided through manual input or unexpected client behavior.
- Ensured the same validation is applied consistently across registration and profile editing flows.

✅ Verification:
- Verified that years beyond the current year are no longer selectable.
- Verified that future dates within the current year are disabled.
- Verified that today's date remains selectable.
- Tested both registration and profile update workflows.
- Ran relevant unit and UI tests to confirm no regressions.

✨ Result:
Users can no longer select future dates for their Date of Birth, ensuring data consistency and preventing invalid age calculations.


<img width="610" height="1356" alt="image" src="https://github.com/user-attachments/assets/af3aec80-7c16-4318-87c6-b1bdb513bf38" />
