### PR TITLE
Migrate ResourceExplorerAdapter to ListAdapter

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
@@ -55,9 +55,9 @@ private fun DashboardResourcesPageFragment.refreshTeamResources(
     }
     val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
     if (currentAdapter == null) {
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(teamResourcesItems.toList()) }
     } else {
-        currentAdapter.replaceResources(teamResourcesItems)
+        currentAdapter.submitList(teamResourcesItems.toList())
     }
     swipeRefreshLayout?.isRefreshing = false
 }
@@ -82,9 +82,9 @@ private fun DashboardResourcesPageFragment.refreshMainResources(
     }
     val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
     if (currentAdapter == null) {
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
     } else {
-        currentAdapter.replaceResources(mainResourcesItems)
+        currentAdapter.submitList(mainResourcesItems.toList())
     }
     swipeRefreshLayout?.isRefreshing = false
 }
@@ -99,7 +99,7 @@ internal fun DashboardResourcesPageFragment.showDownloadedResourcesOnly(list: Re
             mainResourcesItems.clear()
             mainResourcesItems.addAll(downloadedResources)
         }
-        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(downloadedResources, resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(downloadedResources) }
     }
 
 internal fun DashboardResourcesPageFragment.resetMainResourcesAndLoad() {
@@ -110,7 +110,7 @@ internal fun DashboardResourcesPageFragment.resetMainResourcesAndLoad() {
         mainResourcesItems.clear()
         mainResourcesItems.addAll(loadDownloadedResourcesFiltered())
         ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
-        resourcesList?.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+        resourcesList?.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
         loadMoreMainResources()
     }
 
@@ -122,7 +122,7 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
         val list = resourcesList ?: return
         val resolvedBaseUrl = DashboardServerPreferences.getServerBaseUrl(context)
         if (resolvedBaseUrl.isNullOrBlank()) {
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
             swipeRefreshLayout?.isRefreshing = false
             return
         }
@@ -152,9 +152,9 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
                 ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
                 val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
                 if (currentAdapter == null || mainResourcesSkip == 0) {
-                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(mainResourcesItems.toList()) }
                 } else {
-                    currentAdapter.replaceResources(mainResourcesItems)
+                    currentAdapter.submitList(mainResourcesItems.toList())
                 }
                 mainResourcesSkip += items.size
                 hasMoreMainResources = items.size >= DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE
