### PR TITLE
Add AppNavigator for Deep-Link Resolution

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/AppNavigator.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/AppNavigator.kt
@@ -1,0 +1,121 @@
+package org.ole.planet.myplanet.lite
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity
+import org.ole.planet.myplanet.lite.dashboard.DashboardServerCatalog
+import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository
+import org.ole.planet.myplanet.lite.util.IntentUtils
+
+object AppNavigator {
+
+    fun resolveDeepLink(
+        context: Context,
+        intent: Intent?,
+        surveysRepository: DashboardSurveysRepository,
+        scope: CoroutineScope,
+        onFinished: () -> Unit
+    ) {
+        val postId = IntentUtils.extractDeepLinkPostId(intent)
+        if (postId != null) {
+            val nextIntent = Intent(context, SplashScreen::class.java).apply {
+                putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            context.startActivity(nextIntent)
+            onFinished()
+            return
+        }
+
+        val survey = IntentUtils.extractDeepLinkSurvey(intent)
+        if (survey != null) {
+            scope.launch {
+                val storedBaseUrl = DashboardServerPreferences.getServerBaseUrl(context.applicationContext)
+                val includeUserContext = IntentUtils.sameServer(storedBaseUrl, survey.baseUrl)
+                val result = surveysRepository.fetchPublicSurvey(
+                    baseUrl = survey.baseUrl,
+                    teamId = survey.teamId,
+                    surveyId = survey.surveyId,
+                )
+                val publicSurvey = result.getOrNull()
+                val document = publicSurvey?.survey
+                if (document == null) {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.dashboard_surveys_error_loading),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                    onFinished()
+                    return@launch
+                }
+                DashboardServerCatalog.addObservedServer(
+                    context = context.applicationContext,
+                    baseUrl = survey.baseUrl,
+                    displayName = DashboardServerCatalog.displayNameFromBaseUrl(survey.baseUrl),
+                )
+                val nextIntent = SurveyWizardActivity.newIntent(
+                    context = context,
+                    document = document,
+                    teamId = survey.teamId,
+                    teamName = publicSurvey.team?.name,
+                    baseUrl = survey.baseUrl,
+                    includeUserContext = includeUserContext,
+                ).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+                context.startActivity(nextIntent)
+                onFinished()
+            }
+            return
+        }
+
+        onFinished()
+    }
+
+    fun forwardDeepLinkIntent(sourceIntent: Intent?, targetIntent: Intent, delegatingToLogin: Boolean) {
+        val forwardedPostId = sourceIntent?.getStringExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID)
+            ?.takeIf { it.isNotBlank() }
+
+        if (forwardedPostId != null) {
+            targetIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, forwardedPostId)
+        } else if (sourceIntent?.action == Intent.ACTION_VIEW && sourceIntent.data != null) {
+            if (delegatingToLogin) {
+                targetIntent.action = sourceIntent.action
+                targetIntent.data = sourceIntent.data
+            } else {
+                val postId = IntentUtils.extractDeepLinkPostId(sourceIntent)
+                if (postId != null) {
+                    targetIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
+                }
+            }
+        }
+    }
+
+    fun extractForwardedPostId(intent: Intent?): String? {
+        return intent?.getStringExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID)
+            ?.takeIf { it.isNotBlank() }
+            ?: IntentUtils.extractDeepLinkPostId(intent)
+    }
+
+    fun applyForwardedPostId(targetIntent: Intent, postId: String?) {
+        postId?.let {
+            targetIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, it)
+        }
+    }
+
+    fun handleDashboardDeepLink(context: Context, intent: Intent?): Boolean {
+        val postId = intent?.getStringExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID)
+            ?.takeIf { it.isNotBlank() }
+            ?: return false
+
+        val detailIntent = Intent(context, DashboardPostDetailActivity::class.java).apply {
+            putExtra(DashboardPostDetailActivity.EXTRA_POST_ID, postId)
+        }
+        context.startActivity(detailIntent)
+        return true
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardActivity.kt
@@ -578,14 +578,7 @@ class DashboardActivity : BaseActivity() {
         if (deepLinkHandled) {
             return
         }
-        val postId = intent?.getStringExtra(EXTRA_DEEP_LINK_POST_ID)
-            ?.takeIf { it.isNotBlank() }
-            ?: return
-        val detailIntent = Intent(this, DashboardPostDetailActivity::class.java).apply {
-            putExtra(DashboardPostDetailActivity.EXTRA_POST_ID, postId)
-        }
-        startActivity(detailIntent)
-        deepLinkHandled = true
+        deepLinkHandled = AppNavigator.handleDashboardDeepLink(this, intent)
     }
 
     private fun showVoiceBatchSizeDialog() {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivity.kt
@@ -22,69 +22,16 @@ class DeepLinkResolverActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val postId = IntentUtils.extractDeepLinkPostId(intent)
-        if (postId != null) {
-            openPost(postId)
-            return
-        }
-
-        val survey = IntentUtils.extractDeepLinkSurvey(intent)
-        if (survey != null) {
-            openSurvey(survey)
-            return
-        }
-
-        finish()
+        AppNavigator.resolveDeepLink(
+            context = this,
+            intent = intent,
+            surveysRepository = surveysRepository,
+            scope = lifecycleScope,
+            onFinished = { finish() }
+        )
     }
 
