### PR TITLE
Refactor: Replace commit() with commitAllowingStateLoss() in DashboardSurveysFragment

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardSurveysFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardSurveysFragment.kt
@@ -58,7 +58,7 @@ class DashboardSurveysFragment : Fragment(R.layout.fragment_dashboard_surveys) {
             childFragmentManager.findFragmentById(R.id.dashboardSurveysContentContainer)?.let { fragment ->
                 childFragmentManager.beginTransaction()
                     .remove(fragment)
-                    .commit()
+                    .commitAllowingStateLoss()
             }
         }
     }
@@ -71,6 +71,6 @@ class DashboardSurveysFragment : Fragment(R.layout.fragment_dashboard_surveys) {
         val fragment = DashboardTeamSurveysFragment.newInstanceForTeam(teamId, teamName)
         childFragmentManager.beginTransaction()
             .replace(R.id.dashboardSurveysContentContainer, fragment)
-            .commit()
+            .commitAllowingStateLoss()
     }
 }


### PR DESCRIPTION
Replaced `FragmentTransaction.commit()` with `commitAllowingStateLoss()` in `DashboardSurveysFragment.kt` to prevent potential `IllegalStateException`s if fragments are committed after the activity's state has been saved, as requested by the user.

---
*PR created automatically by Jules for task [2767229908942625560](https://jules.google.com/task/2767229908942625560) started by @dogi*