### PR TITLE
Optimize CourseAdapter image loader invalidation

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
@@ -156,6 +156,14 @@ class CourseAdapter(
         applyFilter()
     }
 
+    fun notifyImageLoaderReady() {
+        currentList.forEachIndexed { index, item ->
+            if (item is CourseListItem.CourseItemWrapper && !item.course.coverPath.isNullOrBlank()) {
+                notifyItemChanged(index)
+            }
+        }
+    }
+
     fun isHeader(position: Int) = getItem(position) is CourseListItem.Header
 
     private fun updateSearchQuery(query: String) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -252,7 +252,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val sessionCookie = withContext(Dispatchers.IO) { authService.getStoredToken() }
             courseImageLoader = DashboardPostImageLoader(base, sessionCookie, viewLifecycleOwner.lifecycleScope)
             isCourseImageLoaderLoading = false
-            adapter.notifyDataSetChanged()
+            adapter.notifyImageLoaderReady()
         }
     }
 


### PR DESCRIPTION
Optimized the invalidation of the `CourseAdapter` when the image loader is ready. Instead of calling `notifyDataSetChanged()`, which refreshes the entire list, we now use a targeted helper function `notifyImageLoaderReady()` that only notifies items containing image URLs, preventing unnecessary rebinds of headers or text-only rows.

---
*PR created automatically by Jules for task [9625782590446745761](https://jules.google.com/task/9625782590446745761) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course image updates when the image loader becomes ready.
  * Course listings now refresh only the relevant items, helping images appear more reliably and reducing unnecessary UI refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->