### PR TITLE
🔒 Fix Regex Injection in DashboardResourcesRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 460
-        versionName = "0.4.60"
+        versionCode = 461
+        versionName = "0.4.61"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import java.net.URLEncoder
+import java.util.regex.Pattern
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -52,7 +53,7 @@ class DashboardResourcesRepository {
                     .put("privateFor", JSONObject().put($$"$exists", false))
 
                 if (searchQuery.isNotBlank()) {
-                    selectorJson.put("title", JSONObject().put($$"$regex", "(?i)$searchQuery"))
+                    selectorJson.put("title", JSONObject().put($$"$regex", "(?i)" + Pattern.quote(searchQuery)))
                 }
 
                 mediaTypeFilter?.takeIf { it.isNotBlank() }?.let { type ->
@@ -413,7 +414,7 @@ class DashboardResourcesRepository {
         selectorJson.put($$"$or", orArray)
 
         if (searchQuery.isNotBlank()) {
-            selectorJson.put("title", JSONObject().put($$"$regex", "(?i)$searchQuery"))
+            selectorJson.put("title", JSONObject().put($$"$regex", "(?i)" + Pattern.quote(searchQuery)))
         }
 
         mediaTypeFilter?.takeIf { it.isNotBlank() }?.let { type ->


### PR DESCRIPTION
🎯 **What:** The `searchQuery` string was directly inserted into a regex string concatenation `$"$regex"` without being properly escaped.
⚠️ **Risk:** If an attacker sends a malicious or complex regex string, it could be executed leading to Regular Expression Denial of Service (ReDoS), degrading database performance, or potentially resulting in unintended database queries and leaking out information.
🛡️ **Solution:** Escaped the `searchQuery` using `Pattern.quote()` before placing it in the regex condition so that user inputs are treated literally. Tested successfully via `./gradlew testDebugUnitTest` and `lintDebug`.

---
*PR created automatically by Jules for task [608622042879465515](https://jules.google.com/task/608622042879465515) started by @dogi*