### PR TITLE
Refactor Dashboard surveys load into repository state class

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
@@ -165,6 +165,7 @@ class DashboardTeamSurveysFragment : Fragment(R.layout.fragment_dashboard_team_s
         }
     }
 
+
     private fun loadSurveys(isSwipeRefresh: Boolean = false) {
         val base = baseUrl
         val team = teamId
@@ -195,65 +196,46 @@ class DashboardTeamSurveysFragment : Fragment(R.layout.fragment_dashboard_team_s
 
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                val documents = if (offlineMode) {
-                    localSurveyRepository.getSavedSurveysForTeam(team)
-                } else {
-                    val result = repository.fetchTeamSurveys(base, creds, sessionCookie, team)
-                    result.getOrElse {
-                        val cached = localSurveyRepository.getSavedSurveysForTeam(team)
-                        if (cached.isEmpty()) {
-                            showError(getString(R.string.dashboard_surveys_error_loading))
-                            swipeRefresh.isRefreshing = false
-                            return@launch
-                        }
-                        cached
-                    }
-                }
-                statusStore.ensureNewDefaults(documents.map { it.id })
-                adoptedSurveys = documents.filter { !it.sourceSurveyId.isNullOrBlank() }
-                teamSurveys = documents.filter { it.sourceSurveyId.isNullOrBlank() }
-                if (offlineMode) {
-                    completionCounts.clear()
-                    documents.mapNotNull { it.id }.forEach { id -> completionCounts[id] = 0 }
-                } else {
-                    fetchCompletionCounts(base, team, documents)
-                }
-                savedSurveyIds = localSurveyRepository.getSavedSurveyIds()
-                savedSurveyRevisions = localSurveyRepository.getSavedSurveyRevisions()
-                outboxEntries = localSurveyRepository.getPendingForTeam(team)
-                pagerAdapter.submit(
-                    teamSurveys,
-                    adoptedSurveys,
-                    completionCounts,
-                    savedSurveyIds,
-                    savedSurveyRevisions,
-                    outboxEntries,
+                val stateResult = repository.loadSurveysState(
+                    baseUrl = base,
+                    credentials = creds,
+                    sessionCookie = sessionCookie,
+                    teamId = team,
+                    offlineMode = offlineMode,
+                    localRepository = localSurveyRepository
                 )
-                updateTabBadges()
-                showLoading(false)
+
+                stateResult.onSuccess { state ->
+                    val documents = state.teamSurveys + state.adoptedSurveys
+                    statusStore.ensureNewDefaults(documents.map { it.id })
+
+                    adoptedSurveys = state.adoptedSurveys
+                    teamSurveys = state.teamSurveys
+                    completionCounts.clear()
+                    completionCounts.putAll(state.completionCounts)
+                    savedSurveyIds = state.savedSurveyIds
+                    savedSurveyRevisions = state.savedSurveyRevisions
+                    outboxEntries = state.outboxEntries
+
+                    pagerAdapter.submit(
+                        teamSurveys,
+                        adoptedSurveys,
+                        completionCounts,
+                        savedSurveyIds,
+                        savedSurveyRevisions,
+                        outboxEntries,
+                    )
+                    updateTabBadges()
+                    showLoading(false)
+                }.onFailure {
+                    showError(getString(R.string.dashboard_surveys_error_loading))
+                }
                 swipeRefresh.isRefreshing = false
             } finally {
                 hasLoadedOnce = true
             }
         }
     }
-
-    private suspend fun fetchCompletionCounts(
-        base: String,
-        team: String,
-        documents: List<SurveyDocument>,
-    ) {
-        withContext(Dispatchers.IO) {
-            completionCounts.clear()
-            val ids = documents.mapNotNull { it.id }
-            completionCounts.putAll(ids.associateWith { 0 })
-            if (ids.isNotEmpty()) {
-                val result = repository.fetchSurveyCompletionCountsBatched(base, credentials, sessionCookie, team, ids)
-                completionCounts.putAll(result.getOrDefault(emptyMap()))
-            }
-        }
-    }
-
     private fun showLoading(loading: Boolean) {
         loadingView.isVisible = loading
         viewPager.isVisible = !loading

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysFragment.kt
@@ -165,7 +165,6 @@ class DashboardTeamSurveysFragment : Fragment(R.layout.fragment_dashboard_team_s
         }
     }
 
