### PR TITLE
🧹 Fix: Define Data Extraction Rules

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="sharedpref" path="."/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="."/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="."/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
🎯 **What:** Updated `data_extraction_rules.xml` and `backup_rules.xml` to define explicit exclusion rules instead of placeholder comments.

💡 **Why:** Using `EncryptedSharedPreferences` requires explicit exclusion of SharedPreferences from backups and device-to-device transfers. If transferred without the associated Keystore key (which is not transferred), the app will crash on the new device due to decryption failures. This change prevents those crashes and improves overall code health by removing unresolved TODOs in configuration files.

✅ **Verification:** Verified via manual review of XML modifications and successfully running `./gradlew lintDebug testDebugUnitTest` to ensure no build regressions or parsing errors were introduced.

✨ **Result:** Android 12+ data extraction and older full backup configurations correctly exclude `sharedpref`, securing encrypted preferences against problematic restorations.

---
*PR created automatically by Jules for task [883838478022499436](https://jules.google.com/task/883838478022499436) started by @dogi*