### PR TITLE
🧹 Refactor fetchTeamResources to use parameter data class

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
@@ -188,16 +188,18 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
             }.getOrNull()
 
             val mergedResources = resourceSyncService.fetchTeamResources(
-                baseUrl = resolvedBaseUrl,
-                sessionCookie = sessionCookie,
-                username = credentials?.username,
-                password = credentials?.password,
-                teamId = teamId,
-                searchQuery = searchQuery,
-                mediaTypeFilter = selectedMediaType,
-                isSortDescending = isSortDescending,
-                limit = DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE,
-                downloadedResources = loadDownloadedResourcesFiltered()
+                params = TeamResourcesFetchParams(
+                    baseUrl = resolvedBaseUrl,
+                    sessionCookie = sessionCookie,
+                    username = credentials?.username,
+                    password = credentials?.password,
+                    teamId = teamId,
+                    searchQuery = searchQuery,
+                    mediaTypeFilter = selectedMediaType,
+                    isSortDescending = isSortDescending,
+                    limit = DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE,
+                    downloadedResources = loadDownloadedResourcesFiltered()
+                )
             )
             isLoadingTeamResources = false
             if (isAdded) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
@@ -8,6 +8,19 @@ internal data class MainResourcesFetchResult(
     val page: List<ResourceUi>
 )
 
+internal data class TeamResourcesFetchParams(
+    val baseUrl: String,
+    val sessionCookie: String?,
+    val username: String?,
+    val password: String?,
+    val teamId: String,
+    val searchQuery: String,
+    val mediaTypeFilter: String?,
+    val isSortDescending: Boolean,
+    val limit: Int,
+    val downloadedResources: List<ResourceUi>
+)
+
 internal class ResourceSyncService(
     private val repository: DashboardResourcesRepository,
     private val downloadService: ResourceDownloadService
@@ -61,28 +74,19 @@ internal class ResourceSyncService(
     }
 
     suspend fun fetchTeamResources(
-        baseUrl: String,
-        sessionCookie: String?,
-        username: String?,
-        password: String?,
-        teamId: String,
-        searchQuery: String,
-        mediaTypeFilter: String?,
-        isSortDescending: Boolean,
-        limit: Int,
-        downloadedResources: List<ResourceUi>
+        params: TeamResourcesFetchParams
     ): List<ResourceUi> {
         val result = repository.fetchTeamResources(
-            baseUrl = baseUrl,
-            sessionCookie = sessionCookie,
-            username = username,
-            password = password,
-            teamId = teamId,
-            searchQuery = searchQuery,
-            mediaTypeFilter = mediaTypeFilter,
+            baseUrl = params.baseUrl,
+            sessionCookie = params.sessionCookie,
+            username = params.username,
+            password = params.password,
+            teamId = params.teamId,
+            searchQuery = params.searchQuery,
+            mediaTypeFilter = params.mediaTypeFilter,
             sortBy = "title",
-            sortDescending = isSortDescending,
-            limit = limit
+            sortDescending = params.isSortDescending,
+            limit = params.limit
         )
         val page = result.getOrDefault(emptyList())
         val allRemoteItems = page.map { resource ->
@@ -103,7 +107,7 @@ internal class ResourceSyncService(
             )
         }
         val remoteKeys = allRemoteItems.map { it.resourceIdentityKey() }.toSet()
-        val downloaded = downloadedResources.filter { remoteKeys.contains(it.resourceIdentityKey()) }
+        val downloaded = params.downloadedResources.filter { remoteKeys.contains(it.resourceIdentityKey()) }
         val existingKeys = downloaded.map { it.resourceIdentityKey() }.toMutableSet()
         val remoteItems = allRemoteItems.filter { item ->
             val key = item.resourceIdentityKey()

--- a/app/src/test/java/org/ole/planet/myplanet/lite/ResourceSyncServiceTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/ResourceSyncServiceTest.kt
@@ -157,16 +157,18 @@ class ResourceSyncServiceTest {
         )
 
         val result = service.fetchTeamResources(
-            baseUrl = "http://base",
-            sessionCookie = null,
-            username = "user",
-            password = "pwd",
-            teamId = "team1",
-            searchQuery = "",
-            mediaTypeFilter = null,
-            isSortDescending = false,
-            limit = 100,
-            downloadedResources = listOf(downloadedResource)
+            params = TeamResourcesFetchParams(
+                baseUrl = "http://base",
+                sessionCookie = null,
+                username = "user",
+                password = "pwd",
+                teamId = "team1",
+                searchQuery = "",
+                mediaTypeFilter = null,
+                isSortDescending = false,
+                limit = 100,
+                downloadedResources = listOf(downloadedResource)
+            )
         )
 
         assertEquals(2, result.size)


### PR DESCRIPTION
🎯 **What:** Extracted the complex parameter list of `fetchTeamResources` (10 arguments) in `ResourceSyncService.kt` into a new data class `TeamResourcesFetchParams`.
💡 **Why:** A function with 10 parameters is difficult to read, prone to errors when calling (argument mix-ups), and hard to maintain. Grouping related parameters into a single configuration object is a standard refactoring pattern that significantly improves code clarity.
✅ **Verification:** Verified the structural changes via `git diff` and ran the relevant test suite (`./gradlew testDebugUnitTest --tests '*ResourceSyncServiceTest*' --rerun-tasks`), which passed successfully.
✨ **Result:** The `fetchTeamResources` function signature is now cleaner, easier to use, and more maintainable.

---
*PR created automatically by Jules for task [1708907122327477541](https://jules.google.com/task/1708907122327477541) started by @dogi*