### PR TITLE
🧪 Add missing tests for normalizeSelectedId

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensionsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensionsTest.kt
@@ -1,0 +1,32 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SurveyWizardSubmissionExtensionsTest {
+    @Test
+    fun testNormalizeSelectedId() {
+        val fragment = SurveyWizardFragment()
+
+        // null / blank
+        assertNull(fragment.normalizeSelectedId(null))
+        assertNull(fragment.normalizeSelectedId(""))
+        assertNull(fragment.normalizeSelectedId("   "))
+
+        // normal
+        assertEquals("testId", fragment.normalizeSelectedId("testId"))
+        assertEquals("testId", fragment.normalizeSelectedId(" testId "))
+
+        // with slash
+        assertEquals("testId", fragment.normalizeSelectedId("testId/somePath"))
+        assertEquals("testId", fragment.normalizeSelectedId(" testId / somePath "))
+
+        // only slash or spaces before slash
+        assertNull(fragment.normalizeSelectedId("/"))
+        assertNull(fragment.normalizeSelectedId("  /  "))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `normalizeSelectedId` extension function in `SurveyWizardSubmissionExtensions.kt` was missing unit tests. It is a pure string-manipulation function that trims inputs and strips paths, making it trivial to test.
📊 **Coverage:** The new test covers:
- Null inputs (returns `null`)
- Empty or blank strings (returns `null`)
- Normal strings with and without leading/trailing whitespace (returns trimmed string)
- Strings containing slashes to represent paths (returns the trimmed substring before the first slash)
- Edge cases where the content before the slash is empty or blank (returns `null`)
✨ **Result:** Test coverage for `normalizeSelectedId` has been successfully implemented, and the tests pass along with the rest of the unit test suite without regressions.

---
*PR created automatically by Jules for task [14599193128497138602](https://jules.google.com/task/14599193128497138602) started by @dogi*