-
     private fun loadSurveys(isSwipeRefresh: Boolean = false) {
         val base = baseUrl
         val team = teamId

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
@@ -33,6 +33,8 @@ import okhttp3.Response
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore.OutboxEntry
 
 class DashboardSurveysRepository(
     private val client: OkHttpClient = OkHttpClient.Builder().build(),
@@ -48,6 +50,65 @@ class DashboardSurveysRepository(
     private val completionsResponseAdapter = moshi.adapter(SurveyCompletionsResponse::class.java)
     private val surveyDocumentAdapter = moshi.adapter(SurveyDocument::class.java)
     private val publicSurveyResponseAdapter = moshi.adapter(PublicSurveyResponse::class.java)
+
+
+    suspend fun loadSurveysState(
+        baseUrl: String?,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        teamId: String?,
+        offlineMode: Boolean,
+        localRepository: DashboardLocalSurveyRepository
+    ): Result<SurveysLoadState> {
+        return withContext(dispatcher) {
+            runCatching {
+                if (baseUrl.isNullOrBlank()) throw IOException("Missing server base URL")
+                if (teamId.isNullOrBlank()) throw IOException("Missing team id")
+                if (credentials == null) throw IOException("Missing credentials")
+
+                val documents = if (offlineMode) {
+                    localRepository.getSavedSurveysForTeam(teamId)
+                } else {
+                    val fetchResult = fetchTeamSurveys(baseUrl, credentials, sessionCookie, teamId)
+                    fetchResult.getOrElse {
+                        val cached = localRepository.getSavedSurveysForTeam(teamId)
+                        if (cached.isEmpty()) {
+                            throw IOException("Error loading surveys and no cached versions available", it)
+                        }
+                        cached
+                    }
+                }
+
+                val adoptedSurveys = documents.filter { !it.sourceSurveyId.isNullOrBlank() }
+                val teamSurveys = documents.filter { it.sourceSurveyId.isNullOrBlank() }
+                val completionCounts = mutableMapOf<String, Int>()
+
+                if (offlineMode) {
+                    documents.mapNotNull { it.id }.forEach { id -> completionCounts[id] = 0 }
+                } else {
+                    val ids = documents.mapNotNull { it.id }
+                    if (ids.isNotEmpty()) {
+                        completionCounts.putAll(ids.associateWith { 0 })
+                        val countsResult = fetchSurveyCompletionCountsBatched(baseUrl, credentials, sessionCookie, teamId, ids)
+                        completionCounts.putAll(countsResult.getOrDefault(emptyMap()))
+                    }
+                }
+
+                val savedSurveyIds = localRepository.getSavedSurveyIds()
+                val savedSurveyRevisions = localRepository.getSavedSurveyRevisions()
+                val outboxEntries = localRepository.getPendingForTeam(teamId)
+
+                SurveysLoadState(
+                    teamSurveys = teamSurveys,
+                    adoptedSurveys = adoptedSurveys,
+                    completionCounts = completionCounts,
+                    savedSurveyIds = savedSurveyIds,
+                    savedSurveyRevisions = savedSurveyRevisions,
+                    outboxEntries = outboxEntries
+                )
+            }
+        }
+    }
 
     suspend fun fetchTeamSurveys(
         baseUrl: String,
@@ -324,6 +385,16 @@ class DashboardSurveysRepository(
     @JsonClass(generateAdapter = true)
     data class SurveyCompletionsResponse(
         @param:Json(name = "docs") val docs: List<Map<String, Any?>> = emptyList(),
+    )
+
+
+    data class SurveysLoadState(
+        val teamSurveys: List<SurveyDocument>,
+        val adoptedSurveys: List<SurveyDocument>,
+        val completionCounts: Map<String, Int>,
+        val savedSurveyIds: Set<String>,
+        val savedSurveyRevisions: Map<String, String?>,
+        val outboxEntries: List<OutboxEntry>
     )
 
     companion object {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepository.kt
@@ -50,8 +50,6 @@ class DashboardSurveysRepository(
     private val completionsResponseAdapter = moshi.adapter(SurveyCompletionsResponse::class.java)
     private val surveyDocumentAdapter = moshi.adapter(SurveyDocument::class.java)
     private val publicSurveyResponseAdapter = moshi.adapter(PublicSurveyResponse::class.java)
-
-
     suspend fun loadSurveysState(
         baseUrl: String?,
         credentials: StoredCredentials?,
@@ -386,8 +384,6 @@ class DashboardSurveysRepository(
     data class SurveyCompletionsResponse(
         @param:Json(name = "docs") val docs: List<Map<String, Any?>> = emptyList(),
     )
-
-
     data class SurveysLoadState(
         val teamSurveys: List<SurveyDocument>,
         val adoptedSurveys: List<SurveyDocument>,

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveysRepositoryTest.kt
@@ -42,6 +42,106 @@ class DashboardSurveysRepositoryTest {
         mockWebServer.shutdown()
     }
 
+
+    @Test
+    fun loadSurveysState_offlineMode() = runTest {
+        val mockLocalRepo = mock<org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository>()
+
+        val doc1 = DashboardSurveysRepository.SurveyDocument(id = "s1", sourceSurveyId = null)
+        val doc2 = DashboardSurveysRepository.SurveyDocument(id = "s2", sourceSurveyId = "adopted1")
+        val outbox = listOf(mock<org.ole.planet.myplanet.lite.dashboard.DashboardSurveyOutboxStore.OutboxEntry>())
+
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveysForTeam("team1")).thenReturn(listOf(doc1, doc2))
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveyIds()).thenReturn(setOf("s1"))
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveyRevisions()).thenReturn(mapOf("s1" to "rev1"))
+        org.mockito.Mockito.`when`(mockLocalRepo.getPendingForTeam("team1")).thenReturn(outbox)
+
+        val result = repository.loadSurveysState(
+            baseUrl = "http://localhost",
+            credentials = StoredCredentials("user", "pass"),
+            sessionCookie = "cookie",
+            teamId = "team1",
+            offlineMode = true,
+            localRepository = mockLocalRepo
+        )
+
+        if (result.isFailure) throw result.exceptionOrNull()!!
+        assertTrue(result.isSuccess)
+        val state = result.getOrThrow()
+
+        assertEquals(1, state.teamSurveys.size)
+        assertEquals("s1", state.teamSurveys[0].id)
+
+        assertEquals(1, state.adoptedSurveys.size)
+        assertEquals("s2", state.adoptedSurveys[0].id)
+
+        assertEquals(2, state.completionCounts.size)
+        assertEquals(0, state.completionCounts["s1"])
+        assertEquals(0, state.completionCounts["s2"])
+
+        assertEquals(setOf("s1"), state.savedSurveyIds)
+        assertEquals("rev1", state.savedSurveyRevisions["s1"])
+        assertEquals(outbox, state.outboxEntries)
+
+        // Ensure no network calls
+        assertEquals(0, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun loadSurveysState_online_fetchFails_fallbackEmpty() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val mockLocalRepo = mock<org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository>()
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveysForTeam("team1")).thenReturn(emptyList())
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveyIds()).thenReturn(emptySet())
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveyRevisions()).thenReturn(emptyMap())
+        org.mockito.Mockito.`when`(mockLocalRepo.getPendingForTeam("team1")).thenReturn(emptyList())
+
+        val result = repository.loadSurveysState(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = StoredCredentials("user", "pass"),
+            sessionCookie = "cookie",
+            teamId = "team1",
+            offlineMode = false,
+            localRepository = mockLocalRepo
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IOException)
+        assertEquals("Error loading surveys and no cached versions available", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun loadSurveysState_online_fetchFails_fallbackSuccess() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val mockLocalRepo = mock<org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository>()
+        val doc1 = DashboardSurveysRepository.SurveyDocument(id = "s1")
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveysForTeam("team1")).thenReturn(listOf(doc1))
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveyIds()).thenReturn(emptySet())
+        org.mockito.Mockito.`when`(mockLocalRepo.getSavedSurveyRevisions()).thenReturn(emptyMap())
+        org.mockito.Mockito.`when`(mockLocalRepo.getPendingForTeam("team1")).thenReturn(emptyList())
+
+        // Submissions API fallback counts
+        val countsResponse = """{ "docs": [ { "parentId": "s1@x" } ] }"""
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(countsResponse))
+
+        val result = repository.loadSurveysState(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = StoredCredentials("user", "pass"),
+            sessionCookie = "cookie",
+            teamId = "team1",
+            offlineMode = false,
+            localRepository = mockLocalRepo
+        )
+
+        if (result.isFailure) throw result.exceptionOrNull()!!
+        assertTrue(result.isSuccess)
+        val state = result.getOrThrow()
+        assertEquals(1, state.teamSurveys.size)
+        assertEquals(1, state.completionCounts["s1"])
+    }
+
     @Test
     fun fetchTeamSurveys_success() = runTest {
         val jsonResponse = """
@@ -65,6 +165,7 @@ class DashboardSurveysRepositoryTest {
             teamId = "team1"
         )
 
+        if (result.isFailure) throw result.exceptionOrNull()!!
         assertTrue(result.isSuccess)
         val surveys = result.getOrNull()
         assertEquals(1, surveys?.size)
@@ -114,6 +215,7 @@ class DashboardSurveysRepositoryTest {
             surveyId = "survey1",
         )
 
+        if (result.isFailure) throw result.exceptionOrNull()!!
         assertTrue(result.isSuccess)
         assertEquals("survey1", result.getOrNull()?.survey?.id)
         assertEquals("Public Survey", result.getOrNull()?.survey?.name)
@@ -163,6 +265,7 @@ class DashboardSurveysRepositoryTest {
             teamId = "team1"
         )
 
+        if (result.isFailure) throw result.exceptionOrNull()!!
         assertTrue(result.isSuccess)
         val survey = result.getOrThrow().single()
         assertEquals("survey1", survey.id)


### PR DESCRIPTION
The goal of this change is to extract the complex offline, network, and caching data loading orchestration in the `DashboardTeamSurveysFragment` into the repository tier.

I accomplished this by:
1. Creating a `SurveysLoadState` data class in the `DashboardSurveysRepository` that maps the returned data fields from the view (`teamSurveys`, `adoptedSurveys`, `completionCounts`, `savedSurveyIds`, `savedSurveyRevisions`, `outboxEntries`).
2. Moving the core orchestration logic out of the `DashboardTeamSurveysFragment`'s `loadSurveys` method and into a newly defined `loadSurveysState()` method inside the `DashboardSurveysRepository`. This method properly cascades data logic and determines counts by passing in the `DashboardLocalSurveyRepository`.
3. Updating the fragment to handle UI actions and error toasts while feeding the returned result model cleanly into its adapter bindings, removing the previous `fetchCompletionCounts()` method completely.

---
*PR created automatically by Jules for task [16655284187346632625](https://jules.google.com/task/16655284187346632625) started by @dogi*