### PR TITLE
Refactor to reuse shared dependencies in dashboard components

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 520
+        versionName = "0.5.20"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardVoicesFragment.kt
@@ -40,6 +40,7 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardAvatarLoader
 import org.ole.planet.myplanet.lite.dashboard.DashboardImagePreviewActivity
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsActionsRepository
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository
+import org.ole.planet.myplanet.lite.dashboard.SharedBitmapDependencies
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository.NewsDocument
 import org.ole.planet.myplanet.lite.dashboard.DashboardNewsRepository.NewsPage
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity
@@ -93,8 +94,8 @@ class DashboardVoicesFragment : Fragment(R.layout.fragment_dashboard_voices) {
 
     private val repository =
         DashboardNewsRepository(
-            client = OkHttpClient.Builder().build(),
-            moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
+            client = SharedBitmapDependencies.client,
+            moshi = AuthDependencies.moshi,
         )
     private val actionsRepository = DashboardNewsActionsRepository(AuthDependencies.client, AuthDependencies.moshi, Dispatchers.IO)
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
@@ -164,12 +164,12 @@ class PostShareHelper(
         }
 
     companion object {
-        private val client: OkHttpClient
-            get() = SharedBitmapDependencies.client.newBuilder()
+        private val client: OkHttpClient by lazy {
+            SharedBitmapDependencies.client.newBuilder()
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .build()
-
+        }
         private val IMAGE_MARKDOWN_REGEX = Regex("!?\\[[^\\]]*\\]\\([^)]*\\.(?:jpe?g|png)\\)", RegexOption.IGNORE_CASE)
         private val IMAGE_URL_REGEX = Regex("\\b\\S+\\.(?:jpe?g|png)(?:\\?\\S*)?(?=\\s|$)", RegexOption.IGNORE_CASE)
         private val LINK_MARKDOWN_REGEX = Regex("\\[([^\\]]+)\\]\\(([^\\s)]+)\\)")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/PostShareHelper.kt
@@ -164,13 +164,12 @@ class PostShareHelper(
         }
 
     companion object {
-        private val client by lazy {
-            OkHttpClient
-                .Builder()
+        private val client: OkHttpClient
+            get() = SharedBitmapDependencies.client.newBuilder()
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .build()
-        }
+
         private val IMAGE_MARKDOWN_REGEX = Regex("!?\\[[^\\]]*\\]\\([^)]*\\.(?:jpe?g|png)\\)", RegexOption.IGNORE_CASE)
         private val IMAGE_URL_REGEX = Regex("\\b\\S+\\.(?:jpe?g|png)(?:\\?\\S*)?(?=\\s|$)", RegexOption.IGNORE_CASE)
         private val LINK_MARKDOWN_REGEX = Regex("\\[([^\\]]+)\\]\\(([^\\s)]+)\\)")


### PR DESCRIPTION
- Reuse `SharedBitmapDependencies.client` and `AuthDependencies.moshi` in `DashboardVoicesFragment`.
- Delegate `PostShareHelper.client` to `SharedBitmapDependencies.client.newBuilder()` to maintain custom timeouts while reusing the connection pool.

---
*PR created automatically by Jules for task [9652291903386665528](https://jules.google.com/task/9652291903386665528) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading dashboard voices/news content and downloading shared images.
  * Standardized the shared networking and JSON handling used for these flows, while keeping existing connection/read timeout behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->