### PR TITLE
Refactor resource create-upload flow into repository

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadExecutionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesUploadExecutionExtensions.kt
@@ -20,23 +20,14 @@ internal fun DashboardResourcesPageFragment.performResourceCreateAndUpload(
 ) {
     val context = requireContext()
     val planetCode = DashboardServerPreferences.getServerCode(context).orEmpty()
-    if (isTeamResourcesTab) {
-        val teamId = DashboardTeamSelectionPreferences.getSelectedTeamId(context)
-        if (!teamId.isNullOrBlank()) {
-            payload.put("private", true)
-            payload.put("privateFor", JSONObject().put("teams", teamId))
-        }
-    }
-    DashboardResourcesMediaUtils.applyWebCompatibleResourceDefaults(payload)
-    payload.put("mediaType", DashboardResourcesMediaUtils.normalizeResourceMediaType(mimeType))
-    val now = System.currentTimeMillis()
-    payload.put("createdDate", now)
-    payload.put("updatedDate", now)
+    val teamId = if (isTeamResourcesTab) DashboardTeamSelectionPreferences.getSelectedTeamId(context) else null
     val resolvedBaseUrl = DashboardServerPreferences.getServerBaseUrl(context)
+
     if (resolvedBaseUrl.isNullOrBlank()) {
         Toast.makeText(context, getString(R.string.dashboard_voices_no_server), Toast.LENGTH_SHORT).show()
         return
     }
+
     setUploadLoadingVisible(true)
     lifecycleScope.launch {
         val bytes = bytesProvider()
@@ -45,84 +36,26 @@ internal fun DashboardResourcesPageFragment.performResourceCreateAndUpload(
             Toast.makeText(context, getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT).show()
             return@launch
         }
-        val result = repository.createResourceDocument(
+
+        val request = DashboardResourcesRepository.UploadResourceRequest(
             baseUrl = resolvedBaseUrl,
             sessionCookie = sessionCookie,
             username = credentials?.username,
             password = credentials?.password,
-            payload = payload
+            payload = payload,
+            fileExtension = fileExtension,
+            mimeType = mimeType,
+            bytes = bytes,
+            teamId = teamId,
+            planetCode = planetCode
         )
-        result.onSuccess { creationResponse ->
-            val resourceId = creationResponse.optString("id").orEmpty()
-            val creationRevision = creationResponse.optString("rev").orEmpty()
-            if (resourceId.isBlank() || creationRevision.isBlank()) {
-                setUploadLoadingVisible(false)
-                Toast.makeText(context, getString(R.string.dashboard_resources_error_invalid_server_response), Toast.LENGTH_SHORT).show()
-                return@onSuccess
-            }
-            val renamedFileName = "${resourceId}.${fileExtension.lowercase(Locale.ROOT)}"
-            val normalizedMediaType = DashboardResourcesMediaUtils.normalizeResourceMediaType(mimeType)
-            val updatePayload = JSONObject(payload.toString())
-                .put("_id", resourceId)
-                .put("_rev", creationRevision)
-                .put("filename", renamedFileName)
-                .put("mediaType", normalizedMediaType)
-            val updateResult = repository.updateResourceDocument(
-                baseUrl = resolvedBaseUrl,
-                sessionCookie = sessionCookie,
-                username = credentials?.username,
-                password = credentials?.password,
-                resourceId = resourceId,
-                payload = updatePayload
-            )
-            val updateResponse = updateResult.getOrElse { error ->
-                setUploadLoadingVisible(false)
-                Toast.makeText(context, error.message ?: getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT).show()
-                return@onSuccess
-            }
-            val updateRevision = updateResponse.optString("rev").orEmpty().ifBlank { creationRevision }
-            val uploadResult = repository.uploadResourceAttachment(
-                DashboardResourcesRepository.UploadAttachmentRequest(
-                    baseUrl = resolvedBaseUrl,
-                    sessionCookie = sessionCookie,
-                    username = credentials?.username,
-                    password = credentials?.password,
-                    resourceId = resourceId,
-                    filename = renamedFileName,
-                    revision = updateRevision,
-                    mimeType = mimeType,
-                    bytes = bytes
-                )
-            )
-            uploadResult.onSuccess {
-                if (isTeamResourcesTab) {
-                    val teamId = DashboardTeamSelectionPreferences.getSelectedTeamId(context)
-                    if (!teamId.isNullOrBlank()) {
-                        val linkPayload = JSONObject()
-                        linkPayload.put("resourceId", resourceId)
-                        linkPayload.put("sourcePlanet", planetCode)
-                        linkPayload.put("title", payload.optString("title"))
-                        linkPayload.put("teamId", teamId)
-                        linkPayload.put("teamPlanetCode", planetCode)
-                        linkPayload.put("teamType", "local")
-                        linkPayload.put("docType", "resourceLink")
-                        repository.createTeamDocument(
-                            baseUrl = resolvedBaseUrl,
-                            sessionCookie = sessionCookie,
-                            username = credentials?.username,
-                            password = credentials?.password,
-                            payload = linkPayload
-                        )
-                    }
-                }
-                setUploadLoadingVisible(false)
-                onSuccess()
-            }.onFailure { error ->
-                setUploadLoadingVisible(false)
-                Toast.makeText(context, error.message ?: getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT).show()
-            }
+
+        val result = repository.uploadNewResource(request)
+
+        setUploadLoadingVisible(false)
+        result.onSuccess {
+            onSuccess()
         }.onFailure { error ->
-            setUploadLoadingVisible(false)
             Toast.makeText(context, error.message ?: getString(R.string.course_wizard_play_error), Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -195,6 +195,104 @@ class DashboardResourcesRepository {
     }
 
 
+
+    data class UploadResourceRequest(
+        val baseUrl: String,
+        val sessionCookie: String?,
+        val username: String?,
+        val password: String?,
+        val payload: JSONObject,
+        val fileExtension: String,
+        val mimeType: String,
+        val bytes: ByteArray,
+        val teamId: String?,
+        val planetCode: String?
+    )
+
+    suspend fun uploadNewResource(request: UploadResourceRequest): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                if (request.teamId != null && request.teamId.isNotBlank()) {
+                    request.payload.put("private", true)
+                    request.payload.put("privateFor", JSONObject().put("teams", request.teamId))
+                }
+
+                org.ole.planet.myplanet.lite.DashboardResourcesMediaUtils.applyWebCompatibleResourceDefaults(request.payload)
+                val normalizedMediaType = org.ole.planet.myplanet.lite.DashboardResourcesMediaUtils.normalizeResourceMediaType(request.mimeType)
+                request.payload.put("mediaType", normalizedMediaType)
+                val now = System.currentTimeMillis()
+                request.payload.put("createdDate", now)
+                request.payload.put("updatedDate", now)
+
+                val creationResult = createResourceDocument(
+                    baseUrl = request.baseUrl,
+                    sessionCookie = request.sessionCookie,
+                    username = request.username,
+                    password = request.password,
+                    payload = request.payload
+                ).getOrThrow()
+
+                val resourceId = creationResult.optString("id").orEmpty()
+                val creationRevision = creationResult.optString("rev").orEmpty()
+
+                if (resourceId.isBlank() || creationRevision.isBlank()) {
+                    throw IOException("Invalid server response: missing id or rev")
+                }
+
+                val renamedFileName = "${resourceId}.${request.fileExtension.lowercase(java.util.Locale.ROOT)}"
+
+                val updatePayload = JSONObject(request.payload.toString())
+                    .put("_id", resourceId)
+                    .put("_rev", creationRevision)
+                    .put("filename", renamedFileName)
+                    .put("mediaType", normalizedMediaType)
+
+                val updateResult = updateResourceDocument(
+                    baseUrl = request.baseUrl,
+                    sessionCookie = request.sessionCookie,
+                    username = request.username,
+                    password = request.password,
+                    resourceId = resourceId,
+                    payload = updatePayload
+                ).getOrThrow()
+
+                val updateRevision = updateResult.optString("rev").orEmpty().ifBlank { creationRevision }
+
+                uploadResourceAttachment(
+                    UploadAttachmentRequest(
+                        baseUrl = request.baseUrl,
+                        sessionCookie = request.sessionCookie,
+                        username = request.username,
+                        password = request.password,
+                        resourceId = resourceId,
+                        filename = renamedFileName,
+                        revision = updateRevision,
+                        mimeType = request.mimeType,
+                        bytes = request.bytes
+                    )
+                ).getOrThrow()
+
+                if (!request.teamId.isNullOrBlank() && !request.planetCode.isNullOrBlank()) {
+                    val linkPayload = JSONObject()
+                    linkPayload.put("resourceId", resourceId)
+                    linkPayload.put("sourcePlanet", request.planetCode)
+                    linkPayload.put("title", request.payload.optString("title"))
+                    linkPayload.put("teamId", request.teamId)
+                    linkPayload.put("teamPlanetCode", request.planetCode)
+                    linkPayload.put("teamType", "local")
+                    linkPayload.put("docType", "resourceLink")
+                    createTeamDocument(
+                        baseUrl = request.baseUrl,
+                        sessionCookie = request.sessionCookie,
+                        username = request.username,
+                        password = request.password,
+                        payload = linkPayload
+                    ).getOrThrow()
+                }
+            }
+        }
+    }
+
     data class UploadAttachmentRequest(
         val baseUrl: String,
         val sessionCookie: String?,


### PR DESCRIPTION
- Adds `UploadResourceRequest` data class in `DashboardResourcesRepository`.
- Adds `uploadNewResource` method in `DashboardResourcesRepository` to encapsulate the sequential HTTP operations.
- Refactors `performResourceCreateAndUpload` in `DashboardResourcesUploadExecutionExtensions` to delegate to the new repository method.

---
*PR created automatically by Jules for task [993949778237521957](https://jules.google.com/task/993949778237521957) started by @dogi*