### PR TITLE
Mark Course as Completed After Finishing Wizard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 440
-        versionName = "0.4.40"
+        versionCode = 443
+        versionName = "0.4.43"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseWizardActivity.kt
@@ -262,7 +262,12 @@ class CourseWizardActivity : BaseActivity() {
         if (currentIndex >= steps.lastIndex) {
             nextButton.isEnabled = true
             (nextButton as? TextView)?.text = getString(R.string.course_wizard_finish)
-            nextButton.setOnClickListener { finish() }
+            nextButton.setOnClickListener {
+                nextButton.isEnabled = false
+                lifecycleScope.launch {
+                    finishCourse()
+                }
+            }
         } else {
             nextButton.isEnabled = true
             (nextButton as? TextView)?.text = getString(R.string.course_wizard_next)
@@ -302,19 +307,20 @@ class CourseWizardActivity : BaseActivity() {
         val existingDoc = existingDocuments?.get(id)
         val existingStep = existingDoc?.stepNum ?: 0
         if (existingStep >= targetStepNumber) return
+        val progressDoc = existingDoc ?: cachedProgressDocument
         val now = System.currentTimeMillis()
         val document = DashboardCoursesRepository.CourseProgressUpdateDocument(
-            id = cachedProgressDocument?.id,
-            rev = cachedProgressDocument?.rev,
+            id = progressDoc?.id,
+            rev = progressDoc?.rev,
             userId = "org.couchdb.user:${creds.username}",
             courseId = id,
             stepNum = targetStepNumber,
             passed = true,
-            createdOn = cachedProgressDocument?.createdOn
+            createdOn = progressDoc?.createdOn
                 ?: DashboardServerPreferences.getServerCode(applicationContext),
-            parentCode = cachedProgressDocument?.parentCode
+            parentCode = progressDoc?.parentCode
                 ?: DashboardServerPreferences.getServerParentCode(applicationContext),
-            createdDate = cachedProgressDocument?.createdDate ?: now,
+            createdDate = progressDoc?.createdDate ?: now,
             updatedDate = now
         )
         val saveResult = coursesRepository.saveCourseProgress(normalizedBase, creds, listOf(document))
@@ -337,6 +343,19 @@ class CourseWizardActivity : BaseActivity() {
                 parentCode = document.parentCode
             )
         }
+    }
+
+    private suspend fun finishCourse() {
+        runCatching { updateCourseProgressIfNeeded(steps.size) }
+        setResult(
+            RESULT_OK,
+            Intent().apply {
+                putExtra(EXTRA_RESULT_COURSE_ID, courseId)
+                putExtra(EXTRA_RESULT_PROGRESS_PERCENT, 100)
+                putExtra(EXTRA_RESULT_CURRENT_STEP, steps.lastIndex)
+            }
+        )
+        finish()
     }
 
     private suspend fun flushPendingCourseProgress() {
@@ -860,6 +879,25 @@ class CourseWizardActivity : BaseActivity() {
         private const val EXTRA_STEPS = "extra_steps"
         private const val EXTRA_START_STEP = "extra_start_step"
         private const val EXTRA_COMPLETED_EXAM_STEPS = "extra_completed_exam_steps"
+        const val EXTRA_RESULT_COURSE_ID = "extra_result_course_id"
+        const val EXTRA_RESULT_PROGRESS_PERCENT = "extra_result_progress_percent"
+        const val EXTRA_RESULT_CURRENT_STEP = "extra_result_current_step"
+
+        fun createIntent(
+            context: Context,
+            courseId: String,
+            courseTitle: String,
+            steps: List<DashboardCoursePageFragment.CourseItem.LessonStep>,
+            startStep: Int
+        ): Intent {
+            return Intent(context, CourseWizardActivity::class.java).apply {
+                putExtra(EXTRA_COURSE_ID, courseId)
+                putExtra(EXTRA_TITLE, courseTitle)
+                putExtra(EXTRA_STEPS, ArrayList(steps))
+                putExtra(EXTRA_START_STEP, startStep)
+            }
+        }
+
         fun start(
             context: Context,
             courseId: String,
@@ -867,12 +905,7 @@ class CourseWizardActivity : BaseActivity() {
             steps: List<DashboardCoursePageFragment.CourseItem.LessonStep>,
             startStep: Int
         ) {
-            val intent = Intent(context, CourseWizardActivity::class.java).apply {
-                putExtra(EXTRA_COURSE_ID, courseId)
-                putExtra(EXTRA_TITLE, courseTitle)
-                putExtra(EXTRA_STEPS, ArrayList(steps))
-                putExtra(EXTRA_START_STEP, startStep)
-            }
+            val intent = createIntent(context, courseId, courseTitle, steps, startStep)
             context.startActivity(intent)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -13,6 +13,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -76,6 +77,24 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
     private val httpClient = OkHttpClient()
     private val activeDownloads = mutableMapOf<String, Job>()
     private val localSurveyRepository by lazy { DashboardLocalSurveyRepository(requireContext()) }
+    private val courseWizardLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode != android.app.Activity.RESULT_OK) return@registerForActivityResult
+            val data = result.data
+            val courseId = data?.getStringExtra(CourseWizardActivity.EXTRA_RESULT_COURSE_ID)
+            val progressPercent = data?.getIntExtra(
+                CourseWizardActivity.EXTRA_RESULT_PROGRESS_PERCENT,
+                -1
+            )?.takeIf { it >= 0 }
+            val currentStep = data?.getIntExtra(
+                CourseWizardActivity.EXTRA_RESULT_CURRENT_STEP,
+                -1
+            )?.takeIf { it >= 0 }
+            if (!courseId.isNullOrBlank() && progressPercent != null && currentStep != null) {
+                adapter.updateCourseProgress(courseId, progressPercent, currentStep)
+            }
+            refreshCoursesAfterWizard()
+        }
 
     private fun isOfflineModeActive(): Boolean {
         return (activity as? DashboardActivity)?.isOfflineModeActive() == true
@@ -690,7 +709,24 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             return
         }
         val startStep = course.currentStep?.coerceIn(0, course.steps.lastIndex) ?: 0
-        CourseWizardActivity.start(requireContext(), course.id, course.title, course.steps, startStep)
+        courseWizardLauncher.launch(
+            CourseWizardActivity.createIntent(
+                requireContext(),
+                course.id,
+                course.title,
+                course.steps,
+                startStep
+            )
+        )
+    }
+
+    private fun refreshCoursesAfterWizard() {
+        if (!this::adapter.isInitialized) return
+        when (tabPosition) {
+            0 -> refreshUserCourses(adapter, refreshLayout)
+            1 -> refreshAllCourses(adapter, refreshLayout)
+            else -> refreshTeamCourses(adapter, refreshLayout, forceReload = false)
+        }
     }
 
     private fun downloadCourse(course: CourseItem) {
@@ -1215,6 +1251,28 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             }
         }
 
+        fun updateCourseProgress(courseId: String, progressPercent: Int, currentStep: Int) {
+            val update: (CourseItem) -> CourseItem = { item ->
+                if (item.id == courseId) {
+                    item.copy(
+                        progressPercent = progressPercent.coerceIn(0, 100),
+                        currentStep = currentStep.coerceAtLeast(0)
+                    )
+                } else {
+                    item
+                }
+            }
+            val itemIndex = items.indexOfFirst { it.id == courseId }
+            if (itemIndex >= 0) {
+                items[itemIndex] = update(items[itemIndex])
+            }
+            val displayedIndex = displayedItems.indexOfFirst { it.id == courseId }
+            if (displayedIndex >= 0) {
+                displayedItems[displayedIndex] = update(displayedItems[displayedIndex])
+                notifyItemChanged(displayedIndex + 1)
+            }
+        }
+
         fun submitCourses(newItems: List<CourseItem>) {
             val oldDisplayed = displayedItems.toList()
 
@@ -1467,10 +1525,14 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
                 if (showProgress) {
                     progressContainer.visibility = View.VISIBLE
                     progressView.visibility = View.VISIBLE
-                    progressView.text = itemView.context.getString(
-                        R.string.dashboard_course_progress_value,
-                        course.progressPercent
-                    )
+                    progressView.text = if (course.progressPercent >= 100) {
+                        itemView.context.getString(R.string.dashboard_course_completed_progress)
+                    } else {
+                        itemView.context.getString(
+                            R.string.dashboard_course_progress_value,
+                            course.progressPercent
+                        )
+                    }
                     progressIndicator.visibility = View.VISIBLE
                     progressIndicator.progress = course.progressPercent
                 } else {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -551,6 +551,7 @@
     <string name="dashboard_courses_tab_team">دورات الفريق</string>
     <string name="dashboard_courses_content_description_icon">أيقونة الدورة</string>
     <string name="dashboard_course_progress_value">التقدّم: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">مكتمل: 100%</string>
     <string name="dashboard_courses_header_title">ماذا تريد أن تتعلم اليوم؟</string>
     <string name="dashboard_courses_header_subtitle">ابحث في الأسفل.</string>
     <string name="dashboard_courses_search_hint">ابحث عن الدورات</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -550,6 +550,7 @@ Si no está de acuerdo, debe seleccionar "Cancelar" y dejar de usar la aplicaci�
     <string name="dashboard_courses_tab_team">Cursos del equipo</string>
     <string name="dashboard_courses_content_description_icon">Icono del curso</string>
     <string name="dashboard_course_progress_value">Avance: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">Completado: 100%</string>
     <string name="dashboard_courses_header_title">¿Qué te gustaría aprender hoy?</string>
     <string name="dashboard_courses_header_subtitle">Busca a continuación.</string>
     <string name="dashboard_courses_search_hint">Buscar cursos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -547,6 +547,7 @@ Si vous n\'êtes pas d\'accord, vous devez sélectionner « Annuler » et cess
     <string name="dashboard_courses_tab_team">Cours de l\'équipe</string>
     <string name="dashboard_courses_content_description_icon">Icône du cours</string>
     <string name="dashboard_course_progress_value">Progression : %1$d%%</string>
+    <string name="dashboard_course_completed_progress">Terminé : 100%</string>
     <string name="dashboard_courses_header_title">Que voulez-vous apprendre aujourd\'hui ?</string>
     <string name="dashboard_courses_header_subtitle">Recherchez ci-dessous.</string>
     <string name="dashboard_courses_search_hint">Rechercher des cours</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -567,6 +567,7 @@ Applications: Planet, myPlanet, और myPlanetLite</string>
     <string name="dashboard_courses_tab_team">टीम के पाठ्यक्रम</string>
     <string name="dashboard_courses_content_description_icon">कोर्स आइकन</string>
     <string name="dashboard_course_progress_value">प्रगति: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">पूर्ण: 100%</string>
     <string name="dashboard_courses_header_title">आज आप क्या सीखना चाहेंगे?</string>
     <string name="dashboard_courses_header_subtitle">नीचे खोजें।</string>
     <string name="dashboard_courses_search_hint">पाठ्यक्रम खोजें</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -548,6 +548,7 @@
     <string name="dashboard_courses_tab_team">टोलीका पाठ्यक्रमहरू</string>
     <string name="dashboard_courses_content_description_icon">कोर्स आइकन</string>
     <string name="dashboard_course_progress_value">प्रगति: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">पूरा भयो: 100%</string>
     <string name="dashboard_courses_header_title">आज तपाईं के सिक्न चाहनुहुन्छ?</string>
     <string name="dashboard_courses_header_subtitle">तल खोज्नुहोस्।</string>
     <string name="dashboard_courses_search_hint">पाठ्यक्रम खोज्नुहोस्</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -579,6 +579,7 @@ Se você não concordar, deve selecionar "Cancelar" e parar de usar o aplicativo
     <string name="dashboard_courses_tab_team">Cursos da equipe</string>
     <string name="dashboard_courses_content_description_icon">Ícone do curso</string>
     <string name="dashboard_course_progress_value">Progresso: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">Concluído: 100%</string>
     <string name="dashboard_courses_header_title">O que você gostaria de aprender hoje?</string>
     <string name="dashboard_courses_header_subtitle">Pesquise abaixo.</string>
     <string name="dashboard_courses_search_hint">Pesquisar cursos</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -548,6 +548,7 @@ Haddii aadan oggolayn, waa inaad doorataa "Jooji" oo aad joojisaa isticmaalka ba
     <string name="dashboard_courses_tab_team">Koorsooyinka kooxda</string>
     <string name="dashboard_courses_content_description_icon">Astaanta koorsada</string>
     <string name="dashboard_course_progress_value">Horumarka: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">La dhammeeyay: 100%</string>
     <string name="dashboard_courses_header_title">Maxaad rabtaa inaad maanta barato?</string>
     <string name="dashboard_courses_header_subtitle">Ka raadi hoosta.</string>
     <string name="dashboard_courses_search_hint">Raadi koorsooyin</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -582,6 +582,7 @@ If you do not agree, you must select "Cancel" and stop using the application.</s
     <string name="dashboard_courses_tab_team">Team courses</string>
     <string name="dashboard_courses_content_description_icon">Course icon</string>
     <string name="dashboard_course_progress_value">Progress: %1$d%%</string>
+    <string name="dashboard_course_completed_progress">Completed: 100%</string>
     <string name="dashboard_courses_header_title">What would you like to learn today?</string>
     <string name="dashboard_courses_header_subtitle">Search below.</string>
     <string name="dashboard_courses_search_hint">Search courses</string>


### PR DESCRIPTION
## Mark Course as Completed After Finishing Wizard

🎯 What:
Fixed course completion handling so that finishing all steps in the course wizard correctly updates the course progress status to `Completed`.

💡 Why:
Previously, after completing every step and pressing **Finish Course**, the course progress was not updated visually or functionally, leaving the course in an incomplete state even though the user had finished it.

🛠️ Solution:
- Updated the course wizard completion flow to set course progress to `100%`.
- Returned the completion result back to `DashboardCoursePageFragment`.
- Refreshed the dashboard course UI after the wizard finishes.
- Ensured the course card/status reflects the updated completed state.

✅ Verification:
- Opened **Unit 1: Fairy Tales Retold**.
- Completed all course steps.
- Pressed **Finish Course**.
- Verified that the course progress updates to `100%`.
- Verified that the course status displays as `Completed`.
- Verified that the dashboard course page refreshes after returning from the wizard.

✨ Result:
Completed courses are now correctly marked as finished, and the dashboard immediately reflects the updated progress state.

<img width="610" height="1356" alt="image" src="https://github.com/user-attachments/assets/1ddb8ed8-a130-4b14-b00f-9da25293cb21" />
