### PR TITLE
feat: debounce invite member remote search by 300ms

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupport.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersSupport.kt
@@ -22,6 +22,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlin.math.abs
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import org.ole.planet.myplanet.lite.dashboard.DashboardAvatarLoader
 import org.ole.planet.myplanet.lite.dashboard.DashboardTeamsRepository
 import org.ole.planet.myplanet.lite.dashboard.AddTeamMemberRequest
@@ -234,6 +236,7 @@ internal class DashboardTeamMembersInviteDialogController(
     private var nextSkip = 0
     private var currentSearchTerm = ""
     private var pendingReset = false
+    private var searchJob: Job? = null
     private var pagingDialog: AlertDialog? = null
     private lateinit var inviteAdapter: InviteMembersAdapter
     private val currentCandidates = mutableListOf<InviteCandidate>()
@@ -259,7 +262,11 @@ internal class DashboardTeamMembersInviteDialogController(
             val newQuery = editable?.toString()?.trim().orEmpty()
             if (newQuery != currentSearchTerm) {
                 currentSearchTerm = newQuery
-                loadInvitePage(reset = true)
+                searchJob?.cancel()
+                searchJob = lifecycleScope.launch {
+                    delay(300)
+                    loadInvitePage(reset = true)
+                }
             }
         }
 


### PR DESCRIPTION
debounce invite member remote search by 300ms

Added a debounce to the search input in the invite members dialog.
This prevents fetching the page aggressively while the user is typing
and waiting 300ms before triggering the load, saving network bandwidth
and improving performance without changing paging behavior.

---
*PR created automatically by Jules for task [8661618514762178028](https://jules.google.com/task/8661618514762178028) started by @dogi*