### PR TITLE
🔒 Fix Unescaped Regex Query Vulnerability

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import java.net.URLEncoder
+import java.util.regex.Pattern
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -52,7 +53,7 @@ class DashboardResourcesRepository {
                     .put("privateFor", JSONObject().put($$"$exists", false))
 
                 if (searchQuery.isNotBlank()) {
-                    selectorJson.put("title", JSONObject().put($$"$regex", "(?i)$searchQuery"))
+                    selectorJson.put("title", JSONObject().put("\$regex", "(?i)\${Pattern.quote(searchQuery)}"))
                 }
 
                 mediaTypeFilter?.takeIf { it.isNotBlank() }?.let { type ->
@@ -413,7 +414,7 @@ class DashboardResourcesRepository {
         selectorJson.put($$"$or", orArray)
 
         if (searchQuery.isNotBlank()) {
-            selectorJson.put("title", JSONObject().put($$"$regex", "(?i)$searchQuery"))
+            selectorJson.put("title", JSONObject().put("\$regex", "(?i)\${Pattern.quote(searchQuery)}"))
         }
 
         mediaTypeFilter?.takeIf { it.isNotBlank() }?.let { type ->


### PR DESCRIPTION
🎯 **What:**
The vulnerability was an Unescaped User Input in a Regex Query. In `DashboardResourcesRepository.kt`, user input from `searchQuery` was directly concatenated into a string literal used as a regex pattern for CouchDB queries (e.g., `"(?i)$searchQuery"`).

⚠️ **Risk:**
Without escaping, an attacker could input specialized regex characters (like `.*` or catastrophic backtracking payloads) into `searchQuery`. This could lead to a Regex Denial of Service (ReDoS) or unintended bypasses/wildcard selections during community or team resource database queries.

🛡️ **Solution:**
The solution escapes the `searchQuery` variable using `java.util.regex.Pattern.quote(searchQuery)` before interpolation, converting the payload safely into literal characters (e.g., `"(?i)\${Pattern.quote(searchQuery)}"`). This prevents CouchDB's underlying regex engine from executing unintended regex commands injected via the search query. Both occurrences of this issue within the file were updated.

---
*PR created automatically by Jules for task [4695621445350713135](https://jules.google.com/task/4695621445350713135) started by @dogi*