### PR TITLE
Narrow course image-loader adapter invalidation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -279,7 +279,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val sessionCookie = withContext(Dispatchers.IO) { authService.getStoredToken() }
             courseImageLoader = DashboardPostImageLoader(base, sessionCookie, viewLifecycleOwner.lifecycleScope)
             isCourseImageLoaderLoading = false
-            adapter.notifyDataSetChanged()
+            adapter.notifyImageLoaderReady()
         }
     }
 
@@ -1228,6 +1228,14 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         fun updateTagFilter(courseIds: Set<String>?) {
             activeTagCourseIds = courseIds
             applyFilter()
+        }
+
+        fun notifyImageLoaderReady() {
+            displayedItems.forEachIndexed { index, item ->
+                if (!item.coverPath.isNullOrBlank()) {
+                    notifyItemChanged(index + 1)
+                }
+            }
         }
 
         fun updateDownloadedCourses(courseIds: Set<String>) {


### PR DESCRIPTION
- Added an adapter helper that notifies only visible course item positions/rows with image URLs when the loader becomes ready.
- Replaced the broad `notifyDataSetChanged` call in `ensureCourseImageLoader` with this new targeted helper to prevent unnecessary layout invalidations.
- Kept the current `RecyclerView.Adapter` implementation per requirements (did not migrate to `ListAdapter`).

---
*PR created automatically by Jules for task [6043968083098031047](https://jules.google.com/task/6043968083098031047) started by @dogi*