### PR TITLE
Refactor: Move cache cleanup off GlobalScope in Voice Activities

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/CreateVoiceActivity.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
@@ -232,8 +231,7 @@ class CreateVoiceActivity : BaseActivity() {
         val filesToDelete = pendingImages.values.map { it.file }.toList()
         pendingImages.clear()
 
-        @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-        GlobalScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(Dispatchers.IO) {
             filesToDelete.forEach { file ->
                 if (file.exists()) {
                     file.delete()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.ole.planet.myplanet.lite.R
@@ -776,8 +775,7 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
         val filesToDelete = pendingReplyImages.values.map { it.file }.toList()
         pendingReplyImages.clear()
 
-        @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-        GlobalScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(Dispatchers.IO) {
             filesToDelete.forEach { file ->
                 if (file.exists()) {
                     file.delete()


### PR DESCRIPTION
Replaced `GlobalScope.launch` with `lifecycleScope.launch` in `CreateVoiceActivity` and `DashboardPostDetailActivity` for pending image deletion to ensure proper lifecycle management and avoid unbounded background operations. Tests successfully passed.

---
*PR created automatically by Jules for task [3741019081726154316](https://jules.google.com/task/3741019081726154316) started by @dogi*