### PR TITLE
Refactor: Replace private OkHttpClients with ServerConnectivityRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SignupActivity.kt
@@ -80,8 +80,6 @@ class SignupActivity : BaseActivity() {
     internal var selectedLanguageOption: SignupLanguageOption? = null
 
     internal lateinit var stepViews: Map<SignupStep, View>
-
-    internal val connectivityClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
     internal var serverBaseUrl: String = ""
     internal var isServerReachable: Boolean = false
     internal var isCheckingServerAvailability: Boolean = false
@@ -95,7 +93,7 @@ class SignupActivity : BaseActivity() {
     }
     internal val moshi: Moshi by lazy { Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build() }
     internal val serverConnectivityRepository: ServerConnectivityRepository by lazy {
-        ServerConnectivityRepository(connectivityClient, moshi)
+        ServerConnectivityRepository(OkHttpClient.Builder().build(), moshi)
     }
 
     internal val steps = SignupStep.entries
@@ -160,20 +158,11 @@ class SignupActivity : BaseActivity() {
     suspend fun checkUsernameAvailability(username: String): UsernameAvailability {
         val requestUrl = buildUsernameLookupUrl(username) ?: return UsernameAvailability.UNKNOWN
         return withContext(Dispatchers.IO) {
-            runCatching {
-                val request = Request.Builder()
-                    .url(requestUrl)
-                    .get()
-                    .build()
-                connectivityClient.newCall(request).execute().use { response ->
-                    if (response.code == 200) {
-                        UsernameAvailability.TAKEN
-                    } else {
-                        UsernameAvailability.AVAILABLE
-                    }
-                }
-            }.getOrElse {
-                UsernameAvailability.UNKNOWN
+            val taken = serverConnectivityRepository.checkUsernameAvailability(requestUrl)
+            when (taken) {
+                true -> UsernameAvailability.TAKEN
+                false -> UsernameAvailability.AVAILABLE
+                null -> UsernameAvailability.UNKNOWN
             }
         }
     }
@@ -223,16 +212,12 @@ class SignupActivity : BaseActivity() {
         return withContext(Dispatchers.IO) {
             try {
                 val body = payload.toString().toRequestBody(mediaType)
-                val request = Request.Builder()
-                    .url(requestUrl)
-                    .put(body)
-                    .build()
-                connectivityClient.newCall(request).execute().use { response ->
-                    when (response.code) {
-                        in 200..299 -> SignupSubmissionResult.SUCCESS
-                        409 -> SignupSubmissionResult.USERNAME_TAKEN
-                        else -> SignupSubmissionResult.FAILED
-                    }
+                val responseCode = serverConnectivityRepository.submitSignup(requestUrl, body)
+                    ?: throw java.io.IOException("Network error")
+                when (responseCode) {
+                    in 200..299 -> SignupSubmissionResult.SUCCESS
+                    409 -> SignupSubmissionResult.USERNAME_TAKEN
+                    else -> SignupSubmissionResult.FAILED
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
@@ -32,18 +32,16 @@ import org.ole.planet.myplanet.lite.util.IntentUtils
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 
 class SplashScreen : BaseActivity() {
-
-    private val connectivityClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
     private val connectivityMoshi: Moshi by lazy { Moshi.Builder().build() }
     private val serverConnectivityRepository: ServerConnectivityRepository by lazy {
-        ServerConnectivityRepository(connectivityClient, connectivityMoshi)
+        ServerConnectivityRepository(OkHttpClient.Builder().build(), connectivityMoshi)
     }
 
     private val userProfileDatabase: UserProfileDatabase by lazy {
         UserProfileDatabase.getInstance(applicationContext)
     }
     private val userProfileSync: UserProfileSync by lazy {
-        UserProfileSync(connectivityClient, userProfileDatabase)
+        UserProfileSync(serverConnectivityRepository.client, userProfileDatabase)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/ServerConnectivityRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/ServerConnectivityRepository.kt
@@ -8,7 +8,7 @@ import org.ole.planet.myplanet.lite.model.ServerConnectivityResult
 import org.ole.planet.myplanet.lite.util.ServerMetadataExtractor
 
 class ServerConnectivityRepository(
-    private val client: OkHttpClient,
+    val client: OkHttpClient,
     private val moshi: Moshi
 ) {
 
@@ -39,5 +39,29 @@ class ServerConnectivityRepository(
             ?.addQueryParameter("include_docs", "true")
             ?.build()
             ?.toString()
+    }
+
+    fun checkUsernameAvailability(usernameUrl: String): Boolean? {
+        return runCatching {
+            val request = Request.Builder()
+                .url(usernameUrl)
+                .get()
+                .build()
+            client.newCall(request).execute().use { response ->
+                response.code == 200
+            }
+        }.getOrNull()
+    }
+
+    fun submitSignup(requestUrl: String, body: okhttp3.RequestBody): Int? {
+        return runCatching {
+            val request = Request.Builder()
+                .url(requestUrl)
+                .put(body)
+                .build()
+            client.newCall(request).execute().use { response ->
+                response.code
+            }
+        }.getOrNull()
     }
 }


### PR DESCRIPTION
This pull request consolidates network request handling for `SignupActivity` and `SplashScreen` by delegating their manual `OkHttpClient` calls to `ServerConnectivityRepository`.

**Changes:**
- `ServerConnectivityRepository`: Exposed the `OkHttpClient` as a public property and added dedicated `checkUsernameAvailability` and `submitSignup` functions to encapsulate request building and execution.
- `SignupActivity`: Removed the private `connectivityClient`. Swapped manual `OkHttp` probing for the new centralized repository methods. Correctly bridged the result checking to preserve the existing exception handling logic and Toasts.
- `SplashScreen`: Removed the private `connectivityClient`. Updated `UserProfileSync` instantiation to utilize the centralized `serverConnectivityRepository.client`.

**Verification:**
- Validated via `./gradlew assembleDebug`.
- Validated via `./gradlew testDebugUnitTest --tests "*SignupActivity*"` and `./gradlew testDebugUnitTest --tests "*SplashScreen*"`.
- Validated via `./gradlew lint app:lintDebug`.

---
*PR created automatically by Jules for task [16001477616075879246](https://jules.google.com/task/16001477616075879246) started by @dogi*