### PR TITLE
Refactor image cleanup to use lifecycleScope instead of GlobalScope

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.R
@@ -72,6 +71,8 @@ internal fun transformCommentMarkdownForDisplay(markdown: String): String {
 }
 
 class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() {
+
+    private var imageCleanupJob: kotlinx.coroutines.Job? = null
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var loadingView: View
@@ -776,8 +777,7 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
         val filesToDelete = pendingReplyImages.values.map { it.file }.toList()
         pendingReplyImages.clear()
 
-        @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-        GlobalScope.launch(Dispatchers.IO) {
+        imageCleanupJob = lifecycleScope.launch(Dispatchers.IO) {
             filesToDelete.forEach { file ->
                 if (file.exists()) {
                     file.delete()
@@ -1298,6 +1298,7 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
     }
 
     override fun onDestroy() {
+        imageCleanupJob?.cancel()
         super.onDestroy()
         recyclerView.adapter = null
         avatarLoader?.destroy()


### PR DESCRIPTION
Replaced `GlobalScope.launch` with `lifecycleScope.launch` for image cleanup in `DashboardPostDetailActivity`. The coroutine `Job` is tracked and explicitly cancelled early in `onDestroy()` before other teardown operations run.

---
*PR created automatically by Jules for task [3627743076070406597](https://jules.google.com/task/3627743076070406597) started by @dogi*