### PR TITLE
♻️ Migrate SurveyItemUiModelDiffCallback to DiffUtils.itemCallback

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
@@ -524,17 +524,14 @@ private data class SurveyItemUiModel(
     val savedRevision: String?,
 )
 
-private class SurveyItemUiModelDiffCallback : androidx.recyclerview.widget.DiffUtil.ItemCallback<SurveyItemUiModel>() {
-    override fun areItemsTheSame(oldItem: SurveyItemUiModel, newItem: SurveyItemUiModel): Boolean = oldItem.document.id == newItem.document.id
-    override fun areContentsTheSame(oldItem: SurveyItemUiModel, newItem: SurveyItemUiModel): Boolean = oldItem == newItem
-}
-
 private class SurveyItemsAdapter(
     private val statusStore: DashboardSurveyStatusStore,
     private val onStatusChanged: () -> Unit,
     private val onSurveySelected: (SurveyDocument) -> Unit,
     private val onDownloadRequested: (SurveyDocument) -> Unit,
-) : androidx.recyclerview.widget.ListAdapter<SurveyItemUiModel, SurveyItemsAdapter.SurveyViewHolder>(SurveyItemUiModelDiffCallback()) {
+) : androidx.recyclerview.widget.ListAdapter<SurveyItemUiModel, SurveyItemsAdapter.SurveyViewHolder>(
+    org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback({ oldItem, newItem -> oldItem.document.id == newItem.document.id })
+) {
 
     override fun onCreateViewHolder(parent: android.view.ViewGroup, viewType: Int): SurveyViewHolder {
         val view = android.view.LayoutInflater.from(parent.context)


### PR DESCRIPTION
🎯 **What:**
- Removed the explicitly defined `SurveyItemUiModelDiffCallback` class.
- Replaced its usage in `SurveyItemsAdapter` with `DiffUtils.itemCallback`.
- Passed the `areItemsTheSame` lambda explicitly to handle document ID comparisons.

✨ **Result:**
Reduced boilerplate code inside `DashboardTeamSurveysFragment.kt` while maintaining functional equivalence.

---
*PR created automatically by Jules for task [11320299665548728879](https://jules.google.com/task/11320299665548728879) started by @dogi*