### PR TITLE
🧪 Constructor-inject DashboardResourcesRepository dispatcher

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.IOException
 import java.net.URLEncoder
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
@@ -19,7 +20,7 @@ import org.json.JSONObject
 import org.ole.planet.myplanet.lite.util.BirthDateString
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 
-class DashboardResourcesRepository {
+class DashboardResourcesRepository(private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
 
     private val client: OkHttpClient = OkHttpClient.Builder().build()
     private val moshi: Moshi = Moshi.Builder()
@@ -39,7 +40,7 @@ class DashboardResourcesRepository {
         limit: Int = 1000,
         skip: Int = 0
     ): Result<List<ResourceDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -118,7 +119,7 @@ class DashboardResourcesRepository {
         password: String?,
         payload: JSONObject
     ): Result<JSONObject> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -160,7 +161,7 @@ class DashboardResourcesRepository {
         resourceId: String,
         payload: JSONObject
     ): Result<JSONObject> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -210,7 +211,7 @@ class DashboardResourcesRepository {
     suspend fun uploadResourceAttachment(
         request: UploadAttachmentRequest
     ): Result<JSONObject> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val normalizedBase = request.baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -251,7 +252,7 @@ class DashboardResourcesRepository {
         filename: String,
         onProgress: ((Int?) -> Unit)? = null
     ): Result<ByteArray> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val normalizedBase = baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {
@@ -316,7 +317,7 @@ class DashboardResourcesRepository {
     suspend fun fetchTeamResources(
         request: TeamResourcesRequest
     ): Result<List<ResourceDocument>> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val normalizedBase = request.baseUrl.trim().trimEnd('/')
                 if (normalizedBase.isEmpty()) {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
@@ -1,6 +1,8 @@
 package org.ole.planet.myplanet.lite.dashboard
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.json.JSONObject
@@ -9,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DashboardResourcesRepositoryTest {
     private lateinit var server: MockWebServer
     private lateinit var repository: DashboardResourcesRepository
@@ -17,7 +20,7 @@ class DashboardResourcesRepositoryTest {
     fun setup() {
         server = MockWebServer()
         server.start()
-        repository = DashboardResourcesRepository()
+        repository = DashboardResourcesRepository(UnconfinedTestDispatcher())
     }
 
     @After
@@ -26,7 +29,7 @@ class DashboardResourcesRepositoryTest {
     }
 
     @Test
-    fun fetchCommunityResources_sendsCorrectSort() = runBlocking {
+    fun fetchCommunityResources_sendsCorrectSort() = runTest {
         server.enqueue(MockResponse().setBody("{\"docs\": []}"))
 
         repository.fetchCommunityResources(
@@ -50,7 +53,7 @@ class DashboardResourcesRepositoryTest {
     }
 
     @Test
-    fun downloadResourceBytes_reportsProgress() = runBlocking {
+    fun downloadResourceBytes_reportsProgress() = runTest {
         server.enqueue(
             MockResponse()
                 .setBody("abcd")


### PR DESCRIPTION
🎯 **What:**
- Constructor-injects a `CoroutineDispatcher` (defaulting to `Dispatchers.IO`) into `DashboardResourcesRepository`.
- Replaces hardcoded `withContext(Dispatchers.IO)` with `withContext(ioDispatcher)`.
- Updates `DashboardResourcesRepositoryTest` to pass `UnconfinedTestDispatcher()` and use `runTest`.

📊 **Coverage:**
- Unit tests run successfully via `./gradlew testDebugUnitTest`.

✨ **Result:**
- Improves testability by allowing proper mocking/controlling of coroutine dispatchers in the `DashboardResourcesRepository` tests.

---
*PR created automatically by Jules for task [3677872975155305666](https://jules.google.com/task/3677872975155305666) started by @dogi*