### PR TITLE
Show Snackbar When Exam Is Required to Continue

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 440
-        versionName = "0.4.40"
+        versionCode = 442
+        versionName = "0.4.42"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -29,6 +29,7 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.PlayerView
+import com.google.android.material.snackbar.Snackbar
 import io.noties.markwon.Markwon
 import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.html.HtmlPlugin
@@ -81,8 +82,8 @@ class CourseWizardActivity : BaseActivity() {
     private val localSurveyRepository by lazy { DashboardLocalSurveyRepository(applicationContext) }
     private var hasAutoCompletedFirstStep = false
     private val audioPlayers = mutableListOf<ExoPlayer>()
-    private val completedExamSteps = mutableSetOf<Int>()
-    private var pendingExamStepIndex: Int? = null
+    private val completedRequiredSteps = mutableSetOf<Int>()
+    private var pendingRequiredStepIndex: Int? = null
     private var cachedProgressDocument: DashboardCoursesRepository.CourseProgressDocument? = null
 
     private val fullscreenLauncher =
@@ -95,14 +96,14 @@ class CourseWizardActivity : BaseActivity() {
             )
         }
 
-    private val examLauncher =
+    private val requiredStepLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
-                pendingExamStepIndex?.let { completedExamSteps.add(it) }
+                pendingRequiredStepIndex?.let { completedRequiredSteps.add(it) }
             }
-            pendingExamStepIndex = null
+            pendingRequiredStepIndex = null
             if (this::stepPositionView.isInitialized) {
-                    bindStep()
+                bindStep()
             }
         }
 
