### PR TITLE
Refactor: Constructor-inject Coroutine dispatchers in dashboard stores

### DIFF
--- a/app/src/androidTest/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
@@ -6,6 +6,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -16,6 +19,7 @@ import org.junit.runner.RunWith
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 
 @RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class DashboardOfflineSurveyStoreTest {
 
     private lateinit var store: DashboardOfflineSurveyStore
@@ -32,7 +36,11 @@ class DashboardOfflineSurveyStoreTest {
         context.getSharedPreferences("dashboard_offline_surveys", Context.MODE_PRIVATE).edit().clear().commit()
 
         // Pass both context and explicit moshi instance as mentioned in prompt
-        store = DashboardOfflineSurveyStore(context, moshi)
+        store = DashboardOfflineSurveyStore(
+            context = context,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            moshi = moshi
+        )
     }
 
     @After
@@ -43,14 +51,14 @@ class DashboardOfflineSurveyStoreTest {
     }
 
     @Test
-    fun testSaveSurvey_invalidId() = runBlocking {
+    fun testSaveSurvey_invalidId() = runTest {
         val document = SurveyDocument(id = "   ", rev = "1-abc", teamId = "team1")
         val result = store.saveSurvey(document, null)
         assertFalse(result)
     }
 
     @Test
-    fun testSaveSurvey_validId() = runBlocking {
+    fun testSaveSurvey_validId() = runTest {
         val document = SurveyDocument(id = "survey1", rev = "1-abc", teamId = "team1")
         val result = store.saveSurvey(document, null)
         assertTrue(result)
@@ -60,7 +68,7 @@ class DashboardOfflineSurveyStoreTest {
     }
 
     @Test
-    fun testSaveSurvey_fallbackTeamId() = runBlocking {
+    fun testSaveSurvey_fallbackTeamId() = runTest {
         val document = SurveyDocument(id = "survey1", rev = "1-abc", teamId = null)
         val result = store.saveSurvey(document, "fallbackTeam")
         assertTrue(result)
@@ -71,7 +79,7 @@ class DashboardOfflineSurveyStoreTest {
     }
 
     @Test
-    fun testGetSavedSurveyIds() = runBlocking {
+    fun testGetSavedSurveyIds() = runTest {
         val doc1 = SurveyDocument(id = "s1", rev = "1-a", teamId = "t1")
         val doc2 = SurveyDocument(id = "s2", rev = "1-b", teamId = "t2")
 
@@ -85,7 +93,7 @@ class DashboardOfflineSurveyStoreTest {
     }
 
     @Test
-    fun testGetSavedSurveysForTeam() = runBlocking {
+    fun testGetSavedSurveysForTeam() = runTest {
         val doc1 = SurveyDocument(id = "s1", rev = "1-a", teamId = "t1")
         val doc2 = SurveyDocument(id = "s2", rev = "1-b", teamId = "t2")
         val doc3 = SurveyDocument(id = "s3", rev = "1-c", teamId = "t1")
@@ -109,7 +117,7 @@ class DashboardOfflineSurveyStoreTest {
     }
 
     @Test
-    fun testGetSavedSurveyRevisions() = runBlocking {
+    fun testGetSavedSurveyRevisions() = runTest {
         val doc1 = SurveyDocument(id = "s1", rev = "1-a", teamId = "t1")
         val doc2 = SurveyDocument(id = "s2", rev = "1-b", teamId = "t2")
         val doc3 = SurveyDocument(id = "s3", rev = null, teamId = "t1") // null rev

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStore.kt
@@ -12,6 +12,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
@@ -19,6 +20,7 @@ import org.ole.planet.myplanet.lite.util.getStringOrNull
 
 class DashboardOfflineSurveyStore(
     context: Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     moshi: Moshi = Moshi.Builder()
         .add(FlexibleSurveyJsonAdapter())
         .addLast(KotlinJsonAdapterFactory())
@@ -51,7 +53,7 @@ class DashboardOfflineSurveyStore(
         val serialized = documentAdapter.toJson(document) ?: return false
         val rev = document.rev
         val teamId = document.teamId ?: fallbackTeamId
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             val values = ContentValues().apply {
                 put(COLUMN_ID, id)
                 put(COLUMN_REV, rev)
@@ -67,7 +69,7 @@ class DashboardOfflineSurveyStore(
         }
     }
 
-    suspend fun getSavedSurveyIds(): Set<String> = withContext(Dispatchers.IO) {
+    suspend fun getSavedSurveyIds(): Set<String> = withContext(ioDispatcher) {
         readableDatabase.query(
             TABLE_SURVEYS,
             arrayOf(COLUMN_ID),
@@ -86,7 +88,7 @@ class DashboardOfflineSurveyStore(
         }
     }
 
-    suspend fun getSavedSurveysForTeam(teamId: String): List<SurveyDocument> = withContext(Dispatchers.IO) {
+    suspend fun getSavedSurveysForTeam(teamId: String): List<SurveyDocument> = withContext(ioDispatcher) {
         val jsons = readableDatabase.query(
             TABLE_SURVEYS,
             arrayOf(COLUMN_DOCUMENT),
@@ -107,7 +109,7 @@ class DashboardOfflineSurveyStore(
         jsons.mapNotNull { json -> documentAdapter.fromJson(json) }
     }
 
-    suspend fun getSavedSurveyRevisions(): Map<String, String?> = withContext(Dispatchers.IO) {
+    suspend fun getSavedSurveyRevisions(): Map<String, String?> = withContext(ioDispatcher) {
         readableDatabase.query(
             TABLE_SURVEYS,
             arrayOf(COLUMN_ID, COLUMN_REV),

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
@@ -12,13 +12,16 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.util.getStringOrNull
 
-class DashboardSurveyOutboxStore private constructor(
+class DashboardSurveyOutboxStore internal constructor(
     context: Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
     moshi: Moshi = Moshi.Builder()
         .add(FlexibleSurveyJsonAdapter())
         .addLast(KotlinJsonAdapterFactory())
@@ -59,7 +62,7 @@ class DashboardSurveyOutboxStore private constructor(
         teamName: String?,
     ): Boolean {
         val serialized = submissionAdapter.toJson(submission) ?: return false
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             val values = ContentValues().apply {
                 put(COLUMN_SURVEY_ID, surveyId)
                 put(COLUMN_TEAM_ID, teamId)
@@ -72,7 +75,7 @@ class DashboardSurveyOutboxStore private constructor(
         }
     }
 
-    suspend fun getPendingForTeam(teamId: String?): List<OutboxEntry> = withContext(Dispatchers.IO) {
+    suspend fun getPendingForTeam(teamId: String?): List<OutboxEntry> = withContext(ioDispatcher) {
         val rawEntries = readableDatabase.query(
             TABLE_SUBMISSIONS,
             arrayOf(
@@ -116,7 +119,7 @@ class DashboardSurveyOutboxStore private constructor(
             }
         }
 
-        withContext(Dispatchers.Default) {
+        withContext(defaultDispatcher) {
             rawEntries.mapNotNull { raw ->
                 val parsed = try { submissionAdapter.fromJson(raw.payload) } catch(e: Exception) { null } ?: return@mapNotNull null
                 OutboxEntry(
@@ -132,7 +135,7 @@ class DashboardSurveyOutboxStore private constructor(
         }
     }
 
-    suspend fun getEntry(id: Long): OutboxEntry? = withContext(Dispatchers.IO) {
+    suspend fun getEntry(id: Long): OutboxEntry? = withContext(ioDispatcher) {
         val rawEntry = readableDatabase.query(
             TABLE_SUBMISSIONS,
             arrayOf(
@@ -176,7 +179,7 @@ class DashboardSurveyOutboxStore private constructor(
         }
 
         if (rawEntry != null) {
-            withContext(Dispatchers.Default) {
+            withContext(defaultDispatcher) {
                 val parsed = try { submissionAdapter.fromJson(rawEntry.payload) } catch(e: Exception) { null } ?: return@withContext null
                 OutboxEntry(
                     id = rawEntry.id,
@@ -193,11 +196,11 @@ class DashboardSurveyOutboxStore private constructor(
         }
     }
 
-    suspend fun deleteEntry(id: Long): Boolean = withContext(Dispatchers.IO) {
+    suspend fun deleteEntry(id: Long): Boolean = withContext(ioDispatcher) {
         writableDatabase.delete(TABLE_SUBMISSIONS, "$COLUMN_ID = ?", arrayOf(id.toString())) > 0
     }
 
-    suspend fun deleteEntries(ids: Collection<Long>): Boolean = withContext(Dispatchers.IO) {
+    suspend fun deleteEntries(ids: Collection<Long>): Boolean = withContext(ioDispatcher) {
         if (ids.isEmpty()) return@withContext false
         var deletedCount = 0
         val db = writableDatabase

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,6 +21,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
+@OptIn(ExperimentalCoroutinesApi::class)
 class DashboardOfflineSurveyStoreTest {
 
     private lateinit var store: DashboardOfflineSurveyStore
@@ -31,7 +34,10 @@ class DashboardOfflineSurveyStoreTest {
         org.ole.planet.myplanet.lite.util.SecurePreferencesProvider.injectedPreferences = mockPrefs
 
         val context = ApplicationProvider.getApplicationContext<Context>()
-        store = DashboardOfflineSurveyStore.getInstance(context)
+        store = DashboardOfflineSurveyStore(
+            context = context,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        )
         // Clear db before test
         store.writableDatabase.delete("surveys", null, null)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStoreTest.kt
@@ -4,6 +4,8 @@ import android.content.ContentValues
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -26,6 +28,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
+@OptIn(ExperimentalCoroutinesApi::class)
 class DashboardSurveyOutboxStoreTest {
 
     private lateinit var store: DashboardSurveyOutboxStore
@@ -33,7 +36,11 @@ class DashboardSurveyOutboxStoreTest {
     @Before
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        store = DashboardSurveyOutboxStore.getInstance(context)
+        store = DashboardSurveyOutboxStore(
+            context = context,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            defaultDispatcher = UnconfinedTestDispatcher(),
+        )
         store.writableDatabase.delete("outbox_submissions", null, null)
     }
 
@@ -77,7 +84,7 @@ class DashboardSurveyOutboxStoreTest {
 
         store.saveSubmission(submission1, "survey1", "Survey 1", "team1", "Team A")
         // Delay to ensure created_at is different
-        kotlinx.coroutines.delay(10)
+
         store.saveSubmission(submission2, "survey2", "Survey 2", "team1", "Team A")
 
         val pending = store.getPendingForTeam("team1")


### PR DESCRIPTION
This PR refactors `DashboardSurveyOutboxStore` and `DashboardOfflineSurveyStore` to inject Coroutine dispatchers via their constructors.

* Adds `ioDispatcher` (and `defaultDispatcher` where necessary) to the constructors of both stores.
* Replaces inline usages of `Dispatchers.IO` and `Dispatchers.Default` with the injected dispatchers.
* Updates local and instrumentation tests to instantiate the stores with `UnconfinedTestDispatcher` and removes real-IO waits like `delay(10)`.

---
*PR created automatically by Jules for task [11024506999130051594](https://jules.google.com/task/11024506999130051594) started by @dogi*