### PR TITLE
Inject DashboardTeamsRepository in DashboardTeamMembersFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -29,6 +29,7 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamMemberProfileActivity
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferences
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamsRepository
+import org.ole.planet.myplanet.lite.dashboard.DashboardTeamsRepositoryProvider
 import org.ole.planet.myplanet.lite.dashboard.JoinRequestDocument
 import org.ole.planet.myplanet.lite.dashboard.TeamMemberDetails
 import org.ole.planet.myplanet.lite.databinding.DialogInviteMembersBinding
@@ -42,7 +43,7 @@ class DashboardTeamMembersFragment : Fragment() {
     private var _binding: FragmentDashboardTeamMembersBinding? = null
     private val binding get() = _binding ?: error("Binding is only valid between onCreateView and onDestroyView")
 
-    private val repository = DashboardTeamsRepository()
+    private val repository = DashboardTeamsRepositoryProvider.provideRepository()
     private var avatarLoader: DashboardAvatarLoader? = null
 
     private val adapter = TeamMembersAdapter(

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryProvider.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryProvider.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+object DashboardTeamsRepositoryProvider {
+    @Volatile
+    private var repositoryOverride: DashboardTeamsRepository? = null
+
+    fun provideRepository(): DashboardTeamsRepository {
+        return repositoryOverride ?: DashboardTeamsRepository()
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun overrideRepository(repository: DashboardTeamsRepository?) {
+        repositoryOverride = repository
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun resetForTesting() {
+        repositoryOverride = null
+    }
+}


### PR DESCRIPTION
🎯 **What:**
- Created `DashboardTeamsRepositoryProvider` to manage the instantiation and provision of `DashboardTeamsRepository`.
- Updated `DashboardTeamMembersFragment` to retrieve the repository instance via `DashboardTeamsRepositoryProvider` rather than instantiating it directly.

This change aligns the fragment with the project's dependency injection approach, removing direct instantiation and making the component more testable.

---
*PR created automatically by Jules for task [6876410555344387058](https://jules.google.com/task/6876410555344387058) started by @dogi*