@@ -137,9 +138,9 @@ class CourseWizardActivity : BaseActivity() {
         val startIndex = intent.getIntExtra(EXTRA_START_STEP, 0)
         baseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
         credentials = ProfileCredentialsStore.getStoredCredentials(applicationContext)
-        savedInstanceState?.getIntegerArrayList(EXTRA_COMPLETED_EXAM_STEPS)?.let { restored ->
-            completedExamSteps.clear()
-            completedExamSteps.addAll(restored)
+        savedInstanceState?.getIntegerArrayList(EXTRA_COMPLETED_REQUIRED_STEPS)?.let { restored ->
+            completedRequiredSteps.clear()
+            completedRequiredSteps.addAll(restored)
         }
         val rawSteps = IntentCompat.getSerializableExtra(
             intent,
@@ -196,8 +197,8 @@ class CourseWizardActivity : BaseActivity() {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putIntegerArrayList(
-            EXTRA_COMPLETED_EXAM_STEPS,
-            ArrayList(completedExamSteps)
+            EXTRA_COMPLETED_REQUIRED_STEPS,
+            ArrayList(completedRequiredSteps)
         )
     }
 
@@ -257,26 +258,44 @@ class CourseWizardActivity : BaseActivity() {
                 bindStep()
             }
         }
-        val examPending = step.exam?.questions?.isNotEmpty() == true &&
-                !completedExamSteps.contains(currentIndex)
+        val requiredStepPending = isRequiredStepPending(step)
         if (currentIndex >= steps.lastIndex) {
             nextButton.isEnabled = true
             (nextButton as? TextView)?.text = getString(R.string.course_wizard_finish)
-            nextButton.setOnClickListener { finish() }
+            nextButton.setOnClickListener {
+                if (requiredStepPending) {
+                    showCompleteRequiredStepSnackbar()
+                } else {
+                    finish()
+                }
+            }
         } else {
             nextButton.isEnabled = true
             (nextButton as? TextView)?.text = getString(R.string.course_wizard_next)
             nextButton.setOnClickListener {
-                if (currentIndex < steps.lastIndex) {
+                if (requiredStepPending) {
+                    showCompleteRequiredStepSnackbar()
+                } else if (currentIndex < steps.lastIndex) {
                     lifecycleScope.launch {
                         advanceToNextStep()
                     }
                 }
             }
         }
-        if (examPending) {
-            nextButton.isEnabled = false
-        }
+    }
+
+    private fun isRequiredStepPending(step: StepDisplay): Boolean {
+        val hasSurvey = step.survey?.questions?.isNotEmpty() == true
+        val hasExam = step.exam?.questions?.isNotEmpty() == true
+        return (hasSurvey || hasExam) && !completedRequiredSteps.contains(currentIndex)
+    }
+
+    private fun showCompleteRequiredStepSnackbar() {
+        Snackbar.make(
+            findViewById(R.id.courseWizardRoot),
+            getString(R.string.course_wizard_complete_required_step),
+            Snackbar.LENGTH_SHORT
+        ).show()
     }
 
     private fun advanceToNextStep() {
@@ -555,13 +574,14 @@ class CourseWizardActivity : BaseActivity() {
         iconView.contentDescription = getString(R.string.dashboard_surveys_title)
         playButton.contentDescription = getString(R.string.course_wizard_open_survey)
         val openSurvey = {
+            pendingRequiredStepIndex = currentIndex
             SurveyWizardActivity.newIntent(
                 this,
                 survey,
                 survey.teamId,
                 null,
                 courseId
-            ).also { startActivity(it) }
+            ).also { requiredStepLauncher.launch(it) }
         }
         itemView.setOnClickListener { openSurvey() }
         playButton.setOnClickListener { openSurvey() }
@@ -591,7 +611,7 @@ class CourseWizardActivity : BaseActivity() {
         iconView.contentDescription = getString(R.string.dashboard_exam_title)
         playButton.contentDescription = getString(R.string.course_wizard_open_exam)
         val openExam = {
-            pendingExamStepIndex = currentIndex
+            pendingRequiredStepIndex = currentIndex
             SurveyWizardActivity.newIntent(
                 this,
                 exam,
@@ -599,7 +619,7 @@ class CourseWizardActivity : BaseActivity() {
                 null,
                 courseId,
                 isExam = true
-            ).also { examLauncher.launch(it) }
+            ).also { requiredStepLauncher.launch(it) }
         }
         itemView.setOnClickListener { openExam() }
         playButton.setOnClickListener { openExam() }
@@ -859,7 +879,7 @@ class CourseWizardActivity : BaseActivity() {
         private const val EXTRA_COURSE_ID = "extra_course_id"
         private const val EXTRA_STEPS = "extra_steps"
         private const val EXTRA_START_STEP = "extra_start_step"
-        private const val EXTRA_COMPLETED_EXAM_STEPS = "extra_completed_exam_steps"
+        private const val EXTRA_COMPLETED_REQUIRED_STEPS = "extra_completed_required_steps"
         fun start(
             context: Context,
             courseId: String,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardNavigationExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardNavigationExtensions.kt
@@ -289,9 +289,7 @@ internal fun SurveyWizardFragment.buildSteps(includeDetails: Boolean): List<Wiza
 }
 
 internal fun SurveyWizardFragment.finishWithResult() {
-    if (isExam) {
-        requireActivity().setResult(Activity.RESULT_OK)
-    }
+    requireActivity().setResult(Activity.RESULT_OK)
     requireActivity().finish()
 }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -567,6 +567,7 @@
     <string name="course_wizard_next">التالي</string>
     <string name="course_wizard_finish">إنهاء الدورة</string>
     <string name="course_wizard_step_position">الخطوة %1$d من %2$d</string>
+    <string name="course_wizard_complete_required_step">أكمل الاختبار أو الاستبيان للمتابعة.</string>
     <string name="course_wizard_open_survey">فتح الاستبيان</string>
     <string name="course_wizard_open_exam">فتح الامتحان</string>
     <string name="dashboard_exam_title">امتحان</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -566,6 +566,7 @@ Si no est√° de acuerdo, debe seleccionar "Cancelar" y dejar de usar la aplicaci√
     <string name="course_wizard_next">Siguiente</string>
     <string name="course_wizard_finish">Finalizar curso</string>
     <string name="course_wizard_step_position">Paso %1$d de %2$d</string>
+    <string name="course_wizard_complete_required_step">Completa el examen o la encuesta para continuar.</string>
     <string name="course_wizard_open_survey">Abrir encuesta</string>
     <string name="course_wizard_open_exam">Abrir examen</string>
     <string name="dashboard_exam_title">Examen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -563,6 +563,7 @@ Si vous n\'êtes pas d\'accord, vous devez sélectionner « Annuler » et cess
     <string name="course_wizard_next">Suivant</string>
     <string name="course_wizard_finish">Terminer le cours</string>
     <string name="course_wizard_step_position">Étape %1$d sur %2$d</string>
+    <string name="course_wizard_complete_required_step">Terminez le test ou le sondage pour continuer.</string>
     <string name="course_wizard_open_survey">Ouvrir le sondage</string>
     <string name="course_wizard_open_exam">Ouvrir l\'examen</string>
     <string name="dashboard_exam_title">Examen</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -583,6 +583,7 @@ Applications: Planet, myPlanet, और myPlanetLite</string>
     <string name="course_wizard_next">अगला</string>
     <string name="course_wizard_finish">कोर्स पूरा करें</string>
     <string name="course_wizard_step_position">चरण %1$d में से %2$d</string>
+    <string name="course_wizard_complete_required_step">जारी रखने के लिए परीक्षा या सर्वे पूरा करें।</string>
     <string name="course_wizard_attachments_title">संलग्नक</string>
     <string name="course_wizard_attachment_video">वीडियो</string>
     <string name="course_wizard_attachment_image">छवि</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -564,6 +564,7 @@
     <string name="course_wizard_next">अर्को</string>
     <string name="course_wizard_finish">पाठ्यक्रम समाप्त गर्नुहोस्</string>
     <string name="course_wizard_step_position">चरण %1$d / %2$d</string>
+    <string name="course_wizard_complete_required_step">जारी राख्न परीक्षा वा सर्वेक्षण पूरा गर्नुहोस्।</string>
     <string name="course_wizard_attachments_title">संलग्नहरू</string>
     <string name="course_wizard_attachment_video">भिडियो</string>
     <string name="course_wizard_attachment_image">तस्बिर</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -593,6 +593,7 @@ Se você não concordar, deve selecionar "Cancelar" e parar de usar o aplicativo
     <string name="course_wizard_next">Próximo</string>
     <string name="course_wizard_finish">Concluir curso</string>
     <string name="course_wizard_step_position">Etapa %1$d de %2$d</string>
+    <string name="course_wizard_complete_required_step">Conclua o teste ou a pesquisa para continuar.</string>
     <string name="course_wizard_open_survey">Abrir pesquisa</string>
     <string name="course_wizard_open_exam">Abrir prova</string>
     <string name="dashboard_exam_title">Prova</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -564,6 +564,7 @@ Haddii aadan oggolayn, waa inaad doorataa "Jooji" oo aad joojisaa isticmaalka ba
     <string name="course_wizard_next">Kan xiga</string>
     <string name="course_wizard_finish">Dhamee koorsada</string>
     <string name="course_wizard_step_position">Tallaabo %1$d ee %2$d</string>
+    <string name="course_wizard_complete_required_step">Dhammaystir imtixaanka ama sahanka si aad u sii socoto.</string>
     <string name="course_wizard_open_survey">Fur sahanka</string>
     <string name="course_wizard_attachments_title">Faylasha la lifaaqay</string>
     <string name="course_wizard_attachment_video">Fiidyow</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,6 +596,7 @@ If you do not agree, you must select "Cancel" and stop using the application.</s
     <string name="course_wizard_next">Next</string>
     <string name="course_wizard_finish">Finish course</string>
     <string name="course_wizard_step_position">Step %1$d of %2$d</string>
+    <string name="course_wizard_complete_required_step">Complete the test or survey to continue.</string>
     <string name="course_wizard_open_survey">Open survey</string>
     <string name="course_wizard_open_exam">Open exam</string>
     <string name="dashboard_exam_title">Exam</string>

--- a/app/src/test/java/org/ole/planet/myplanet/lite/CourseWizardActivityTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/CourseWizardActivityTest.kt
@@ -4,25 +4,34 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.button.MaterialButton
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.DashboardCoursePageFragment.CourseItem
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
 import org.robolectric.annotation.Config
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -84,5 +93,105 @@ class CourseWizardActivityTest {
 
         assertFalse(activity.isFinishing)
         controller.pause().stop().destroy()
+    }
+
+    @Test
+    fun `next shows snackbar and stays on current step when exam is incomplete`() = runTest(testDispatcher) {
+        val controller = Robolectric.buildActivity(
+            CourseWizardActivity::class.java,
+            createCourseIntent(
+                listOf(
+                    lessonStep(
+                        title = "Step 1",
+                        exam = requiredSurveyDocument("exam1")
+                    ),
+                    lessonStep(title = "Step 2")
+                )
+            )
+        )
+        val activity = controller.create().start().resume().visible().get()
+        advanceUntilIdle()
+
+        activity.findViewById<MaterialButton>(R.id.courseWizardNext).performClick()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals("Step 1", activity.findViewById<TextView>(R.id.courseWizardStepTitle).text.toString())
+        assertTrue(
+            activity.window.decorView.containsText(
+                activity.getString(R.string.course_wizard_complete_required_step)
+            )
+        )
+        controller.pause().stop().destroy()
+    }
+
+    @Test
+    fun `next shows snackbar and stays on current step when survey is incomplete`() = runTest(testDispatcher) {
+        val controller = Robolectric.buildActivity(
+            CourseWizardActivity::class.java,
+            createCourseIntent(
+                listOf(
+                    lessonStep(
+                        title = "Step 1",
+                        survey = requiredSurveyDocument("survey1")
+                    ),
+                    lessonStep(title = "Step 2")
+                )
+            )
+        )
+        val activity = controller.create().start().resume().visible().get()
+        advanceUntilIdle()
+
+        activity.findViewById<MaterialButton>(R.id.courseWizardNext).performClick()
+        ShadowLooper.idleMainLooper()
+
+        assertEquals("Step 1", activity.findViewById<TextView>(R.id.courseWizardStepTitle).text.toString())
+        assertTrue(
+            activity.window.decorView.containsText(
+                activity.getString(R.string.course_wizard_complete_required_step)
+            )
+        )
+        controller.pause().stop().destroy()
+    }
+
+    private fun createCourseIntent(steps: List<CourseItem.LessonStep>): Intent {
+        return Intent(context, CourseWizardActivity::class.java).apply {
+            putExtra("extra_course_id", "course1")
+            putExtra("extra_title", "Test Course")
+            putExtra("extra_steps", ArrayList(steps))
+            putExtra("extra_start_step", 0)
+        }
+    }
+
+    private fun lessonStep(
+        title: String,
+        survey: SurveyDocument? = null,
+        exam: SurveyDocument? = null
+    ): CourseItem.LessonStep {
+        return CourseItem.LessonStep(
+            title = title,
+            description = "$title description",
+            mediaTypes = emptyList(),
+            resources = emptyList(),
+            exam = exam,
+            survey = survey
+        )
+    }
+
+    private fun requiredSurveyDocument(id: String): SurveyDocument {
+        return SurveyDocument(
+            id = id,
+            name = "Required",
+            questions = listOf(SurveyQuestion(body = "Question", type = "input"))
+        )
+    }
+
+    private fun View.containsText(expected: String): Boolean {
+        if (this is TextView && text?.toString() == expected) return true
+        if (this is ViewGroup) {
+            for (index in 0 until childCount) {
+                if (getChildAt(index).containsText(expected)) return true
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
## Show Snackbar When Exam Is Required to Continue

🎯 What:
Added user feedback when attempting to proceed to the next course step without completing a required exam or test.

💡 Why:
Previously, users could press the **Next** button without receiving a clear explanation as to why navigation was blocked. This created confusion and made it unclear that the exam/test must be completed before progressing.

🛠️ Solution:
- Display a Snackbar when the user attempts to continue without completing a required exam.
- Prevent navigation to the next step until the exam/test requirements are satisfied.
- Provide a clear and user-friendly message explaining why progression is blocked.

Suggested message:
> "Please complete the exam before continuing."

✅ Verification:
- Opened **Unit 1: Fairy Tales Retold**.
- Navigated to Step 7.
- Attempted to proceed without completing the exam.
- Verified that a Snackbar is displayed.
- Verified that navigation remains blocked until the exam is completed.
- Verified that the Snackbar is not shown once the exam has been successfully completed.

✨ Result:
Users now receive immediate feedback when attempting to advance without completing a required exam, improving usability and reducing confusion during course progression.


<img width="610" height="1356" alt="image" src="https://github.com/user-attachments/assets/99182f2f-198e-4dd2-a7ad-c59466dbed66" />
