### PR TITLE
Use commitAllowingStateLoss() in SurveyWizardActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardActivity.kt
@@ -54,7 +54,7 @@ class SurveyWizardActivity : AppCompatActivity() {
                         intent.getBooleanExtra(EXTRA_INCLUDE_USER_CONTEXT, true),
                     ),
                 )
-                .commit()
+                .commitAllowingStateLoss()
         }
     }
 


### PR DESCRIPTION
Replaced `commit()` with `commitAllowingStateLoss()` for the fragment transaction in `SurveyWizardActivity.kt` to prevent `IllegalStateException`s if the fragment is committed after the activity state has been saved.

---
*PR created automatically by Jules for task [16529222676855689691](https://jules.google.com/task/16529222676855689691) started by @dogi*