### PR TITLE
Refactor DiffUtil usage to DiffUtils.itemCallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 460
-        versionName = "0.4.60"
+        versionCode = 464
+        versionName = "0.4.64"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -1283,16 +1283,20 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
 
             val newDisplayed = displayedItems.toList()
 
+            val diffCallback = org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback<CourseItem>(
+                areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id }
+            )
+
             val diffResult = androidx.recyclerview.widget.DiffUtil.calculateDiff(object : androidx.recyclerview.widget.DiffUtil.Callback() {
                 override fun getOldListSize() = oldDisplayed.size
                 override fun getNewListSize() = newDisplayed.size
 
                 override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                    return oldDisplayed[oldItemPosition].id == newDisplayed[newItemPosition].id
+                    return diffCallback.areItemsTheSame(oldDisplayed[oldItemPosition], newDisplayed[newItemPosition])
                 }
 
                 override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                    return oldDisplayed[oldItemPosition] == newDisplayed[newItemPosition]
+                    return diffCallback.areContentsTheSame(oldDisplayed[oldItemPosition], newDisplayed[newItemPosition])
                 }
             })
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -1287,18 +1287,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
                 areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id }
             )
 
-            val diffResult = androidx.recyclerview.widget.DiffUtil.calculateDiff(object : androidx.recyclerview.widget.DiffUtil.Callback() {
-                override fun getOldListSize() = oldDisplayed.size
-                override fun getNewListSize() = newDisplayed.size
-
-                override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                    return diffCallback.areItemsTheSame(oldDisplayed[oldItemPosition], newDisplayed[newItemPosition])
-                }
-
-                override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-                    return diffCallback.areContentsTheSame(oldDisplayed[oldItemPosition], newDisplayed[newItemPosition])
-                }
-            })
+            val diffResult = org.ole.planet.myplanet.lite.util.DiffUtils.calculateDiff(oldDisplayed, newDisplayed, diffCallback)
 
             diffResult.dispatchUpdatesTo(object : androidx.recyclerview.widget.ListUpdateCallback {
                 override fun onInserted(position: Int, count: Int) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/DiffUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/DiffUtils.kt
@@ -14,4 +14,16 @@ object DiffUtils {
             override fun getChangePayload(oldItem: T, newItem: T): Any? = getChangePayload(oldItem, newItem)
         }
     }
+    fun <T : Any> calculateDiff(oldList: List<T>, newList: List<T>, itemCallback: DiffUtil.ItemCallback<T>): DiffUtil.DiffResult {
+        return DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+            override fun getOldListSize(): Int = oldList.size
+            override fun getNewListSize(): Int = newList.size
+            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                itemCallback.areItemsTheSame(oldList[oldItemPosition], newList[newItemPosition])
+            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                itemCallback.areContentsTheSame(oldList[oldItemPosition], newList[newItemPosition])
+            override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? =
+                itemCallback.getChangePayload(oldList[oldItemPosition], newList[newItemPosition])
+        })
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DiffUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DiffUtilsTest.kt
@@ -79,4 +79,17 @@ class DiffUtilsTest {
         assertEquals("ContentChanged", callback.getChangePayload(item1, item2))
         assertNull(callback.getChangePayload(item1, item3))
     }
+    @Test
+    fun `calculateDiff delegates to itemCallback correctly`() {
+        val oldList = listOf(TestItem(1, "A"), TestItem(2, "B"))
+        val newList = listOf(TestItem(1, "A"), TestItem(2, "C"), TestItem(3, "D"))
+
+        val callback = DiffUtils.itemCallback<TestItem>(
+            areItemsTheSame = { oldItem, newItem -> oldItem.id == newItem.id },
+            areContentsTheSame = { oldItem, newItem -> oldItem.content == newItem.content },
+            getChangePayload = { oldItem, newItem -> if (oldItem.content != newItem.content) "Changed" else null }
+        )
+
+        val result = DiffUtils.calculateDiff(oldList, newList, callback)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DiffUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DiffUtilsTest.kt
@@ -91,5 +91,25 @@ class DiffUtilsTest {
         )
 
         val result = DiffUtils.calculateDiff(oldList, newList, callback)
+
+        // Let's assert on the results of the diff by dispatching updates
+        var insertedCount = 0
+        var changedCount = 0
+
+        result.dispatchUpdatesTo(object : androidx.recyclerview.widget.ListUpdateCallback {
+            override fun onInserted(position: Int, count: Int) {
+                insertedCount += count
+            }
+            override fun onRemoved(position: Int, count: Int) {}
+            override fun onMoved(fromPosition: Int, toPosition: Int) {}
+            override fun onChanged(position: Int, count: Int, payload: Any?) {
+                changedCount += count
+                assertEquals("Changed", payload)
+            }
+        })
+
+        // Item 1 is the same. Item 2 changed content ("B" -> "C"). Item 3 is inserted.
+        assertEquals(1, insertedCount)
+        assertEquals(1, changedCount)
     }
 }


### PR DESCRIPTION
I have updated the codebase to use `DiffUtils.itemCallback` and a newly introduced helper function `DiffUtils.calculateDiff` instead of manually creating `DiffUtil.Callback` inline. This simplifies the diff logic in `DashboardCoursePageFragment.kt` and makes the tests more robust.

The previous nested approach was reverted, and the proper extension-like method was added to the `DiffUtils.kt` file. All relevant unit tests pass correctly, and the code was appropriately checked using the standard lint tasks.

---
*PR created automatically by Jules for task [10445980290849966654](https://jules.google.com/task/10445980290849966654) started by @dogi*