### PR TITLE
Fix: Replace commit() with commitAllowingStateLoss() in DashboardActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardActivity.kt
@@ -454,7 +454,7 @@ class DashboardActivity : BaseActivity() {
         if (fragment !is DashboardSurveysFragment) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.dashboardSurveysContainer, DashboardSurveysFragment())
-                .commit()
+                .commitAllowingStateLoss()
         }
 
         updateBottomNavigationState()
@@ -473,7 +473,7 @@ class DashboardActivity : BaseActivity() {
         if (fragment !is DashboardTeamMembersFragment) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.dashboardTeamMembersContainer, DashboardTeamMembersFragment())
-                .commit()
+                .commitAllowingStateLoss()
         }
 
         updateBottomNavigationState()
@@ -492,7 +492,7 @@ class DashboardActivity : BaseActivity() {
         if (fragment !is DashboardCoursesFragment) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.dashboardCoursesContainer, DashboardCoursesFragment())
-                .commit()
+                .commitAllowingStateLoss()
         }
 
         updateBottomNavigationState()
@@ -511,7 +511,7 @@ class DashboardActivity : BaseActivity() {
         if (fragment !is DashboardResourcesFragment) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.dashboardResourcesContainer, DashboardResourcesFragment())
-                .commit()
+                .commitAllowingStateLoss()
         }
 
         updateBottomNavigationState()


### PR DESCRIPTION
Replaced instances of FragmentTransaction.commit() with commitAllowingStateLoss() in DashboardActivity to address state loss exceptions during Fragment replacement. Unit tests pass locally.

---
*PR created automatically by Jules for task [5513625793981944983](https://jules.google.com/task/5513625793981944983) started by @dogi*