@@ -175,7 +175,7 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
         val credentials = ProfileCredentialsStore.getStoredCredentials(context.applicationContext)
         if (teamId.isBlank() || resolvedBaseUrl.isNullOrBlank()) {
             teamResourcesItems.clear()
-            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(emptyList<ResourceUi>(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+            list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(emptyList<ResourceUi>()) }
             swipeRefreshLayout?.isRefreshing = false
             return
         }
@@ -205,7 +205,7 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
                 teamResourcesItems.addAll(mergedResources)
                 ResourceSearchEngine.sortResources(teamResourcesItems, selectedSortBy, isSortDescending)
                 hasLoadedTeamResources = true
-                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(teamResourcesItems.toList()) }
                 swipeRefreshLayout?.isRefreshing = false
             }
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesPageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesPageFragment.kt
@@ -22,6 +22,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.ListAdapter
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import java.io.File
@@ -216,13 +217,14 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
     }
 
     internal class ResourceExplorerAdapter(
-        initialResources: List<ResourceUi>,
         private val downloadProgressByKey: Map<String, Int?>,
         private val onViewResource: (ResourceUi) -> Unit,
         private val onSecondaryAction: (ResourceUi) -> Unit
-    ) : RecyclerView.Adapter<ResourceExplorerAdapter.ResourceViewHolder>() {
-
-        private val resources = initialResources.toMutableList()
+    ) : ListAdapter<ResourceUi, ResourceExplorerAdapter.ResourceViewHolder>(
+        org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback(
+            areItemsTheSame = { oldItem, newItem -> oldItem.uniqueKey() == newItem.uniqueKey() }
+        )
+    ) {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ResourceViewHolder {
             val inflater = LayoutInflater.from(parent.context)
@@ -231,36 +233,15 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
         }
 
         override fun onBindViewHolder(holder: ResourceViewHolder, position: Int) {
-            val item = resources[position]
+            val item = getItem(position)
             val key = item.uniqueKey()
             holder.bind(item, downloadProgressByKey[key], downloadProgressByKey.containsKey(key), onViewResource, onSecondaryAction)
         }
 
-        override fun getItemCount(): Int = resources.size
 
-        fun replaceResources(newResources: List<ResourceUi>) {
-            val oldSize = resources.size
-            resources.clear()
-            resources.addAll(newResources)
-            when {
-                oldSize == 0 && newResources.isNotEmpty() -> notifyItemRangeInserted(0, newResources.size)
-                newResources.isEmpty() && oldSize > 0 -> notifyItemRangeRemoved(0, oldSize)
-                else -> {
-                    val commonCount = minOf(oldSize, newResources.size)
-                    if (commonCount > 0) {
-                        notifyItemRangeChanged(0, commonCount)
-                    }
-                    if (oldSize > newResources.size) {
-                        notifyItemRangeRemoved(newResources.size, oldSize - newResources.size)
-                    } else if (newResources.size > oldSize) {
-                        notifyItemRangeInserted(oldSize, newResources.size - oldSize)
-                    }
-                }
-            }
-        }
 
         fun notifyResourceChanged(item: ResourceUi) {
-            val index = resources.indexOfFirst { it.uniqueKey() == item.uniqueKey() }
+            val index = currentList.indexOfFirst { it.uniqueKey() == item.uniqueKey() }
             if (index >= 0) {
                 notifyItemChanged(index)
             }
@@ -403,9 +384,9 @@ class DashboardResourcesPageFragment : Fragment(R.layout.fragment_dashboard_reso
         val adapter = list.adapter as? ResourceExplorerAdapter
         val source = if (isTeamResourcesTab) teamResourcesItems else mainResourcesItems
         if (adapter == null) {
-            list.adapter = ResourceExplorerAdapter(source.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
+            list.adapter = ResourceExplorerAdapter(resourceDownloadProgress, ::openResource, ::onSecondaryAction).apply { submitList(source.toList()) }
         } else {
-            adapter.replaceResources(source)
+            adapter.submitList(source.toList())
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/ResourceExplorerAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/ResourceExplorerAdapterTest.kt
@@ -1,0 +1,80 @@
+package org.ole.planet.myplanet.lite
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlinx.coroutines.test.runTest
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ResourceExplorerAdapterTest {
+
+    private lateinit var adapter: DashboardResourcesPageFragment.ResourceExplorerAdapter
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(
+            downloadProgressByKey = emptyMap(),
+            onViewResource = {},
+            onSecondaryAction = {}
+        )
+    }
+
+    @Test
+    fun testSubmitListAndDiffing() = runTest {
+        val resource1 = ResourceUi(
+            id = "1",
+            filename = "file1.pdf",
+            name = "Test 1",
+            type = "pdf",
+            date = "2023",
+            createdDate = 12345L,
+            isDownloaded = false,
+            isDownloadable = true,
+            isTeamResource = false
+        )
+        val resource2 = ResourceUi(
+            id = "2",
+            filename = "file2.pdf",
+            name = "Test 2",
+            type = "video",
+            date = "2023",
+            createdDate = 12345L,
+            isDownloaded = false,
+            isDownloadable = true,
+            isTeamResource = false
+        )
+
+        adapter.submitList(listOf(resource1, resource2)) {
+            assertEquals(2, adapter.currentList.size)
+            assertEquals("1", adapter.currentList[0].id)
+        }
+
+        // Remove 1, add 3
+        val resource3 = ResourceUi(
+            id = "3",
+            filename = "file3.pdf",
+            name = "Test 3",
+            type = "audio",
+            date = "2023",
+            createdDate = 12345L,
+            isDownloaded = false,
+            isDownloadable = true,
+            isTeamResource = false
+        )
+
+        adapter.submitList(listOf(resource2, resource3)) {
+            assertEquals(2, adapter.currentList.size)
+            assertEquals("2", adapter.currentList[0].id)
+            assertEquals("3", adapter.currentList[1].id)
+        }
+    }
+}


### PR DESCRIPTION
Migrates the `ResourceExplorerAdapter` to use Android's `ListAdapter` for automated `DiffUtil` calculations instead of manually managing list states and calling `notifyItemRange*` methods. 

This change reduces state-management bugs, safely tracks updates using `currentList`, and leaves `notifyResourceChanged` targeted exclusively for download progress updates. Also introduces testing to verify list behaviors.

---
*PR created automatically by Jules for task [8820679791504026621](https://jules.google.com/task/8820679791504026621) started by @dogi*