### PR TITLE
🧪 Refactor ProfileActivity birth date helpers to DateUtils

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivity.kt
@@ -12,6 +12,7 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import org.ole.planet.myplanet.lite.util.DateUtils
 import android.util.Base64
 import android.view.View
 import android.widget.ArrayAdapter
@@ -385,8 +386,8 @@ class ProfileActivity : BaseActivity() {
             email = emailInput.text?.toString()?.trim().nullIfBlank(),
             phoneNumber = phoneInput.text?.toString()?.trim().nullIfBlank(),
             birthDateIso = birthDateIso,
-            birthYear = extractBirthYearFromIso(birthDateIso),
-            age = calculateAgeFromIso(birthDateIso),
+            birthYear = DateUtils.extractBirthYearFromIso(birthDateIso),
+            age = DateUtils.calculateAgeFromIso(birthDateIso),
             gender = genderValue,
             language = languageInput.text?.toString()?.trim().nullIfBlank(),
             level = LearningLevelTranslator
@@ -687,46 +688,11 @@ class ProfileActivity : BaseActivity() {
     }
 
     private fun formatBirthDate(raw: String?): String {
-        if (raw.isNullOrBlank()) {
-            return ""
-        }
-        val targetPattern = "MMM d, yyyy"
-
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val instant = runCatching { Instant.parse(raw) }.getOrNull()
-                ?: runCatching { LocalDate.parse(raw).atStartOfDay(ZoneOffset.UTC).toInstant() }.getOrNull()
-
-            if (instant != null) {
-                val zonedDate = instant.atZone(ZoneOffset.UTC).toLocalDate()
-                val formatter = DateTimeFormatter.ofPattern(targetPattern, Locale.getDefault())
-                zonedDate.format(formatter)
-            } else {
-                raw
-            }
-        } else {
-            val inputPatterns = listOf(
-                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                "yyyy-MM-dd'T'HH:mm:ss'Z'",
-                "yyyy-MM-dd"
-            )
-            val outputFormat = SimpleDateFormat(targetPattern, Locale.getDefault()).apply {
-                timeZone = TimeZone.getTimeZone("UTC")
-            }
-
-            inputPatterns.firstNotNullOfOrNull { pattern ->
-                runCatching {
-                    SimpleDateFormat(pattern, Locale.US).apply {
-                        timeZone = TimeZone.getTimeZone("UTC")
-                    }.parse(raw)
-                }.getOrNull()?.let { date ->
-                    outputFormat.format(date)
-                }
-            } ?: raw
-        }
+        return DateUtils.formatBirthDate(raw, raw ?: "", "MMM d, yyyy")
     }
 
     private fun showBirthDatePicker(targetView: TextInputEditText) {
-        val selection = BirthDateConstraints.coerceSelection(parseBirthDateToMillis(selectedBirthDateIso))
+        val selection = BirthDateConstraints.coerceSelection(DateUtils.parseBirthDateToMillis(selectedBirthDateIso))
         val picker = MaterialDatePicker.Builder.datePicker()
             .setTitleText(R.string.profile_birth_date_picker_title)
             .setSelection(selection)
@@ -753,81 +719,15 @@ class ProfileActivity : BaseActivity() {
     }
 
     private fun normalizeBirthDateIso(raw: String?): String? {
-        val millis = parseBirthDateToMillis(raw)
+        val millis = DateUtils.parseBirthDateToMillis(raw)
         return raw?.takeIf { millis != null && !BirthDateConstraints.isFuture(millis) }
     }
 
-    private fun parseBirthDateToMillis(raw: String?): Long? {
-        if (raw.isNullOrBlank()) {
-            return null
-        }
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            runCatching { Instant.parse(raw).toEpochMilli() }.getOrNull()
-                ?: runCatching { LocalDate.parse(raw).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() }
-                    .getOrNull()
-        } else {
-            val patterns = listOf(
-                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                "yyyy-MM-dd'T'HH:mm:ss'Z'",
-                "yyyy-MM-dd"
-            )
-            patterns.firstNotNullOfOrNull { pattern ->
-                runCatching {
-                    SimpleDateFormat(pattern, Locale.US).apply {
-                        timeZone = TimeZone.getTimeZone("UTC")
-                    }.parse(raw)?.time
-                }.getOrNull()
-            }
-        }
-    }
 
-    private fun extractBirthYearFromIso(iso: String?): String? {
-        if (iso.isNullOrBlank()) {
-            return null
-        }
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            runCatching {
-                Instant.parse(iso).atZone(ZoneOffset.UTC).year.toString()
-            }.getOrNull()
-        } else {
-            runCatching {
-                val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-                    timeZone = TimeZone.getTimeZone("UTC")
-                }
-                val date = format.parse(iso) ?: return@runCatching null
-                val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-                calendar.time = date
-                calendar.get(Calendar.YEAR).toString()
-            }.getOrNull()
-        }
-    }
 
