### PR TITLE
🧪 Add unit tests for SurveyWizardFragment.normalizeCorrectChoice

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 443
-        versionName = "0.4.43"
+        versionCode = 446
+        versionName = "0.4.46"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardFragmentTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardFragmentTest.kt
@@ -223,4 +223,39 @@ class SurveyWizardFragmentTest {
         }
         return matches
     }
+
+    @Test
+    fun testNormalizeCorrectChoice_withString() {
+        val fragment = SurveyWizardFragment()
+        val result = fragment.normalizeCorrectChoice("correct")
+        assertEquals(listOf("correct"), result)
+    }
+
+    @Test
+    fun testNormalizeCorrectChoice_withList() {
+        val fragment = SurveyWizardFragment()
+        val list = listOf(
+            mapOf("id" to "1"),
+            mapOf("_id" to "2"),
+            mapOf("text" to "3"),
+            mapOf("other" to "4"),
+            "plain_string"
+        )
+        val result = fragment.normalizeCorrectChoice(list)
+        assertEquals(listOf("1", "2", "3", "plain_string"), result)
+    }
+
+    @Test
+    fun testNormalizeCorrectChoice_withNull() {
+        val fragment = SurveyWizardFragment()
+        val result = fragment.normalizeCorrectChoice(null)
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun testNormalizeCorrectChoice_withOtherType() {
+        val fragment = SurveyWizardFragment()
+        val result = fragment.normalizeCorrectChoice(12345)
+        assertEquals(listOf("12345"), result)
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `normalizeCorrectChoice` extension function lacked unit test coverage. This function handles transforming survey correct choices (which can be Strings, Lists of Maps, nulls, etc.) into a consistent `List<String>`.

📊 **Coverage:** The new tests cover all branching logic of the function, including:
- Processing direct `String` values.
- Processing a `List` of items, correctly extracting `id`, `_id`, or `text` fields from `Map` instances, and gracefully stringifying non-map items.
- Handling `null` inputs (returning an empty list).
- Handling unknown/other fallback types.

✨ **Result:** Increased test coverage and validation of data processing behavior for survey wizard responses.

---
*PR created automatically by Jules for task [13979235671174767272](https://jules.google.com/task/13979235671174767272) started by @dogi*