### PR TITLE
Refactor: remove redundant nested Dispatchers.IO in DashboardCoursesRepository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -353,17 +353,15 @@ class DashboardCoursesRepository(
                     .addHeader("Authorization", Credentials.basic(credentials.username, credentials.password))
                     .build()
 
-                val docs = withContext(Dispatchers.IO) {
-                    client.newCall(request).execute().use { response ->
-                        if (!response.isSuccessful) {
-                            response.body.string()
-                            throw IOException("Unexpected response ${response.code}")
-                        }
-                        val parsed = coursesProgressResponseAdapter.fromJson(response.body.string())
-                            ?: throw IOException("Invalid response body")
-                        parsed.docs
-                            .filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
+                val docs = client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        response.body.string()
+                        throw IOException("Unexpected response ${response.code}")
                     }
+                    val parsed = coursesProgressResponseAdapter.fromJson(response.body.string())
+                        ?: throw IOException("Invalid response body")
+                    parsed.docs
+                        .filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
                 }
 
                 docs.forEach { doc ->
@@ -412,16 +410,14 @@ class DashboardCoursesRepository(
                     .addHeader("Authorization", Credentials.basic(credentials.username, credentials.password))
                     .build()
 
-                val docs = withContext(Dispatchers.IO) {
-                    client.newCall(request).execute().use { response ->
-                        if (!response.isSuccessful) {
-                            response.body.string()
-                            throw IOException("Unexpected response ${response.code}")
-                        }
-                        val parsed = coursesProgressResponseAdapter.fromJson(response.body.string())
-                            ?: throw IOException("Invalid response body")
-                        parsed.docs.filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
+                val docs = client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        response.body.string()
+                        throw IOException("Unexpected response ${response.code}")
                     }
+                    val parsed = coursesProgressResponseAdapter.fromJson(response.body.string())
+                        ?: throw IOException("Invalid response body")
+                    parsed.docs.filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
                 }
                 if (stepNum != null) {
                     docs.associateBy { it.courseId!! }


### PR DESCRIPTION
This PR optimizes `DashboardCoursesRepository` by removing redundant nested `withContext(Dispatchers.IO)` blocks inside the course progress fetch methods (`fetchCoursesProgress` and `fetchCoursesProgressDocuments`). Because the entire method is already wrapped in `withContext(dispatcher)` (which defaults to `Dispatchers.IO`), the inner context switch is unnecessary and adds minor overhead. The network calls now execute directly on the injected repository dispatcher. All relevant repository unit tests pass successfully.

---
*PR created automatically by Jules for task [12514807323475253387](https://jules.google.com/task/12514807323475253387) started by @dogi*