### PR TITLE
Refactor to reuse shared dependencies in dashboard components

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -92,8 +92,8 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
     }
 
     private val repository = DashboardNewsRepository(
-        client = OkHttpClient.Builder().build(),
-        moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+        client = org.ole.planet.myplanet.lite.dashboard.SharedBitmapDependencies.client,
+        moshi = sharedMoshi
     )
     private val actionsRepository = DashboardNewsActionsRepository()
     @androidx.annotation.VisibleForTesting
@@ -853,6 +853,7 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
     }
 
         companion object {
+            private val sharedMoshi: Moshi by lazy { Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build() }
             private const val ARG_TEAM_ID = "arg_team_id"
             private const val ARG_TEAM_NAME = "arg_team_name"
             private const val LOAD_MORE_THRESHOLD = 3

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -30,6 +30,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.noties.markwon.Markwon
+import org.ole.planet.myplanet.lite.dashboard.SharedBitmapDependencies
 import java.util.ArrayList
 import java.util.Locale
 import kotlin.math.max
@@ -92,7 +93,7 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
     }
 
     private val repository = DashboardNewsRepository(
-        client = org.ole.planet.myplanet.lite.dashboard.SharedBitmapDependencies.client,
+        client = SharedBitmapDependencies.client,
         moshi = sharedMoshi
     )
     private val actionsRepository = DashboardNewsActionsRepository()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
@@ -148,12 +148,10 @@ class PostShareHelper(
     }
 
     companion object {
-        private val client by lazy {
-            OkHttpClient.Builder()
+        private val client: OkHttpClient get() = SharedBitmapDependencies.client.newBuilder()
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .build()
-        }
         private val IMAGE_MARKDOWN_REGEX = Regex("!?\\[[^\\]]*\\]\\([^)]*\\.(?:jpe?g|png)\\)", RegexOption.IGNORE_CASE)
         private val IMAGE_URL_REGEX = Regex("\\b\\S+\\.(?:jpe?g|png)(?:\\?\\S*)?(?=\\s|$)", RegexOption.IGNORE_CASE)
         private val LINK_MARKDOWN_REGEX = Regex("\\[([^\\]]+)\\]\\(([^\\s)]+)\\)")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
@@ -148,10 +148,12 @@ class PostShareHelper(
     }
 
     companion object {
-        private val client: OkHttpClient get() = SharedBitmapDependencies.client.newBuilder()
+        private val client: OkHttpClient by lazy {
+            SharedBitmapDependencies.client.newBuilder()
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .build()
+        }
         private val IMAGE_MARKDOWN_REGEX = Regex("!?\\[[^\\]]*\\]\\([^)]*\\.(?:jpe?g|png)\\)", RegexOption.IGNORE_CASE)
         private val IMAGE_URL_REGEX = Regex("\\b\\S+\\.(?:jpe?g|png)(?:\\?\\S*)?(?=\\s|$)", RegexOption.IGNORE_CASE)
         private val LINK_MARKDOWN_REGEX = Regex("\\[([^\\]]+)\\]\\(([^\\s)]+)\\)")


### PR DESCRIPTION
Reuses `SharedBitmapDependencies.client` and `Moshi` instances in `PostShareHelper` and `DashboardVoicesFragment` to reduce memory footprint and improve performance.

---
*PR created automatically by Jules for task [2017829751815137383](https://jules.google.com/task/2017829751815137383) started by @dogi*