### PR TITLE
feat: enrich join requests in repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -254,9 +254,9 @@ class DashboardTeamMembersFragment : Fragment() {
 
         val teamPlanetCodeForRequests = currentTeamPlanetCode ?: serverPlanetCode
         val joinRequests = if (teamPlanetCodeForRequests.isNullOrBlank()) {
-            emptyList<JoinRequestDocument>()
+            emptyList<TeamJoinRequestUiModel>()
         } else {
-            repository.fetchTeamJoinRequests(
+            repository.fetchEnrichedTeamJoinRequests(
                 baseUrl = base,
                 credentials = creds,
                 sessionCookie = sessionCookie,
@@ -268,7 +268,7 @@ class DashboardTeamMembersFragment : Fragment() {
             }
         }
         if (joinRequests != null) {
-            loadJoinRequestsData(base, creds, joinRequests)
+            loadJoinRequestsData(joinRequests)
         } else {
             hideJoinRequestsSection()
         }
@@ -309,11 +309,7 @@ class DashboardTeamMembersFragment : Fragment() {
         }
     }
 
-    private suspend fun loadJoinRequestsData(
-        base: String,
-        creds: StoredCredentials,
-        joinRequests: List<JoinRequestDocument>
-    ) {
+    private fun loadJoinRequestsData(joinRequests: List<TeamJoinRequestUiModel>) {
         if (joinRequests.isEmpty()) {
             currentJoinRequests = emptyList()
             updateJoinRequestsAdapterList(emptyList())
@@ -321,30 +317,8 @@ class DashboardTeamMembersFragment : Fragment() {
             return
         }
 
-        val userIds = joinRequests.mapNotNull { it.userId?.takeIf(String::isNotBlank) }.distinct()
-        val profilesById = repository.fetchUserProfiles(base, creds, sessionCookie, userIds)
-            .getOrDefault(emptyList())
-            .associateBy { it._id }
-        val requests = joinRequests.map { request ->
-            val userId = request.userId.orEmpty()
-            val profile = profilesById[userId]
-            val username = userId.substringAfter("org.couchdb.user:", userId)
-            val fullName = listOfNotNull(
-                profile?.firstName,
-                profile?.middleName,
-                profile?.lastName
-            ).filter { it.isNotBlank() }.joinToString(" ").ifBlank { username }
-            TeamJoinRequestUiModel(
-                id = request.id ?: userId,
-                username = username,
-                fullName = fullName,
-                hasAvatar = profile?.attachments?.image != null,
-                request = request,
-            )
-        }.sortedBy { it.fullName.lowercase() }
-
-        currentJoinRequests = requests
-        updateJoinRequestsAdapterList(requests)
+        currentJoinRequests = joinRequests
+        updateJoinRequestsAdapterList(joinRequests)
     }
 
     private fun showLoading(loading: Boolean) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -254,7 +254,7 @@ class DashboardTeamMembersFragment : Fragment() {
 
         val teamPlanetCodeForRequests = currentTeamPlanetCode ?: serverPlanetCode
         val joinRequests = if (teamPlanetCodeForRequests.isNullOrBlank()) {
-            emptyList<TeamJoinRequestUiModel>()
+            emptyList<org.ole.planet.myplanet.lite.dashboard.EnrichedJoinRequest>()
         } else {
             repository.fetchEnrichedTeamJoinRequests(
                 baseUrl = base,
@@ -309,7 +309,7 @@ class DashboardTeamMembersFragment : Fragment() {
         }
     }
 
-    private fun loadJoinRequestsData(joinRequests: List<TeamJoinRequestUiModel>) {
+    private fun loadJoinRequestsData(joinRequests: List<org.ole.planet.myplanet.lite.dashboard.EnrichedJoinRequest>) {
         if (joinRequests.isEmpty()) {
             currentJoinRequests = emptyList()
             updateJoinRequestsAdapterList(emptyList())
@@ -317,8 +317,17 @@ class DashboardTeamMembersFragment : Fragment() {
             return
         }
 
-        currentJoinRequests = joinRequests
-        updateJoinRequestsAdapterList(joinRequests)
+        val mappedRequests = joinRequests.map {
+            TeamJoinRequestUiModel(
+                id = it.id,
+                username = it.username,
+                fullName = it.fullName,
+                hasAvatar = it.hasAvatar,
+                request = it.request
+            )
+        }
+        currentJoinRequests = mappedRequests
+        updateJoinRequestsAdapterList(mappedRequests)
     }
 
     private fun showLoading(loading: Boolean) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
-import org.ole.planet.myplanet.lite.TeamJoinRequestUiModel
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 
 class DashboardTeamsRepository(
@@ -188,12 +187,12 @@ class DashboardTeamsRepository(
         sessionCookie: String?,
         teamId: String,
         teamPlanetCode: String,
-    ): Result<List<TeamJoinRequestUiModel>> = runInDispatcher {
+    ): Result<List<EnrichedJoinRequest>> = runInDispatcher {
         val joinRequests = operations.fetchTeamJoinRequests(baseUrl, credentials, sessionCookie, teamId, teamPlanetCode)
         if (joinRequests.isEmpty()) return@runInDispatcher emptyList()
 
         val userIds = joinRequests.mapNotNull { it.userId?.takeIf(String::isNotBlank) }.distinct()
-        val profilesById = operations.fetchUserProfiles(baseUrl, credentials, sessionCookie, userIds).associateBy { it._id }
+        val profilesById = runCatching { operations.fetchUserProfiles(baseUrl, credentials, sessionCookie, userIds) }.getOrDefault(emptyList()).associateBy { it._id }
 
         joinRequests.map { request ->
             val userId = request.userId.orEmpty()
@@ -204,7 +203,7 @@ class DashboardTeamsRepository(
                 profile?.middleName,
                 profile?.lastName
             ).filter { it.isNotBlank() }.joinToString(" ").ifBlank { username }
-            TeamJoinRequestUiModel(
+            EnrichedJoinRequest(
                 id = request.id ?: userId,
                 username = username,
                 fullName = fullName,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.ole.planet.myplanet.lite.TeamJoinRequestUiModel
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 
 class DashboardTeamsRepository(
@@ -178,6 +179,39 @@ class DashboardTeamsRepository(
 
     suspend fun fetchAllUsers(request: FetchUsersRequest): Result<List<UserDocument>> = runInDispatcher {
         operations.fetchAllUsers(request)
+    }
+
+
+    internal suspend fun fetchEnrichedTeamJoinRequests(
+        baseUrl: String,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        teamId: String,
+        teamPlanetCode: String,
+    ): Result<List<TeamJoinRequestUiModel>> = runInDispatcher {
+        val joinRequests = operations.fetchTeamJoinRequests(baseUrl, credentials, sessionCookie, teamId, teamPlanetCode)
+        if (joinRequests.isEmpty()) return@runInDispatcher emptyList()
+
+        val userIds = joinRequests.mapNotNull { it.userId?.takeIf(String::isNotBlank) }.distinct()
+        val profilesById = operations.fetchUserProfiles(baseUrl, credentials, sessionCookie, userIds).associateBy { it._id }
+
+        joinRequests.map { request ->
+            val userId = request.userId.orEmpty()
+            val profile = profilesById[userId]
+            val username = userId.substringAfter("org.couchdb.user:", userId)
+            val fullName = listOfNotNull(
+                profile?.firstName,
+                profile?.middleName,
+                profile?.lastName
+            ).filter { it.isNotBlank() }.joinToString(" ").ifBlank { username }
+            TeamJoinRequestUiModel(
+                id = request.id ?: userId,
+                username = username,
+                fullName = fullName,
+                hasAvatar = profile?.attachments?.image != null,
+                request = request,
+            )
+        }.sortedBy { it.fullName.lowercase() }
     }
 
     private suspend fun <T> runInDispatcher(block: () -> T): Result<T> {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/EnrichedJoinRequest.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/EnrichedJoinRequest.kt
@@ -1,0 +1,9 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+data class EnrichedJoinRequest(
+    val id: String,
+    val username: String,
+    val fullName: String,
+    val hasAvatar: Boolean,
+    val request: JoinRequestDocument,
+)

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryTest.kt
@@ -186,4 +186,39 @@ class DashboardTeamsRepositoryTest {
         assertTrue(request.path?.startsWith("/db/teams") == true)
         assertEquals("POST", request.method)
     }
+
+    @Test
+    fun `test fetchEnrichedTeamJoinRequests returns mapped list with graceful fallback`() = runTest {
+        val joinRequestsResponse = """
+            {
+                "docs": [
+                    {
+                        "_id": "req1",
+                        "teamId": "team123",
+                        "userId": "org.couchdb.user:testuser"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        // Missing profiles response or error -> graceful fallback
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody(joinRequestsResponse))
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+
+        val result = repository.fetchEnrichedTeamJoinRequests(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = null,
+            sessionCookie = null,
+            teamId = "team123",
+            teamPlanetCode = "planetA"
+        )
+
+        val requests = result.getOrThrow()
+        assertEquals(1, requests.size)
+        assertEquals("req1", requests[0].id)
+        assertEquals("testuser", requests[0].username)
+        assertEquals("testuser", requests[0].fullName) // Falls back to username since profile fetch fails
+        assertEquals(false, requests[0].hasAvatar)
+    }
+
 }


### PR DESCRIPTION
Moved the user profile lookup and merging logic for join requests from DashboardTeamMembersFragment into DashboardTeamsRepository to encapsulate data assembly. The fragment now cleanly consumes a list of pre-assembled TeamJoinRequestUiModel objects.

---
*PR created automatically by Jules for task [15870863711445644226](https://jules.google.com/task/15870863711445644226) started by @dogi*