-    private fun openPost(postId: String) {
-        val nextIntent = Intent(this, SplashScreen::class.java).apply {
-            putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        }
 
-        startActivity(nextIntent)
-        finish()
-    }
 
-    private fun openSurvey(link: IntentUtils.DeepLinkSurvey) {
-        lifecycleScope.launch {
-            val storedBaseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
-            val includeUserContext = IntentUtils.sameServer(storedBaseUrl, link.baseUrl)
-            val result = surveysRepository.fetchPublicSurvey(
-                baseUrl = link.baseUrl,
-                teamId = link.teamId,
-                surveyId = link.surveyId,
-            )
-            val publicSurvey = result.getOrNull()
-            val document = publicSurvey?.survey
-            if (document == null) {
-                Toast.makeText(
-                    this@DeepLinkResolverActivity,
-                    getString(R.string.dashboard_surveys_error_loading),
-                    Toast.LENGTH_SHORT,
-                ).show()
-                finish()
-                return@launch
-            }
-            DashboardServerCatalog.addObservedServer(
-                context = applicationContext,
-                baseUrl = link.baseUrl,
-                displayName = DashboardServerCatalog.displayNameFromBaseUrl(link.baseUrl),
-            )
-            val nextIntent = SurveyWizardActivity.newIntent(
-                context = this@DeepLinkResolverActivity,
-                document = document,
-                teamId = link.teamId,
-                teamName = publicSurvey.team?.name,
-                baseUrl = link.baseUrl,
-                includeUserContext = includeUserContext,
-            ).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            }
-            startActivity(nextIntent)
-            finish()
-        }
-    }
+
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/MyPlanetLite.kt
@@ -182,9 +182,7 @@ class MyPlanetLite : BaseActivity() {
         ProfileCredentialsStore.setSessionCredentials(null)
         clearStoredSessionIfNotRemembered()
         autoLoginEnabled = intent?.getBooleanExtra(EXTRA_ALLOW_AUTO_LOGIN, false) == true
-        deepLinkPostId = intent?.getStringExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID)
-            ?.takeIf { it.isNotBlank() }
-            ?: IntentUtils.extractDeepLinkPostId(intent)
+        deepLinkPostId = AppNavigator.extractForwardedPostId(intent)
 
         if (savedInstanceState != null) {
             val contentRoot: View? = findViewById(android.R.id.content)
@@ -304,9 +302,7 @@ class MyPlanetLite : BaseActivity() {
 
     private fun launchDashboard() {
         val dashboardIntent = Intent(this, DashboardActivity::class.java)
-        deepLinkPostId?.let { postId ->
-            dashboardIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
-        }
+        AppNavigator.applyForwardedPostId(dashboardIntent, deepLinkPostId)
         startActivity(dashboardIntent)
         deepLinkPostId = null
         finish()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
@@ -132,22 +132,7 @@ class SplashScreen : BaseActivity() {
             }
         }
 
-        val forwardedPostId = intent.getStringExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID)
-            ?.takeIf { it.isNotBlank() }
-
-        if (forwardedPostId != null) {
-            nextIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, forwardedPostId)
-        } else if (intent.action == Intent.ACTION_VIEW && intent.data != null) {
-            if (launchMode == DashboardLaunchMode.NONE) {
-                nextIntent.action = intent.action
-                nextIntent.data = intent.data
-            } else {
-                val postId = IntentUtils.extractDeepLinkPostId(intent)
-                if (postId != null) {
-                    nextIntent.putExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID, postId)
-                }
-            }
-        }
+        AppNavigator.forwardDeepLinkIntent(intent, nextIntent, launchMode == DashboardLaunchMode.NONE)
 
         startActivity(nextIntent)
         finish()


### PR DESCRIPTION
Extracts deep-link resolution and forwarding into `AppNavigator.kt` so that activities don't duplicate intent handling logic.

---
*PR created automatically by Jules for task [1108223845309814521](https://jules.google.com/task/1108223845309814521) started by @dogi*