### PR TITLE
Replace commit() with commitAllowingStateLoss() in DashboardTeamsFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamsFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamsFragment.kt
@@ -81,7 +81,7 @@ class DashboardTeamsFragment : Fragment(R.layout.fragment_dashboard_teams_feed) 
                 childFragmentManager.findFragmentById(R.id.teamContentContainer)?.let { fragment ->
                     childFragmentManager.beginTransaction()
                         .remove(fragment)
-                        .commit()
+                        .commitAllowingStateLoss()
                 }
             }
         }
@@ -96,7 +96,7 @@ class DashboardTeamsFragment : Fragment(R.layout.fragment_dashboard_teams_feed) 
         val fragment = DashboardVoicesFragment.newInstanceForTeam(teamId, teamName)
         childFragmentManager.beginTransaction()
             .replace(R.id.teamContentContainer, fragment)
-            .commit()
+            .commitAllowingStateLoss()
     }
 
     private fun loadTeamSurveys(teamId: String, teamName: String) {
@@ -108,7 +108,7 @@ class DashboardTeamsFragment : Fragment(R.layout.fragment_dashboard_teams_feed) 
         val fragment = DashboardTeamSurveysFragment.newInstanceForTeam(teamId, teamName)
         childFragmentManager.beginTransaction()
             .replace(R.id.teamContentContainer, fragment)
-            .commit()
+            .commitAllowingStateLoss()
     }
 
     private fun switchSection(section: TeamSection) {


### PR DESCRIPTION
This PR updates `DashboardTeamsFragment` to use `commitAllowingStateLoss()` instead of `commit()` for all FragmentTransactions, reducing the risk of `IllegalStateException` after saved state.

---
*PR created automatically by Jules for task [18357201619865605145](https://jules.google.com/task/18357201619865605145) started by @dogi*