-    private fun calculateAgeFromIso(iso: String?): String? {
-        if (iso.isNullOrBlank()) {
-            return null
-        }
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            runCatching {
-                val birthDate = Instant.parse(iso).atZone(ZoneOffset.UTC).toLocalDate()
-                val now = Instant.now().atZone(ZoneOffset.UTC).toLocalDate()
-                Period.between(birthDate, now).years.takeIf { it >= 0 }?.toString()
-            }.getOrNull()
-        } else {
-            runCatching {
-                val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-                    timeZone = TimeZone.getTimeZone("UTC")
-                }
-                val date = format.parse(iso) ?: return@runCatching null
-                val birthCalendar = Calendar.getInstance().apply { time = date }
-                val today = Calendar.getInstance()
-                var age = today.get(Calendar.YEAR) - birthCalendar.get(Calendar.YEAR)
-                if (today.get(Calendar.DAY_OF_YEAR) < birthCalendar.get(Calendar.DAY_OF_YEAR)) {
-                    age -= 1
-                }
-                age.takeIf { it >= 0 }?.toString()
-            }.getOrNull()
-        }
-    }
+
+
+
 
     private fun launchAvatarPicker() {
         selectAvatarLauncher.launch("image/*")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/DateUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/DateUtils.kt
@@ -6,6 +6,8 @@ import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.Period
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -68,12 +70,10 @@ object DateUtils {
     @VisibleForTesting
     var sdkInt: Int = Build.VERSION.SDK_INT
 
-    fun formatBirthDate(value: String?, fallback: String): String {
+    fun formatBirthDate(value: String?, fallback: String, targetPattern: String = "yyyy-MM-dd"): String {
         if (value.isNullOrBlank()) {
             return fallback
         }
-
-        val targetPattern = "yyyy-MM-dd"
 
         return if (sdkInt >= Build.VERSION_CODES.O) {
             val date = runCatching { Instant.parse(value).atZone(ZoneOffset.UTC).toLocalDate() }.getOrNull()
@@ -100,6 +100,79 @@ object DateUtils {
                     outputFormat.format(date)
                 }
             } ?: fallback
+        }
+    }
+
+
+    fun parseBirthDateToMillis(raw: String?): Long? {
+        if (raw.isNullOrBlank()) {
+            return null
+        }
+        return if (sdkInt >= Build.VERSION_CODES.O) {
+            runCatching { Instant.parse(raw).toEpochMilli() }.getOrNull()
+                ?: runCatching { LocalDate.parse(raw).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() }
+                    .getOrNull()
+        } else {
+            val patterns = listOf(
+                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                "yyyy-MM-dd"
+            )
+            patterns.firstNotNullOfOrNull { pattern ->
+                runCatching {
+                    SimpleDateFormat(pattern, Locale.US).apply {
+                        timeZone = TimeZone.getTimeZone("UTC")
+                    }.parse(raw)?.time
+                }.getOrNull()
+            }
+        }
+    }
+
+    fun extractBirthYearFromIso(iso: String?): String? {
+        if (iso.isNullOrBlank()) {
+            return null
+        }
+        return if (sdkInt >= Build.VERSION_CODES.O) {
+            runCatching {
+                Instant.parse(iso).atZone(ZoneOffset.UTC).year.toString()
+            }.getOrNull()
+        } else {
+            runCatching {
+                val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+                    timeZone = TimeZone.getTimeZone("UTC")
+                }
+                val date = format.parse(iso) ?: return@runCatching null
+                val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+                calendar.time = date
+                calendar.get(Calendar.YEAR).toString()
+            }.getOrNull()
+        }
+    }
+
+    fun calculateAgeFromIso(iso: String?): String? {
+        if (iso.isNullOrBlank()) {
+            return null
+        }
+        return if (sdkInt >= Build.VERSION_CODES.O) {
+            runCatching {
+                val birthDate = Instant.parse(iso).atZone(ZoneOffset.UTC).toLocalDate()
+                val now = Instant.now().atZone(ZoneOffset.UTC).toLocalDate()
+                Period.between(birthDate, now).years.takeIf { it >= 0 }?.toString()
+            }.getOrNull()
+        } else {
+            runCatching {
+                val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+                    timeZone = TimeZone.getTimeZone("UTC")
+                }
+                val date = format.parse(iso) ?: return@runCatching null
+                val birthCalendar = Calendar.getInstance().apply { time = date }
+                val today = Calendar.getInstance()
+                var age = today.get(Calendar.YEAR) - birthCalendar.get(Calendar.YEAR)
+                if (today.get(Calendar.DAY_OF_YEAR) < birthCalendar.get(Calendar.DAY_OF_YEAR)) {
+                    age -= 1
+                }
+                age.takeIf { it >= 0 }?.toString()
+            }.getOrNull()
         }
     }
 

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DateUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DateUtilsTest.kt
@@ -92,4 +92,107 @@ class DateUtilsTest {
         assertEquals("-", DateUtils.toDisplayDate(0L))
         assertEquals("-", DateUtils.toDisplayDate(-1L))
     }
