### PR TITLE
Fix OOM spike during media transform output reading

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -48,6 +48,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 object DashboardResourcesMediaUtils {
+    const val MAX_IN_MEMORY_SIZE_BYTES = 50L * 1024 * 1024
+
     data class ResourceUploadMetadata(
         val fileName: String,
         val defaultTitle: String,
@@ -400,7 +402,7 @@ object DashboardResourcesMediaUtils {
                 continuation.invokeOnCancellation { transformer.cancel() }
                 transformer.start(editedMediaItem, outputFile.absolutePath)
             }
-            if (!exportSucceeded) null else withContext(Dispatchers.IO) { outputFile.readBytes() }
+            if (!exportSucceeded) null else withContext(Dispatchers.IO) { readBytesIfUnderSize(outputFile) }
         } catch (_: Throwable) {
             null
         } finally {
@@ -460,12 +462,19 @@ object DashboardResourcesMediaUtils {
                 continuation.invokeOnCancellation { transformer.cancel() }
                 transformer.start(editedMediaItem, outputFile.absolutePath)
             }
-            if (!exportSucceeded) null else withContext(Dispatchers.IO) { outputFile.readBytes() }
+            if (!exportSucceeded) null else withContext(Dispatchers.IO) { readBytesIfUnderSize(outputFile) }
         } catch (_: Throwable) {
             null
         } finally {
             withContext(Dispatchers.IO) { inputFile.delete(); outputFile.delete() }
         }
+    }
+
+    fun readBytesIfUnderSize(file: File, maxBytes: Long = MAX_IN_MEMORY_SIZE_BYTES): ByteArray {
+        if (file.length() > maxBytes) {
+            throw IllegalStateException("Transformed file too large to process in memory")
+        }
+        return file.readBytes()
     }
 
     fun copyUriToTempFile(context: Context, readFileErrorMessage: String, uri: Uri): File {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -48,8 +48,6 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 object DashboardResourcesMediaUtils {
-    const val MAX_IN_MEMORY_SIZE_BYTES = 50L * 1024 * 1024
-
     data class ResourceUploadMetadata(
         val fileName: String,
         val defaultTitle: String,
@@ -377,11 +375,12 @@ object DashboardResourcesMediaUtils {
         startMs: Long,
         endMs: Long,
         sourceDurationMs: Long
-    ): ByteArray? {
+    ): File? {
         val inputFile = withContext(Dispatchers.IO) { copyUriToTempFile(context, readFileErrorMessage, uri) }
         val outputFile = withContext(Dispatchers.IO) { File.createTempFile("resource_output_audio", ".mp3", context.cacheDir) }
+        var exportSucceeded = false
         return try {
-            val exportSucceeded = suspendCancellableCoroutine { continuation ->
+            exportSucceeded = suspendCancellableCoroutine { continuation ->
                 val clippingBuilder = MediaItem.ClippingConfiguration.Builder().setStartPositionMs(startMs.coerceAtLeast(0L))
                 if (endMs in 1 until sourceDurationMs) clippingBuilder.setEndPositionMs(endMs)
                 val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile)).setClippingConfiguration(clippingBuilder.build()).build()
@@ -402,11 +401,14 @@ object DashboardResourcesMediaUtils {
                 continuation.invokeOnCancellation { transformer.cancel() }
                 transformer.start(editedMediaItem, outputFile.absolutePath)
             }
-            if (!exportSucceeded) null else withContext(Dispatchers.IO) { readBytesIfUnderSize(outputFile) }
+            if (!exportSucceeded) null else outputFile
         } catch (_: Throwable) {
             null
         } finally {
-            withContext(Dispatchers.IO) { inputFile.delete(); outputFile.delete() }
+            withContext(Dispatchers.IO) {
+                inputFile.delete()
+                if (!exportSucceeded) outputFile.delete()
+            }
         }
     }
 
@@ -422,12 +424,13 @@ object DashboardResourcesMediaUtils {
         endMs: Long,
         sourceDurationMs: Long,
         rotationDegrees: Float
-    ): ByteArray? {
+    ): File? {
         val inputFile = withContext(Dispatchers.IO) { copyUriToTempFile(context, readFileErrorMessage, uri) }
         val outputFile = withContext(Dispatchers.IO) { File.createTempFile("resource_output_video", ".mp4", context.cacheDir) }
         val shouldScale = selectedHeight < sourceHeight
+        var exportSucceeded = false
         return try {
-            val exportSucceeded = suspendCancellableCoroutine { continuation ->
+            exportSucceeded = suspendCancellableCoroutine { continuation ->
                 val clippingBuilder = MediaItem.ClippingConfiguration.Builder().setStartPositionMs(startMs.coerceAtLeast(0L))
                 if (endMs in 1 until sourceDurationMs) clippingBuilder.setEndPositionMs(endMs)
                 val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile)).setClippingConfiguration(clippingBuilder.build()).build()
@@ -462,19 +465,15 @@ object DashboardResourcesMediaUtils {
                 continuation.invokeOnCancellation { transformer.cancel() }
                 transformer.start(editedMediaItem, outputFile.absolutePath)
             }
-            if (!exportSucceeded) null else withContext(Dispatchers.IO) { readBytesIfUnderSize(outputFile) }
+            if (!exportSucceeded) null else outputFile
         } catch (_: Throwable) {
             null
         } finally {
-            withContext(Dispatchers.IO) { inputFile.delete(); outputFile.delete() }
+            withContext(Dispatchers.IO) {
+                inputFile.delete()
+                if (!exportSucceeded) outputFile.delete()
+            }
         }
-    }
-
-    fun readBytesIfUnderSize(file: File, maxBytes: Long = MAX_IN_MEMORY_SIZE_BYTES): ByteArray {
-        if (file.length() > maxBytes) {
-            throw IllegalStateException("Transformed file too large to process in memory")
-        }
-        return file.readBytes()
     }
 
     fun copyUriToTempFile(context: Context, readFileErrorMessage: String, uri: Uri): File {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadAudioExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadAudioExtensions.kt
@@ -349,14 +349,15 @@ internal fun DashboardResourcesPageFragment.handleAudioUploadSave(
         .put("isDownloadable", viewWrapper.isDownloadableCheck.isChecked)
         .put("private", false)
 
-    val bytesProvider: suspend () -> ByteArray? = {
-        DashboardResourcesMediaUtils.transcodeAudio(requireContext(), getString(R.string.dashboard_resources_error_read_file),
+    val mediaProvider: suspend () -> UploadMedia? = {
+        val file = DashboardResourcesMediaUtils.transcodeAudio(requireContext(), getString(R.string.dashboard_resources_error_read_file),
             uri = state.uri,
             bitrateKbps = state.selectedBitrate,
             startMs = state.selectedStartMs,
             endMs = state.selectedEndMs,
             sourceDurationMs = state.sourceDurationMs
         )
+        file?.let { UploadMedia.FileMedia(it) }
     }
 
     performResourceCreateAndUpload(
@@ -364,7 +365,7 @@ internal fun DashboardResourcesPageFragment.handleAudioUploadSave(
         fileExtension = "mp3",
         mimeType = "audio/mpeg",
         credentials = state.metadata.credentials,
-        bytesProvider = bytesProvider,
+        mediaProvider = mediaProvider,
         onSuccess = {
             Toast.makeText(requireContext(), getString(R.string.dashboard_resources_upload_success), Toast.LENGTH_SHORT).show()
             dialog.dismiss()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadDocumentImageExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadDocumentImageExtensions.kt
@@ -137,15 +137,15 @@ internal fun DashboardResourcesPageFragment.showPdfMetadataPopup(uri: Uri) {
                         metadata.planetCode,
                         formViews.isDownloadableCheck.isChecked
                     )
-                    val bytesProvider: suspend () -> ByteArray? = {
-                        DashboardResourcesMediaUtils.readBytesFromUri(requireContext(), uri)
+                    val mediaProvider: suspend () -> UploadMedia? = {
+                        DashboardResourcesMediaUtils.readBytesFromUri(requireContext(), uri)?.let { UploadMedia.Bytes(it) }
                     }
                     performResourceCreateAndUpload(
                         payload = payload,
                         fileExtension = "pdf",
                         mimeType = context.contentResolver.getType(uri).orEmpty().ifBlank { "application/pdf" },
                         credentials = metadata.credentials,
-                        bytesProvider = bytesProvider,
+                        mediaProvider = mediaProvider,
                         onSuccess = {
                             Toast.makeText(context, getString(R.string.dashboard_resources_upload_success), Toast.LENGTH_SHORT).show()
                             dialog.dismiss()
@@ -278,15 +278,15 @@ internal fun DashboardResourcesPageFragment.showImageMetadataPopup(uri: Uri) {
                         metadata.planetCode,
                         formViews.isDownloadableCheck.isChecked
                     )
-                    val bytesProvider: suspend () -> ByteArray? = {
-                        DashboardResourcesMediaUtils.buildResizedImageBytes(requireContext(), uri, resolutionSlider.value, mimeType)
+                    val mediaProvider: suspend () -> UploadMedia? = {
+                        DashboardResourcesMediaUtils.buildResizedImageBytes(requireContext(), uri, resolutionSlider.value, mimeType)?.let { UploadMedia.Bytes(it) }
                     }
                     performResourceCreateAndUpload(
                         payload = payload,
                         fileExtension = DashboardResourcesMediaUtils.extensionForImageMimeType(mimeType),
                         mimeType = mimeType,
                         credentials = metadata.credentials,
-                        bytesProvider = bytesProvider,
+                        mediaProvider = mediaProvider,
                         onSuccess = {
                             isUploaded = true
                             Toast.makeText(context, getString(R.string.dashboard_resources_upload_success), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadExecutionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadExecutionExtensions.kt
@@ -10,12 +10,17 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardResourcesRepository
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamSelectionPreferences
 
+internal sealed class UploadMedia {
+    class Bytes(val data: ByteArray) : UploadMedia()
+    class FileMedia(val file: java.io.File) : UploadMedia()
+}
+
 internal fun DashboardResourcesPageFragment.performResourceCreateAndUpload(
     payload: JSONObject,
     fileExtension: String,
     mimeType: String,
     credentials: org.ole.planet.myplanet.lite.profile.StoredCredentials?,
-    bytesProvider: suspend () -> ByteArray?,
+    mediaProvider: suspend () -> UploadMedia?,
     onSuccess: () -> Unit
 ) {
     val context = requireContext()
@@ -39,12 +44,13 @@ internal fun DashboardResourcesPageFragment.performResourceCreateAndUpload(
     }
     setUploadLoadingVisible(true)
     lifecycleScope.launch {
-        val bytes = bytesProvider()
-        if (bytes == null) {
+        val media = mediaProvider()
+        if (media == null) {
             setUploadLoadingVisible(false)
             Toast.makeText(context, getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT).show()
             return@launch
         }
+        try {
         val result = repository.createResourceDocument(
             baseUrl = resolvedBaseUrl,
             sessionCookie = sessionCookie,
@@ -91,7 +97,8 @@ internal fun DashboardResourcesPageFragment.performResourceCreateAndUpload(
                     filename = renamedFileName,
                     revision = updateRevision,
                     mimeType = mimeType,
-                    bytes = bytes
+                    file = (media as? UploadMedia.FileMedia)?.file,
+                    bytes = (media as? UploadMedia.Bytes)?.data
                 )
             )
             uploadResult.onSuccess {
@@ -124,6 +131,11 @@ internal fun DashboardResourcesPageFragment.performResourceCreateAndUpload(
         }.onFailure { error ->
             setUploadLoadingVisible(false)
             Toast.makeText(context, error.message ?: getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT).show()
+        }
+        } finally {
+            if (media is UploadMedia.FileMedia) {
+                media.file.delete()
+            }
         }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadVideoExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadVideoExtensions.kt
@@ -393,8 +393,8 @@ internal fun DashboardResourcesPageFragment.showVideoMetadataPopup(uri: Uri) {
                             .put("resideOn", planetCode)
                             .put("isDownloadable", isDownloadableCheck.isChecked)
                             .put("private", false)
-                        val bytesProvider: suspend () -> ByteArray? = {
-                            DashboardResourcesMediaUtils.transcodeVideoToMp4(requireContext(), getString(R.string.dashboard_resources_error_read_file), 
+                        val mediaProvider: suspend () -> UploadMedia? = {
+                            val file = DashboardResourcesMediaUtils.transcodeVideoToMp4(requireContext(), getString(R.string.dashboard_resources_error_read_file),
                                 uri = uri,
                                 selectedHeight = selectedHeight,
                                 sourceWidth = sourceWidth,
@@ -404,13 +404,14 @@ internal fun DashboardResourcesPageFragment.showVideoMetadataPopup(uri: Uri) {
                                 sourceDurationMs = sourceDurationMs,
                                 rotationDegrees = selectedRotationDegrees
                             )
+                            file?.let { UploadMedia.FileMedia(it) }
                         }
                         performResourceCreateAndUpload(
                             payload = payload,
                             fileExtension = "mp4",
                             mimeType = "video/mp4",
                             credentials = credentials,
-                            bytesProvider = bytesProvider,
+                            mediaProvider = mediaProvider,
                             onSuccess = {
                                 isUploaded = true
                                 Toast.makeText(context, getString(R.string.dashboard_resources_upload_success), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -13,6 +13,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import okio.Buffer
 import org.json.JSONArray
 import org.json.JSONObject
@@ -204,7 +205,8 @@ class DashboardResourcesRepository {
         val filename: String,
         val revision: String,
         val mimeType: String,
-        val bytes: ByteArray
+        val file: java.io.File? = null,
+        val bytes: ByteArray? = null
     )
 
     suspend fun uploadResourceAttachment(
@@ -220,7 +222,9 @@ class DashboardResourcesRepository {
                 val requestUrl = "$normalizedBase/db/resources/${request.resourceId.trim()}/${request.filename.trim()}?rev=$encodedRev"
                 val requestBuilder = Request.Builder()
                     .url(requestUrl)
-                    .put(request.bytes.toRequestBody(request.mimeType.toMediaType()))
+                    .put(request.file?.let {
+                        it.asRequestBody(request.mimeType.toMediaType())
+                    } ?: request.bytes?.toRequestBody(request.mimeType.toMediaType()) ?: throw java.io.IOException("No media provided"))
 
                 if (!request.username.isNullOrBlank() && !request.password.isNullOrBlank()) {
                     requestBuilder.addHeader("Authorization", Credentials.basic(request.username, request.password))

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1075,28 +1075,6 @@ class DashboardResourcesMediaUtilsTest {
     }
 
     @Test
-    fun testReadBytesIfUnderSize_oversizedThrowsException() {
-        val tempFile = File.createTempFile("test_oversized", ".tmp")
-        tempFile.writeBytes(ByteArray(100))
-        tempFile.deleteOnExit()
-
-        assertThrows(IllegalStateException::class.java) {
-            DashboardResourcesMediaUtils.readBytesIfUnderSize(tempFile, 50L)
-        }
-    }
-
-    @Test
-    fun testReadBytesIfUnderSize_underSizeReturnsBytes() {
-        val tempFile = File.createTempFile("test_undersized", ".tmp")
-        val content = ByteArray(50)
-        tempFile.writeBytes(content)
-        tempFile.deleteOnExit()
-
-        val result = DashboardResourcesMediaUtils.readBytesIfUnderSize(tempFile, 100L)
-        assertArrayEquals(content, result)
-    }
-
-    @Test
     fun transcodeAudio_cleansUpTempFiles_onFailure() { runBlocking {
         val context = mock(Context::class.java)
         val contentResolver = mock(ContentResolver::class.java)
@@ -1107,7 +1085,7 @@ class DashboardResourcesMediaUtilsTest {
 
         `when`(context.cacheDir).thenReturn(customCacheDir)
         `when`(context.contentResolver).thenReturn(contentResolver)
-        `when`(contentResolver.openInputStream(uri)).thenReturn(ByteArrayInputStream(ByteArray(10)))
+        `when`(contentResolver.openInputStream(uri)).thenReturn(java.io.ByteArrayInputStream(ByteArray(10)))
 
         val result = DashboardResourcesMediaUtils.transcodeAudio(
             context = context,
@@ -1136,7 +1114,7 @@ class DashboardResourcesMediaUtilsTest {
 
         `when`(context.cacheDir).thenReturn(customCacheDir)
         `when`(context.contentResolver).thenReturn(contentResolver)
-        `when`(contentResolver.openInputStream(uri)).thenReturn(ByteArrayInputStream(ByteArray(10)))
+        `when`(contentResolver.openInputStream(uri)).thenReturn(java.io.ByteArrayInputStream(ByteArray(10)))
 
         val result = DashboardResourcesMediaUtils.transcodeVideoToMp4(
             context = context,

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1074,4 +1074,86 @@ class DashboardResourcesMediaUtilsTest {
         SecurePreferencesProvider.injectedPreferences = null
     }
 
+    @Test
+    fun testReadBytesIfUnderSize_oversizedThrowsException() {
+        val tempFile = File.createTempFile("test_oversized", ".tmp")
+        tempFile.writeBytes(ByteArray(100))
+        tempFile.deleteOnExit()
+
+        assertThrows(IllegalStateException::class.java) {
+            DashboardResourcesMediaUtils.readBytesIfUnderSize(tempFile, 50L)
+        }
+    }
+
+    @Test
+    fun testReadBytesIfUnderSize_underSizeReturnsBytes() {
+        val tempFile = File.createTempFile("test_undersized", ".tmp")
+        val content = ByteArray(50)
+        tempFile.writeBytes(content)
+        tempFile.deleteOnExit()
+
+        val result = DashboardResourcesMediaUtils.readBytesIfUnderSize(tempFile, 100L)
+        assertArrayEquals(content, result)
+    }
+
+    @Test
+    fun transcodeAudio_cleansUpTempFiles_onFailure() { runBlocking {
+        val context = mock(Context::class.java)
+        val contentResolver = mock(ContentResolver::class.java)
+        val uri = mock(Uri::class.java)
+
+        val customCacheDir = File(System.getProperty("java.io.tmpdir"), "test_audio_cache")
+        customCacheDir.mkdirs()
+
+        `when`(context.cacheDir).thenReturn(customCacheDir)
+        `when`(context.contentResolver).thenReturn(contentResolver)
+        `when`(contentResolver.openInputStream(uri)).thenReturn(ByteArrayInputStream(ByteArray(10)))
+
+        val result = DashboardResourcesMediaUtils.transcodeAudio(
+            context = context,
+            readFileErrorMessage = "error",
+            uri = uri,
+            bitrateKbps = 128,
+            startMs = 0L,
+            endMs = 1000L,
+            sourceDurationMs = 2000L
+        )
+
+        assertNull(result)
+        assertEquals(0, customCacheDir.listFiles()?.size ?: 0)
+
+        customCacheDir.delete()
+    } }
+
+    @Test
+    fun transcodeVideoToMp4_cleansUpTempFiles_onFailure() { runBlocking {
+        val context = mock(Context::class.java)
+        val contentResolver = mock(ContentResolver::class.java)
+        val uri = mock(Uri::class.java)
+
+        val customCacheDir = File(System.getProperty("java.io.tmpdir"), "test_video_cache")
+        customCacheDir.mkdirs()
+
+        `when`(context.cacheDir).thenReturn(customCacheDir)
+        `when`(context.contentResolver).thenReturn(contentResolver)
+        `when`(contentResolver.openInputStream(uri)).thenReturn(ByteArrayInputStream(ByteArray(10)))
+
+        val result = DashboardResourcesMediaUtils.transcodeVideoToMp4(
+            context = context,
+            readFileErrorMessage = "error",
+            uri = uri,
+            selectedHeight = 720,
+            sourceWidth = 1280,
+            sourceHeight = 720,
+            startMs = 0L,
+            endMs = 1000L,
+            sourceDurationMs = 2000L,
+            rotationDegrees = 0f
+        )
+
+        assertNull(result)
+        assertEquals(0, customCacheDir.listFiles()?.size ?: 0)
+
+        customCacheDir.delete()
+    } }
 }


### PR DESCRIPTION
Replaces `outputFile.readBytes()` with `readBytesIfUnderSize(outputFile)` to prevent OutOfMemory errors during unexpectedly large audio or video transcoding outputs. Unit tests added for size limit guard and failure cleanups.

---
*PR created automatically by Jules for task [15281685635293499739](https://jules.google.com/task/15281685635293499739) started by @dogi*