### PR TITLE
Limit concurrency for comment image fetches in DashboardPostDetailActivity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 488
+        versionName = "0.4.88"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyActionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyActionExtensions.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity.Companion.KEY_DEVICE_ANDROID_ID
@@ -272,12 +274,15 @@ internal suspend fun DashboardPostDetailActivity.loadExistingCommentImages(comme
     }
     val loaded =
         coroutineScope {
+            val semaphore = Semaphore(10)
             comment.imagePaths
                 .map { path ->
                     async(Dispatchers.IO) {
-                        VoiceImageFetcher.fetchExistingImage(httpClient, cacheDir, sessionCookie, base, path, {
-                            VoiceImageFactory.generateImageFileName()
-                        }, { generatePendingImageId(it) })
+                        semaphore.withPermit {
+                            VoiceImageFetcher.fetchExistingImage(httpClient, cacheDir, sessionCookie, base, path, {
+                                VoiceImageFactory.generateImageFileName()
+                            }, { generatePendingImageId(it) })
+                        }
                     }
                 }.awaitAll()
                 .filterNotNull()


### PR DESCRIPTION
This bounds the concurrent async fetches to match the pattern used in
CreateVoiceActivity, preventing potential OOM issues or thread pool
exhaustion while avoiding new global architectures.

---
*PR created automatically by Jules for task [13241983937574728541](https://jules.google.com/task/13241983937574728541) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading comment images by limiting how many image fetches run at the same time.
  * Reduces the risk of slowdowns and resource spikes during reply image loading.
* **Chores / Release**
  * Updated the app version (version code/name) for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->