+
+    @Test
+    fun `parseBirthDateToMillis returns null for null or blank input`() {
+        assertEquals(null, DateUtils.parseBirthDateToMillis(null))
+        assertEquals(null, DateUtils.parseBirthDateToMillis(""))
+        assertEquals(null, DateUtils.parseBirthDateToMillis("   "))
+    }
+
+    @Test
+    fun `parseBirthDateToMillis parses valid ISO8601 with millis (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        val input = "1990-05-15T14:30:00.000Z"
+        val expected = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse(input)?.time
+        assertEquals(expected, DateUtils.parseBirthDateToMillis(input))
+    }
+
+    @Test
+    fun `parseBirthDateToMillis parses valid ISO8601 with millis (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "1990-05-15T14:30:00.000Z"
+        val expected = java.time.Instant.parse(input).toEpochMilli()
+        assertEquals(expected, DateUtils.parseBirthDateToMillis(input))
+    }
+
+    @Test
+    fun `parseBirthDateToMillis parses valid short date (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        val input = "2000-01-01"
+        val expected = SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.parse(input)?.time
+        assertEquals(expected, DateUtils.parseBirthDateToMillis(input))
+    }
+
+    @Test
+    fun `parseBirthDateToMillis parses valid short date (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "2000-01-01"
+        val expected = java.time.LocalDate.parse(input).atStartOfDay(java.time.ZoneOffset.UTC).toInstant().toEpochMilli()
+        assertEquals(expected, DateUtils.parseBirthDateToMillis(input))
+    }
+
+    @Test
+    fun `extractBirthYearFromIso returns null for null or blank input`() {
+        assertEquals(null, DateUtils.extractBirthYearFromIso(null))
+        assertEquals(null, DateUtils.extractBirthYearFromIso(""))
+        assertEquals(null, DateUtils.extractBirthYearFromIso("   "))
+    }
+
+    @Test
+    fun `extractBirthYearFromIso extracts year from valid ISO8601 (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        val input = "1990-05-15T14:30:00.000Z"
+        assertEquals("1990", DateUtils.extractBirthYearFromIso(input))
+    }
+
+    @Test
+    fun `extractBirthYearFromIso extracts year from valid ISO8601 (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "1990-05-15T14:30:00.000Z"
+        assertEquals("1990", DateUtils.extractBirthYearFromIso(input))
+    }
+
+    @Test
+    fun `calculateAgeFromIso returns null for null or blank input`() {
+        assertEquals(null, DateUtils.calculateAgeFromIso(null))
+        assertEquals(null, DateUtils.calculateAgeFromIso(""))
+        assertEquals(null, DateUtils.calculateAgeFromIso("   "))
+    }
+
+    @Test
+    fun `calculateAgeFromIso calculates correct age from valid ISO8601 (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        val input = "1990-05-15T14:30:00.000Z"
+
+        val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }
+        val date = format.parse(input)
+        val birthCalendar = java.util.Calendar.getInstance().apply { time = date }
+        val today = java.util.Calendar.getInstance()
+        var expectedAge = today.get(java.util.Calendar.YEAR) - birthCalendar.get(java.util.Calendar.YEAR)
+        if (today.get(java.util.Calendar.DAY_OF_YEAR) < birthCalendar.get(java.util.Calendar.DAY_OF_YEAR)) {
+            expectedAge -= 1
+        }
+
+        assertEquals(expectedAge.toString(), DateUtils.calculateAgeFromIso(input))
+    }
+
+    @Test
+    fun `calculateAgeFromIso calculates correct age from valid ISO8601 (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "1990-05-15T14:30:00.000Z"
+
+        val birthDate = java.time.Instant.parse(input).atZone(java.time.ZoneOffset.UTC).toLocalDate()
+        val now = java.time.Instant.now().atZone(java.time.ZoneOffset.UTC).toLocalDate()
+        val expectedAge = java.time.Period.between(birthDate, now).years
+
+        assertEquals(expectedAge.toString(), DateUtils.calculateAgeFromIso(input))
+    }
+
 }


### PR DESCRIPTION
This PR addresses an issue to consolidate date logic inside `DateUtils` rather than having duplicates floating in `ProfileActivity`.

🎯 **What:**
- Transferred `parseBirthDateToMillis`, `extractBirthYearFromIso`, and `calculateAgeFromIso` into `DateUtils`.
- Delegated `ProfileActivity.formatBirthDate` to `DateUtils.formatBirthDate`.
- Added missing tests for the newly added `DateUtils` functions.

📊 **Coverage:**
- `./gradlew testDebugUnitTest --tests "org.ole.planet.myplanet.lite.util.DateUtilsTest"` passed.

✨ **Result:**
- `ProfileActivity` is cleaner, and date manipulation functions are centralized and easily testable.

---
*PR created automatically by Jules for task [12767540828921808387](https://jules.google.com/task/12767540828921808387) started by @dogi*