### PR TITLE
🔒 Remove stack trace logging from audio recorder errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 443
-        versionName = "0.4.43"
+        versionCode = 452
+        versionName = "0.4.52"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
@@ -93,7 +93,7 @@ internal fun DashboardResourcesPageFragment.showRecordAudioPopup() {
         try {
             mediaRecorder?.stop()
         } catch (e: Exception) {
-            Log.e("DashboardResources", "Error stopping recorder", e)
+            Log.e("DashboardResources", "Error stopping recorder: ${e.message}")
         }
         mediaRecorder?.reset()
         mediaRecorder?.release()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesRecordAudioExtensions.kt
@@ -93,7 +93,7 @@ internal fun DashboardResourcesPageFragment.showRecordAudioPopup() {
         try {
             mediaRecorder?.stop()
         } catch (e: Exception) {
-            Log.e("DashboardResources", "Error stopping recorder: ${e.message}")
+            Log.e("DashboardResources", "Error stopping recorder: ${e.javaClass.simpleName} - ${e.message}")
         }
         mediaRecorder?.reset()
         mediaRecorder?.release()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the potential leakage of sensitive internal application data or state through full exception stack traces being written to production Logcat.
⚠️ **Risk:** If left unfixed, malicious apps on the device or users with adb access could read the Logcat and potentially extract internal application state, configuration details, or other sensitive information embedded within the stack trace that shouldn't be exposed.
🛡️ **Solution:** The fix replaces `Log.e(TAG, MSG, e)` (which prints the entire stack trace) with `Log.e(TAG, "$MSG: ${e.message}")`. This ensures that we still get the useful context (the error message itself) for debugging purposes, but without exposing the entire stack trace.

---
*PR created automatically by Jules for task [17683808799743291547](https://jules.google.com/task/17683808799743291547) started by @dogi*