### PR TITLE
🧪 Add error test for SurveyTranslationCache compileStatement

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/survey/SurveyTranslationCacheTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/survey/SurveyTranslationCacheTest.kt
@@ -78,4 +78,27 @@ class SurveyTranslationCacheTest {
 
         assert(optimizedTime <= originalTime) { "Optimization did not improve performance" }
     }
+
+    @Test
+    fun `test saveTranslations compileStatement error path`() = runBlocking {
+        val mockDb = mock(SQLiteDatabase::class.java)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val cache = spy(SurveyTranslationCache.getInstance(context))
+        doReturn(mockDb).whenever(cache).writableDatabase
+
+        whenever(mockDb.compileStatement(any())).thenThrow(RuntimeException("Compile Error"))
+
+        val translations = mapOf(1 to SurveyTranslationManager.TranslatedQuestion("body", listOf("a")))
+
+        assertThrows(RuntimeException::class.java) {
+            runBlocking {
+                cache.saveTranslations("survey1", "es", translations)
+            }
+        }
+
+        verify(mockDb).beginTransaction()
+        verify(mockDb).endTransaction()
+        verify(mockDb, never()).setTransactionSuccessful()
+    }
 }


### PR DESCRIPTION
🎯 **What:**
Added a unit test for `SurveyTranslationCache.kt` to cover the scenario where `db.compileStatement()` throws an exception during a database transaction.

📊 **Coverage:**
The test specifically targets the `try-finally` block within `saveTranslations`. It verifies that when `compileStatement` fails, `db.endTransaction()` is guaranteed to be called, but `db.setTransactionSuccessful()` is correctly bypassed, ensuring the transaction rolls back gracefully.

✨ **Result:**
Improved test coverage and ensured reliability of the cache transaction logic under error conditions.

---
*PR created automatically by Jules for task [1058873130243433492](https://jules.google.com/task/1058873130243433492) started by @dogi*