### PR TITLE
feat: Constrain shared image loader coroutine scopes with cleanup APIs

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -256,7 +256,10 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
         fetchJob = null
         recyclerView.adapter = null
         avatarLoader?.destroy()
+        DashboardAvatarLoader.clearInFlightRequests()
         avatarLoader = null
+        postImageLoader?.destroy()
+        DashboardPostImageLoader.clearInFlightRequests()
         postImageLoader = null
         postShareHelper = null
         AvatarUpdateNotifier.unregister(avatarUpdateListener)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoader.kt
@@ -139,6 +139,13 @@ class DashboardAvatarLoader(
             }
         }
 
+        fun clearInFlightRequests() {
+            synchronized(inFlightRequests) {
+                inFlightScope.coroutineContext[Job]?.cancelChildren()
+                inFlightRequests.clear()
+            }
+        }
+
         @androidx.annotation.VisibleForTesting
         fun resetForTesting() {
             synchronized(missingAvatars) { missingAvatars.clear() }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -1301,7 +1301,10 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
         super.onDestroy()
         recyclerView.adapter = null
         avatarLoader?.destroy()
+        DashboardAvatarLoader.clearInFlightRequests()
         avatarLoader = null
+        imageLoader?.destroy()
+        DashboardPostImageLoader.clearInFlightRequests()
         imageLoader = null
         shareHelper = null
         AvatarUpdateNotifier.unregister(avatarUpdateListener)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -75,6 +77,9 @@ class DashboardPostImageLoader(
         }
     }
 
+    fun destroy() {
+    }
+
     private fun fetchImageBitmap(imagePath: String): Bitmap? {
         val requestUrl = resolveUrl(imagePath) ?: return null
         if (Uri.parse(requestUrl).scheme.equals("file", ignoreCase = true)) {
@@ -123,13 +128,20 @@ class DashboardPostImageLoader(
         return "$normalizedBase/$finalPath"
     }
 
-    private companion object {
+    companion object {
         private const val CACHE_SIZE_BYTES = 6 * 1024 * 1024 // 6MB cache for post images
         private val inFlightScope = CoroutineScope(Dispatchers.IO + kotlinx.coroutines.SupervisorJob())
         private val inFlightRequests = mutableMapOf<String, Deferred<Bitmap?>>()
         private val sharedCache = object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
             override fun sizeOf(key: String, value: Bitmap): Int {
                 return value.byteCount
+            }
+        }
+
+        fun clearInFlightRequests() {
+            synchronized(inFlightRequests) {
+                inFlightScope.coroutineContext[Job]?.cancelChildren()
+                inFlightRequests.clear()
             }
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMemberProfileActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamMemberProfileActivity.kt
@@ -111,6 +111,7 @@ class DashboardTeamMemberProfileActivity : BaseActivity() {
     override fun onDestroy() {
         super.onDestroy()
         avatarLoader?.destroy()
+        DashboardAvatarLoader.clearInFlightRequests()
         avatarLoader = null
     }
 


### PR DESCRIPTION
Constrain shared image loader coroutine scopes. Added explicit production-safe clear/cancel APIs to `DashboardAvatarLoader` and `DashboardPostImageLoader` for in-flight image requests. Ensured that owners call these cleanups during teardown, maintaining symmetry between both loaders to avoid conflicts. Made companion objects public to allow correct API usage.

---
*PR created automatically by Jules for task [7466467186413102095](https://jules.google.com/task/7466467186413102095) started by @dogi*