### PR TITLE
🧪 Test DashboardSurveysRepository cancellation error handling

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
@@ -347,7 +347,7 @@ suspend fun Call.await(): Response {
         continuation.invokeOnCancellation {
             try {
                 cancel()
-            } catch (ex: CancellationException) {
+            } catch (ex: Exception) {
                 // Ignore cancel exception
             }
         }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepositoryTest.kt
@@ -346,4 +346,25 @@ class DashboardSurveysRepositoryTest {
 
         assertTrue(job.isCancelled)
     }
+
+    @Test
+    fun await_onCancellation_ignoresGeneralException() = runTest {
+        val mockCall = mock<Call>()
+
+        doThrow(RuntimeException("Cancel failed")).`when`(mockCall).cancel()
+
+        doAnswer {
+            null
+        }.`when`(mockCall).enqueue(any())
+
+        val job = launch {
+            mockCall.await()
+        }
+
+        delay(10)
+        job.cancel()
+        job.join()
+
+        assertTrue(job.isCancelled)
+    }
 }


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap where an unexpected exception thrown during the cancellation of a network request (`Call.cancel()`) could crash the coroutine because only `CancellationException` was being caught.

📊 **Coverage:** 
- Modified `DashboardSurveysRepository.kt` to catch a generic `Exception` instead of just `CancellationException` in the `invokeOnCancellation` handler.
- Added a new unit test `await_onCancellation_ignoresGeneralException` in `DashboardSurveysRepositoryTest.kt` to explicitly mock `Call.cancel()` throwing a `RuntimeException` and verify that the application properly ignores the exception and remains stable.

✨ **Result:** Enhanced test coverage and increased reliability by ensuring the app gracefully handles general exceptions emitted by OkHttp during request cancellation.

---
*PR created automatically by Jules for task [740460385015018604](https://jules.google.com/task/740460385015018604) started by @dogi*