### PR TITLE
Refactor survey submission paths

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
@@ -72,6 +72,7 @@ import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.ole.planet.myplanet.lite.profile.UserProfile
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository
+import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult
 import org.ole.planet.myplanet.lite.surveys.SurveyTranslationManager
 import org.ole.planet.myplanet.lite.surveys.SurveyTranslationManager.TranslatedQuestion
 import org.ole.planet.myplanet.lite.util.NetworkUtils
@@ -354,7 +355,7 @@ internal suspend fun SurveyWizardFragment.processSubmission(
     setSubmitting(false)
 
     when (result) {
-        org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.SUBMITTED_ONLINE -> {
+        SubmissionResult.SUBMITTED_ONLINE -> {
             DashboardSurveyStatusStore(
                 requireContext().applicationContext,
                 username,
@@ -372,7 +373,7 @@ internal suspend fun SurveyWizardFragment.processSubmission(
             ).show()
             finishWithResult()
         }
-        org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.QUEUED_OFFLINE -> {
+        SubmissionResult.QUEUED_OFFLINE -> {
             Toast.makeText(
                 requireContext(),
                 getString(R.string.dashboard_survey_submission_saved_offline),

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
@@ -338,62 +338,49 @@ internal suspend fun SurveyWizardFragment.processSubmission(
     survey: SurveyDocument,
     username: String?
 ) {
-    val isOnline = NetworkUtils.isDeviceOnline(requireContext())
-    if (!isOnline) {
-        setSubmitting(false)
-        if (baseUrlOverride != null) {
-            showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
-            return
-        }
-        queueSubmissionForOutbox(submission, survey)
-        return
-    }
+    val allowQueueing = baseUrlOverride == null
+    val result = localSurveyRepository.submitOrQueue(
+        base = base,
+        credentials = credentials,
+        sessionCookie = sessionCookie,
+        submission = submission,
+        surveyId = survey.id,
+        surveyName = survey.name,
+        teamId = teamId,
+        teamName = teamName,
+        allowQueueing = allowQueueing
+    )
 
-    val result = submissionRepository.submitSurvey(base, credentials, sessionCookie, submission)
     setSubmitting(false)
-    if (result.isSuccess) {
-        DashboardSurveyStatusStore(
-            requireContext().applicationContext,
-            username,
-        ).markCompleted(survey.id)
-        Toast.makeText(
-            requireContext(),
-            getString(
-                if (isExam) {
-                    R.string.dashboard_exam_completed
-                } else {
-                    R.string.dashboard_survey_wizard_completed
-                }
-            ),
-            Toast.LENGTH_SHORT
-        ).show()
-        finishWithResult()
-    } else {
-        if (baseUrlOverride != null) {
-            showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
-            return
-        }
-        queueSubmissionForOutbox(submission, survey)
-    }
-}
 
-internal fun SurveyWizardFragment.queueSubmissionForOutbox(submission: SurveySubmission, survey: SurveyDocument) {
-    viewLifecycleOwner.lifecycleScope.launch {
-        val saved = localSurveyRepository.saveSubmission(
-            submission = submission,
-            surveyId = survey.id,
-            surveyName = survey.name,
-            teamId = teamId,
-            teamName = teamName,
-        )
-        if (saved) {
+    when (result) {
+        org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.SUBMITTED_ONLINE -> {
+            DashboardSurveyStatusStore(
+                requireContext().applicationContext,
+                username,
+            ).markCompleted(survey.id)
+            Toast.makeText(
+                requireContext(),
+                getString(
+                    if (isExam) {
+                        R.string.dashboard_exam_completed
+                    } else {
+                        R.string.dashboard_survey_wizard_completed
+                    }
+                ),
+                Toast.LENGTH_SHORT
+            ).show()
+            finishWithResult()
+        }
+        org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.QUEUED_OFFLINE -> {
             Toast.makeText(
                 requireContext(),
                 getString(R.string.dashboard_survey_submission_saved_offline),
                 Toast.LENGTH_SHORT,
             ).show()
             finishWithResult()
-        } else {
+        }
+        else -> {
             showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
@@ -270,75 +270,45 @@ class DashboardOutboxDetailActivity : BaseActivity() {
     }
 
     private fun attemptSend(entry: DashboardSurveyOutboxStore.OutboxEntry) {
-        if (!NetworkUtils.isDeviceOnline(this@DashboardOutboxDetailActivity)) {
-            Toast.makeText(this, R.string.dashboard_outbox_offline_cannot_send, Toast.LENGTH_SHORT).show()
-            return
-        }
         lifecycleScope.launch {
             val baseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
-            val credentials = ProfileCredentialsStore.getStoredCredentials(applicationContext)
-            val sessionCookie = baseUrl?.let { AuthDependencies.provideAuthService(this@DashboardOutboxDetailActivity, it).getStoredToken() }
-            val serverRev = fetchServerRevision(
-                baseUrl,
-                entry.submission.parent.id,
-                entry.teamId,
-                sessionCookie,
-                credentials?.username,
-                credentials?.password,
-            )
-            val localRev = entry.submission.parent.rev
-            if (serverRev == null) {
-                Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_unable_to_verify_rev, Toast.LENGTH_SHORT).show()
+            val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
+            if (normalized == null) {
+                Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_surveys_missing_server, Toast.LENGTH_SHORT).show()
                 return@launch
             }
-            if (localRev != null && localRev != serverRev) {
-                showRevMismatchDialog(entry)
-                return@launch
-            }
-            submitEntry(entry, baseUrl, credentials?.username, credentials?.password, sessionCookie)
-        }
-    }
 
-    private suspend fun fetchServerRevision(
-        baseUrl: String?,
-        surveyId: String?,
-        teamId: String?,
-        sessionCookie: String?,
-        username: String?,
-        password: String?,
-    ): String? = withContext(Dispatchers.IO) {
-        val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return@withContext null
-        val id = surveyId?.takeIf { it.isNotBlank() } ?: return@withContext null
-        val selector = JSONObject().apply {
-            put("_id", id)
-            put("type", "surveys")
-            teamId?.takeIf { it.isNotBlank() }?.let { put("teamId", it) }
-        }
-        val payload = JSONObject().apply {
-            put("selector", selector)
-            put("limit", 1)
-            put("fields", JSONArray().apply { put("_rev") })
-        }.toString()
-        val url = "$normalized/db/exams/_find"
-        val requestBuilder = Request.Builder()
-            .url(url)
-            .post(payload.toRequestBody(JSON_MEDIA_TYPE))
-        if (!sessionCookie.isNullOrBlank()) {
-            requestBuilder.addHeader("Cookie", sessionCookie)
-        } else if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
-            val creds = okhttp3.Credentials.basic(username, password)
-            requestBuilder.addHeader("Authorization", creds)
-        }
-        runCatching {
-            httpClient.newCall(requestBuilder.build()).execute().use { response ->
-                if (!response.isSuccessful) return@use null
-                val body = response.body.string()
-                if (body.isBlank()) return@use null
-                val docs = JSONObject(body).optJSONArray("docs")
-                val first = docs?.optJSONObject(0)
-                first?.optString("_rev")?.takeIf { it.isNotBlank() }
+            val credentials = ProfileCredentialsStore.getStoredCredentials(applicationContext)
+            val authService = AuthDependencies.provideAuthService(this@DashboardOutboxDetailActivity, normalized)
+            val sessionCookie = withContext(Dispatchers.IO) { authService.getStoredToken() }
+
+            val localRepo = org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository(applicationContext)
+            val result = localRepo.resendOutboxEntry(
+                base = normalized,
+                credentials = credentials,
+                sessionCookie = sessionCookie,
+                entry = entry
+            )
+
+            when (result) {
+                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.FAILED_OFFLINE -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_offline_cannot_send, Toast.LENGTH_SHORT).show()
+                }
+                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.FAILED_REVISION_CHECK -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_unable_to_verify_rev, Toast.LENGTH_SHORT).show()
+                }
+                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.REVISION_MISMATCH -> {
+                    showRevMismatchDialog(entry)
+                }
+                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.SUBMITTED_ONLINE -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_send_success, Toast.LENGTH_SHORT).show()
+                    finish()
+                }
+                else -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_send_failed, Toast.LENGTH_SHORT).show()
+                }
             }
-        }.getOrNull()
+        }
     }
 
     private fun confirmDelete(entry: DashboardSurveyOutboxStore.OutboxEntry) {
@@ -368,36 +338,6 @@ class DashboardOutboxDetailActivity : BaseActivity() {
             .show()
     }
 
-    private suspend fun submitEntry(
-        entry: DashboardSurveyOutboxStore.OutboxEntry,
-        baseUrl: String?,
-        username: String?,
-        password: String?,
-        sessionCookie: String?,
-    ) {
-        val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
-        if (normalized == null) {
-            Toast.makeText(this, R.string.dashboard_surveys_missing_server, Toast.LENGTH_SHORT).show()
-            return
-        }
-        val authService = AuthDependencies.provideAuthService(this, normalized)
-        val token = sessionCookie ?: authService.getStoredToken()
-        val result = withContext(Dispatchers.IO) {
-            DashboardSurveySubmissionsRepository().submitSurvey(
-                normalized,
-                credentials = username?.let { user -> password?.let { pass -> org.ole.planet.myplanet.lite.profile.StoredCredentials(user, pass) } },
-                sessionCookie = token,
-                submission = entry.submission,
-            )
-        }
-        if (result.isSuccess) {
-            outboxStore.deleteEntry(entry.id)
-            Toast.makeText(this, R.string.dashboard_outbox_send_success, Toast.LENGTH_SHORT).show()
-            finish()
-        } else {
-            Toast.makeText(this, R.string.dashboard_outbox_send_failed, Toast.LENGTH_SHORT).show()
-        }
-    }
 
     private fun showRevMismatchDialog(entry: DashboardSurveyOutboxStore.OutboxEntry) {
         androidx.appcompat.app.AlertDialog.Builder(this)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
@@ -35,6 +35,7 @@ import org.ole.planet.myplanet.lite.BaseActivity
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
+import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
 import org.ole.planet.myplanet.lite.util.NetworkUtils
 
@@ -291,16 +292,16 @@ class DashboardOutboxDetailActivity : BaseActivity() {
             )
 
             when (result) {
-                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.FAILED_OFFLINE -> {
+                SubmissionResult.FAILED_OFFLINE -> {
                     Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_offline_cannot_send, Toast.LENGTH_SHORT).show()
                 }
-                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.FAILED_REVISION_CHECK -> {
+                SubmissionResult.FAILED_REVISION_CHECK -> {
                     Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_unable_to_verify_rev, Toast.LENGTH_SHORT).show()
                 }
-                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.REVISION_MISMATCH -> {
+                SubmissionResult.REVISION_MISMATCH -> {
                     showRevMismatchDialog(entry)
                 }
-                org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository.SubmissionResult.SUBMITTED_ONLINE -> {
+                SubmissionResult.SUBMITTED_ONLINE -> {
                     Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_send_success, Toast.LENGTH_SHORT).show()
                     finish()
                 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveySubmissionsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveySubmissionsRepository.kt
@@ -170,6 +170,54 @@ class DashboardSurveySubmissionsRepository(
         }
     }
 
+    suspend fun fetchSurveyRevision(
+        baseUrl: String,
+        surveyId: String,
+        teamId: String?,
+        sessionCookie: String?,
+        credentials: StoredCredentials?,
+    ): String? {
+        return withContext(dispatcher) {
+            runCatching {
+                val normalizedBase = baseUrl.trim().trimEnd('/')
+                if (normalizedBase.isEmpty()) {
+                    return@runCatching null
+                }
+
+                val selector = org.json.JSONObject().apply {
+                    put("_id", surveyId)
+                    put("type", "surveys")
+                    teamId?.takeIf { it.isNotBlank() }?.let { put("teamId", it) }
+                }
+                val payload = org.json.JSONObject().apply {
+                    put("selector", selector)
+                    put("limit", 1)
+                    put("fields", org.json.JSONArray().apply { put("_rev") })
+                }.toString()
+
+                val endpoint = "$normalizedBase/db/exams/_find"
+                val requestBuilder = Request.Builder()
+                    .url(endpoint)
+                    .post(payload.toRequestBody(JSON_MEDIA_TYPE))
+
+                if (!sessionCookie.isNullOrBlank()) {
+                    requestBuilder.addHeader("Cookie", sessionCookie)
+                } else if (credentials != null) {
+                    requestBuilder.addHeader("Authorization", Credentials.basic(credentials.username, credentials.password))
+                }
+
+                client.newCall(requestBuilder.build()).execute().use { response ->
+                    if (!response.isSuccessful) return@runCatching null
+                    val body = response.body.string()
+                    if (body.isBlank()) return@runCatching null
+                    val docs = org.json.JSONObject(body).optJSONArray("docs")
+                    val first = docs?.optJSONObject(0)
+                    first?.optString("_rev")?.takeIf { it.isNotBlank() }
+                }
+            }.getOrNull()
+        }
+    }
+
     @JsonClass(generateAdapter = true)
     data class SurveySubmission(
         @param:Json(name = "_id") val id: String? = null,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
@@ -103,7 +103,7 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
         teamName: String?,
         allowQueueing: Boolean
     ): SubmissionResult {
-        val isOnline = isDeviceOnline()
+        val isOnline = NetworkUtils.isDeviceOnline(context)
         if (!isOnline) {
             if (!allowQueueing) return SubmissionResult.FAILED_OFFLINE
             val saved = saveSubmission(submission, surveyId, surveyName, teamId, teamName)
@@ -126,12 +126,16 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
         sessionCookie: String?,
         entry: OutboxEntry
     ): SubmissionResult {
-        if (!isDeviceOnline()) {
+        if (!NetworkUtils.isDeviceOnline(context)) {
             return SubmissionResult.FAILED_OFFLINE
+        }
+        val surveyId = entry.submission.parent.id
+        if (surveyId.isNullOrBlank()) {
+            return SubmissionResult.FAILED_REVISION_CHECK
         }
         val serverRev = submissionsRepo.fetchSurveyRevision(
             baseUrl = base,
-            surveyId = entry.submission.parent.id ?: "",
+            surveyId = surveyId,
             teamId = entry.teamId,
             sessionCookie = sessionCookie,
             credentials = credentials
@@ -151,12 +155,7 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
         return SubmissionResult.FAILED
     }
 
-    private fun isDeviceOnline(): Boolean {
-        val manager = context.getSystemService(ConnectivityManager::class.java) ?: return false
-        val network = manager.activeNetwork ?: return false
-        val capabilities = manager.getNetworkCapabilities(network) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-    }
+
 
     override fun close() {
         // Managed by singletons

--- a/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
@@ -82,6 +82,75 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
         }
     }
 
+
+    enum class SubmissionResult {
+        SUBMITTED_ONLINE,
+        QUEUED_OFFLINE,
+        FAILED_OFFLINE,
+        FAILED_REVISION_CHECK,
+        REVISION_MISMATCH,
+        FAILED
+    }
+
+    suspend fun submitOrQueue(
+        base: String,
+        credentials: org.ole.planet.myplanet.lite.profile.StoredCredentials?,
+        sessionCookie: String?,
+        submission: SurveySubmission,
+        surveyId: String?,
+        surveyName: String?,
+        teamId: String?,
+        teamName: String?,
+        allowQueueing: Boolean
+    ): SubmissionResult {
+        val isOnline = isDeviceOnline()
+        if (!isOnline) {
+            if (!allowQueueing) return SubmissionResult.FAILED_OFFLINE
+            val saved = saveSubmission(submission, surveyId, surveyName, teamId, teamName)
+            return if (saved) SubmissionResult.QUEUED_OFFLINE else SubmissionResult.FAILED
+        }
+
+        val result = submissionsRepo.submitSurvey(base, credentials, sessionCookie, submission)
+        if (result.isSuccess) {
+            return SubmissionResult.SUBMITTED_ONLINE
+        }
+
+        if (!allowQueueing) return SubmissionResult.FAILED
+        val saved = saveSubmission(submission, surveyId, surveyName, teamId, teamName)
+        return if (saved) SubmissionResult.QUEUED_OFFLINE else SubmissionResult.FAILED
+    }
+
+    suspend fun resendOutboxEntry(
+        base: String,
+        credentials: org.ole.planet.myplanet.lite.profile.StoredCredentials?,
+        sessionCookie: String?,
+        entry: OutboxEntry
+    ): SubmissionResult {
+        if (!isDeviceOnline()) {
+            return SubmissionResult.FAILED_OFFLINE
+        }
+        val serverRev = submissionsRepo.fetchSurveyRevision(
+            baseUrl = base,
+            surveyId = entry.submission.parent.id ?: "",
+            teamId = entry.teamId,
+            sessionCookie = sessionCookie,
+            credentials = credentials
+        )
+        if (serverRev == null) {
+            return SubmissionResult.FAILED_REVISION_CHECK
+        }
+        val localRev = entry.submission.parent.rev
+        if (localRev != null && localRev != serverRev) {
+            return SubmissionResult.REVISION_MISMATCH
+        }
+        val result = submissionsRepo.submitSurvey(base, credentials, sessionCookie, entry.submission)
+        if (result.isSuccess) {
+            deleteEntry(entry.id)
+            return SubmissionResult.SUBMITTED_ONLINE
+        }
+        return SubmissionResult.FAILED
+    }
+
     private fun isDeviceOnline(): Boolean {
         val manager = context.getSystemService(ConnectivityManager::class.java) ?: return false
         val network = manager.activeNetwork ?: return false

--- a/app/src/test/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepositoryTest.kt
@@ -73,6 +73,70 @@ class DashboardLocalSurveyRepositoryTest {
         totalMarks = 100
     )
 
+
+    @Test
+    fun `submitOrQueue offline queues when allowed`() = runTest {
+        val submission = createSubmission()
+        val result = repository.submitOrQueue(
+            base = "http://example.com",
+            credentials = null,
+            sessionCookie = null,
+            submission = submission,
+            surveyId = "survey123",
+            surveyName = "Test Survey",
+            teamId = "team1",
+            teamName = "Team A",
+            allowQueueing = true
+        )
+
+        assertEquals(DashboardLocalSurveyRepository.SubmissionResult.QUEUED_OFFLINE, result)
+        val pending = repository.getPendingForTeam("team1")
+        assertEquals(1, pending.size)
+    }
+
+    @Test
+    fun `submitOrQueue offline fails when queueing not allowed`() = runTest {
+        val submission = createSubmission()
+        val result = repository.submitOrQueue(
+            base = "http://example.com",
+            credentials = null,
+            sessionCookie = null,
+            submission = submission,
+            surveyId = "survey123",
+            surveyName = "Test Survey",
+            teamId = "team1",
+            teamName = "Team A",
+            allowQueueing = false
+        )
+
+        assertEquals(DashboardLocalSurveyRepository.SubmissionResult.FAILED_OFFLINE, result)
+        val pending = repository.getPendingForTeam("team1")
+        assertTrue(pending.isEmpty())
+    }
+
+    @Test
+    fun `resendOutboxEntry fails when offline`() = runTest {
+        val submission = createSubmission()
+        repository.saveSubmission(
+            submission = submission,
+            surveyId = "survey123",
+            surveyName = "Test Survey",
+            teamId = "team1",
+            teamName = "Team A"
+        )
+        val pending = repository.getPendingForTeam("team1")
+        val entry = pending[0]
+
+        val result = repository.resendOutboxEntry(
+            base = "http://example.com",
+            credentials = null,
+            sessionCookie = null,
+            entry = entry
+        )
+
+        assertEquals(DashboardLocalSurveyRepository.SubmissionResult.FAILED_OFFLINE, result)
+    }
+
     @Test
     fun `saveSurvey success saves document to offline store`() = runTest {
         val document = createSurveyDocument()


### PR DESCRIPTION
Collapse survey submit paths into `DashboardLocalSurveyRepository` by adding `submitOrQueue` and `resendOutboxEntry`. Move online/offline branching out of `SurveyWizardSubmissionExtensions` and `DashboardOutboxDetailActivity`. Keep the repository interface narrow by returning simple enum outcomes the UI can render directly.

---
*PR created automatically by Jules for task [7733024649301883604](https://jules.google.com/task/7733024649301883604) started by @dogi*