### PR TITLE
Refactor: Inject DashboardTeamsRepository in DashboardTeamMemberProfileActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMemberProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMemberProfileActivity.kt
@@ -56,7 +56,7 @@ class DashboardTeamMemberProfileActivity : BaseActivity() {
     private var credentials: StoredCredentials? = null
     private var avatarLoader: DashboardAvatarLoader? = null
 
-    private val repository = DashboardTeamsRepository()
+    private val repository = DashboardTeamsDependencies.provideTeamsRepository()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsDependencies.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsDependencies.kt
@@ -1,0 +1,20 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+object DashboardTeamsDependencies {
+    @Volatile
+    private var repositoryOverride: DashboardTeamsRepository? = null
+
+    fun provideTeamsRepository(): DashboardTeamsRepository {
+        return repositoryOverride ?: DashboardTeamsRepository()
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun overrideRepository(repository: DashboardTeamsRepository?) {
+        repositoryOverride = repository
+    }
+
+    @androidx.annotation.VisibleForTesting
+    fun resetForTesting() {
+        repositoryOverride = null
+    }
+}


### PR DESCRIPTION
🎯 **What:**
Replaced the direct instantiation of `DashboardTeamsRepository` in `DashboardTeamMemberProfileActivity` with dependency injection using a new factory provider.

🛠 **How:**
- Created `DashboardTeamsDependencies` to serve as a manual dependency provider.
- Updated `DashboardTeamMemberProfileActivity` to use `DashboardTeamsDependencies.provideTeamsRepository()` instead of `DashboardTeamsRepository()`.
- The factory object includes methods like `overrideRepository` to make it easier to mock the dependency in future testing.

---
*PR created automatically by Jules for task [6448862740867706374](https://jules.google.com/task/6448862740867706374) started by @dogi*