### PR TITLE
Refactor: Remove redundant nested withContext(Dispatchers.IO) in DashboardCoursesRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 489
+        versionName = "0.4.89"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -406,18 +406,16 @@ class DashboardCoursesRepository(
                         .build()
 
                 val docs =
-                    withContext(Dispatchers.IO) {
-                        client.newCall(request).await().use { response ->
-                            if (!response.isSuccessful) {
-                                response.body.string()
-                                throw IOException("Unexpected response ${response.code}")
-                            }
-                            val parsed =
-                                coursesProgressResponseAdapter.fromJson(response.body.string())
-                                    ?: throw IOException("Invalid response body")
-                            parsed.docs
-                                .filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
+                    client.newCall(request).await().use { response ->
+                        if (!response.isSuccessful) {
+                            response.body.string()
+                            throw IOException("Unexpected response ${response.code}")
                         }
+                        val parsed =
+                            coursesProgressResponseAdapter.fromJson(response.body.string())
+                                ?: throw IOException("Invalid response body")
+                        parsed.docs
+                            .filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
                     }
 
                 docs.forEach { doc ->
@@ -471,17 +469,15 @@ class DashboardCoursesRepository(
                         .build()
 
                 val docs =
-                    withContext(Dispatchers.IO) {
-                        client.newCall(request).await().use { response ->
-                            if (!response.isSuccessful) {
-                                response.body.string()
-                                throw IOException("Unexpected response ${response.code}")
-                            }
-                            val parsed =
-                                coursesProgressResponseAdapter.fromJson(response.body.string())
-                                    ?: throw IOException("Invalid response body")
-                            parsed.docs.filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
+                    client.newCall(request).await().use { response ->
+                        if (!response.isSuccessful) {
+                            response.body.string()
+                            throw IOException("Unexpected response ${response.code}")
                         }
+                        val parsed =
+                            coursesProgressResponseAdapter.fromJson(response.body.string())
+                                ?: throw IOException("Invalid response body")
+                        parsed.docs.filter { !it.courseId.isNullOrBlank() && it.stepNum != null }
                     }
                 if (stepNum != null) {
                     docs.associateBy { it.courseId!! }


### PR DESCRIPTION
Removed hardcoded, nested `withContext(Dispatchers.IO)` blocks in the course progress fetch methods (`fetchCoursesProgress` and `fetchCoursesProgressDocuments`). The repository already utilizes its injected dispatcher from the outer scope, making the nested blocks redundant. This change cleans up the network calls and improves testability by inheriting the injected dispatcher correctly. Tests run successfully.

---
*PR created automatically by Jules for task [18082321330207512550](https://jules.google.com/task/18082321330207512550) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined background processing for course progress requests by removing an extra IO context wrapper while keeping the same request/response handling, error reporting, JSON parsing, and filtering behavior.
* **Chores**
  * Updated the app version to **0.4.89** (**versionCode 489**), reflecting this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->