### PR TITLE
Refactor ResourceExplorerAdapter to ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
@@ -55,9 +55,9 @@ private fun DashboardResourcesPageFragment.refreshTeamResources(
     }
     val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
     if (currentAdapter == null) {
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(teamResourcesItems.toList()) }
     } else {
-        currentAdapter.replaceResources(teamResourcesItems)
+        currentAdapter.submitList(teamResourcesItems.toList())
     }
     swipeRefreshLayout?.isRefreshing = false
 }
@@ -82,9 +82,9 @@ private fun DashboardResourcesPageFragment.refreshMainResources(
     }
     val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
     if (currentAdapter == null) {
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
     } else {
-        currentAdapter.replaceResources(mainResourcesItems)
+        currentAdapter.submitList(mainResourcesItems.toList())
     }
     swipeRefreshLayout?.isRefreshing = false
 }
@@ -99,7 +99,7 @@ internal fun DashboardResourcesPageFragment.showDownloadedResourcesOnly(list: Re
             mainResourcesItems.clear()
             mainResourcesItems.addAll(downloadedResources)
         }
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(downloadedResources, resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(downloadedResources) }
     }
 
 internal fun DashboardResourcesPageFragment.resetMainResourcesAndLoad() {
@@ -110,7 +110,7 @@ internal fun DashboardResourcesPageFragment.resetMainResourcesAndLoad() {
         mainResourcesItems.clear()
         mainResourcesItems.addAll(loadDownloadedResourcesFiltered())
         ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
-        resourcesList?.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        resourcesList?.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
         loadMoreMainResources()
     }
 
@@ -122,7 +122,7 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
         val list = resourcesList ?: return
         val resolvedBaseUrl = DashboardServerPreferences.getServerBaseUrl(context)
         if (resolvedBaseUrl.isNullOrBlank()) {
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
             swipeRefreshLayout?.isRefreshing = false
             return
         }
@@ -152,9 +152,9 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
                 ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
                 val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
                 if (currentAdapter == null || mainResourcesSkip == 0) {
-                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
                 } else {
-                    currentAdapter.replaceResources(mainResourcesItems)
+                    currentAdapter.submitList(mainResourcesItems.toList())
                 }
                 mainResourcesSkip += items.size
                 hasMoreMainResources = items.size >= DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE
@@ -175,7 +175,7 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
         val credentials = ProfileCredentialsStore.getStoredCredentials(context.applicationContext)
         if (teamId.isBlank() || resolvedBaseUrl.isNullOrBlank()) {
             teamResourcesItems.clear()
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(emptyList<ResourceUi>(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(emptyList<ResourceUi>()) }
             swipeRefreshLayout?.isRefreshing = false
             return
         }
@@ -205,7 +205,7 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
                 teamResourcesItems.addAll(mergedResources)
                 ResourceSearchEngine.sortResources(teamResourcesItems, selectedSortBy, isSortDescending)
                 hasLoadedTeamResources = true
-                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(teamResourcesItems.toList()) }
                 swipeRefreshLayout?.isRefreshing = false
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesPageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesPageFragment.kt
@@ -216,13 +216,15 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
     }
 
     internal class ResourceExplorerAdapter(
-        initialResources: List<ResourceUi>,
         private val downloadProgressByKey: Map<String, Int?>,
         private val onViewResource: (ResourceUi) -> Unit,
         private val onSecondaryAction: (ResourceUi) -> Unit
-    ) : RecyclerView.Adapter<ResourceExplorerAdapter.ResourceViewHolder>() {
-
-        private val resources = initialResources.toMutableList()
+    ) : androidx.recyclerview.widget.ListAdapter<ResourceUi, ResourceExplorerAdapter.ResourceViewHolder>(
+        org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback(
+            areItemsTheSame = { oldItem, newItem -> oldItem.uniqueKey() == newItem.uniqueKey() },
+            areContentsTheSame = { oldItem, newItem -> oldItem == newItem }
+        )
+    ) {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ResourceViewHolder {
             val inflater = LayoutInflater.from(parent.context)
@@ -231,39 +233,9 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
         }
 
         override fun onBindViewHolder(holder: ResourceViewHolder, position: Int) {
-            val item = resources[position]
+            val item = getItem(position)
             val key = item.uniqueKey()
             holder.bind(item, downloadProgressByKey[key], downloadProgressByKey.containsKey(key), onViewResource, onSecondaryAction)
-        }
-
-        override fun getItemCount(): Int = resources.size
-
-        fun replaceResources(newResources: List<ResourceUi>) {
-            val oldSize = resources.size
-            resources.clear()
-            resources.addAll(newResources)
-            when {
-                oldSize == 0 && newResources.isNotEmpty() -> notifyItemRangeInserted(0, newResources.size)
-                newResources.isEmpty() && oldSize > 0 -> notifyItemRangeRemoved(0, oldSize)
-                else -> {
-                    val commonCount = minOf(oldSize, newResources.size)
-                    if (commonCount > 0) {
-                        notifyItemRangeChanged(0, commonCount)
-                    }
-                    if (oldSize > newResources.size) {
-                        notifyItemRangeRemoved(newResources.size, oldSize - newResources.size)
-                    } else if (newResources.size > oldSize) {
-                        notifyItemRangeInserted(oldSize, newResources.size - oldSize)
-                    }
-                }
-            }
-        }
-
-        fun notifyResourceChanged(item: ResourceUi) {
-            val index = resources.indexOfFirst { it.uniqueKey() == item.uniqueKey() }
-            if (index >= 0) {
-                notifyItemChanged(index)
-            }
         }
 
         class ResourceViewHolder(
@@ -382,12 +354,20 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
 
     internal fun updateResourceDownloadProgress(item: ResourceUi, progress: Int?) {
         resourceDownloadProgress[item.uniqueKey()] = progress
-        (resourcesList?.adapter as? ResourceExplorerAdapter)?.notifyResourceChanged(item)
+        val currentList = (resourcesList?.adapter as? ResourceExplorerAdapter)?.currentList
+        val index = currentList?.indexOfFirst { it.uniqueKey() == item.uniqueKey() } ?: -1
+        if (index >= 0) {
+            resourcesList?.adapter?.notifyItemChanged(index)
+        }
     }
 
     internal fun clearResourceDownloadProgress(item: ResourceUi) {
         resourceDownloadProgress.remove(item.uniqueKey())
-        (resourcesList?.adapter as? ResourceExplorerAdapter)?.notifyResourceChanged(item)
+        val currentList = (resourcesList?.adapter as? ResourceExplorerAdapter)?.currentList
+        val index = currentList?.indexOfFirst { it.uniqueKey() == item.uniqueKey() } ?: -1
+        if (index >= 0) {
+            resourcesList?.adapter?.notifyItemChanged(index)
+        }
     }
 
     internal fun markResourceDownloadState(item: ResourceUi, downloaded: Boolean) {
@@ -403,9 +383,9 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
         val adapter = list.adapter as? ResourceExplorerAdapter
         val source = if (isTeamResourcesTab) teamResourcesItems else mainResourcesItems
         if (adapter == null) {
-            list.adapter = ResourceExplorerAdapter(source.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+            list.adapter = ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(source.toList()) }
         } else {
-            adapter.replaceResources(source)
+            adapter.submitList(source.toList())
         }
     }
 


### PR DESCRIPTION
Converts the custom RecyclerView.Adapter `ResourceExplorerAdapter` to standard `ListAdapter` backed by `DiffUtils.itemCallback`. The download progress state remains externally managed to allow explicit updates (`notifyItemChanged()`) without requiring full list diff recalculations. All initial and replace list usages in the call sites have been updated to `submitList`.

---
*PR created automatically by Jules for task [4246740652844429396](https://jules.google.com/task/4246740652844429396) started by @dogi*