### PR TITLE
Extract join request enrichment logic to repository layer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 524
+        versionName = "0.5.24"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamMembersFragment.kt
@@ -272,10 +272,10 @@ class DashboardTeamMembersFragment : Fragment() {
         val teamPlanetCodeForRequests = currentTeamPlanetCode ?: serverPlanetCode
         val joinRequests =
             if (teamPlanetCodeForRequests.isNullOrBlank()) {
-                emptyList<JoinRequestDocument>()
+                emptyList()
             } else {
                 repository
-                    .fetchTeamJoinRequests(
+                    .fetchTeamJoinRequestDetails(
                         baseUrl = base,
                         credentials = creds,
                         sessionCookie = sessionCookie,
@@ -287,7 +287,23 @@ class DashboardTeamMembersFragment : Fragment() {
                     }
             }
         if (joinRequests != null) {
-            loadJoinRequestsData(base, creds, joinRequests)
+            if (joinRequests.isEmpty()) {
+                currentJoinRequests = emptyList()
+                updateJoinRequestsAdapterList(emptyList())
+                showJoinRequestsEmptyState()
+            } else {
+                val requests = joinRequests.map { detail ->
+                    TeamJoinRequestUiModel(
+                        id = detail.request.id ?: detail.request.userId.orEmpty(),
+                        username = detail.username,
+                        fullName = detail.fullName,
+                        hasAvatar = detail.hasAvatar,
+                        request = detail.request,
+                    )
+                }
+                currentJoinRequests = requests
+                updateJoinRequestsAdapterList(requests)
+            }
         } else {
             hideJoinRequestsSection()
         }
@@ -334,49 +350,6 @@ class DashboardTeamMembersFragment : Fragment() {
                 binding.dashboardTeamMembersSwipeRefresh.isRefreshing = false
                 showLoading(false)
             }
-    }
-
-    private suspend fun loadJoinRequestsData(
-        base: String,
-        creds: StoredCredentials,
-        joinRequests: List<JoinRequestDocument>,
-    ) {
-        if (joinRequests.isEmpty()) {
-            currentJoinRequests = emptyList()
-            updateJoinRequestsAdapterList(emptyList())
-            showJoinRequestsEmptyState()
-            return
-        }
-
-        val userIds = joinRequests.mapNotNull { it.userId?.takeIf(String::isNotBlank) }.distinct()
-        val profilesById =
-            repository
-                .fetchUserProfiles(base, creds, sessionCookie, userIds)
-                .getOrDefault(emptyList())
-                .associateBy { it._id }
-        val requests =
-            joinRequests
-                .map { request ->
-                    val userId = request.userId.orEmpty()
-                    val profile = profilesById[userId]
-                    val username = userId.substringAfter("org.couchdb.user:", userId)
-                    val fullName =
-                        listOfNotNull(
-                            profile?.firstName,
-                            profile?.middleName,
-                            profile?.lastName,
-                        ).filter { it.isNotBlank() }.joinToString(" ").ifBlank { username }
-                    TeamJoinRequestUiModel(
-                        id = request.id ?: userId,
-                        username = username,
-                        fullName = fullName,
-                        hasAvatar = profile?.attachments?.image != null,
-                        request = request,
-                    )
-                }.sortedBy { it.fullName.lowercase() }
-
-        currentJoinRequests = requests
-        updateJoinRequestsAdapterList(requests)
     }
 
     private fun showLoading(loading: Boolean) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsModels.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsModels.kt
@@ -194,6 +194,13 @@ data class JoinRequestSelector(
 @JsonClass(generateAdapter = true)
 data class TeamJoinRequestFindRequest(val selector: TeamJoinRequestSelector)
 
+data class TeamJoinRequestDetails(
+    val username: String,
+    val fullName: String,
+    val hasAvatar: Boolean,
+    val request: JoinRequestDocument,
+)
+
 @JsonClass(generateAdapter = true)
 data class TeamJoinRequestSelector(
     val teamId: String,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperations.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperations.kt
@@ -280,6 +280,41 @@ internal class DashboardTeamsOperations(
         }
     }
 
+    fun fetchTeamJoinRequestDetails(
+        baseUrl: String,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        teamId: String,
+        teamPlanetCode: String,
+    ): List<TeamJoinRequestDetails> {
+        val requests = fetchTeamJoinRequests(baseUrl, credentials, sessionCookie, teamId, teamPlanetCode)
+        if (requests.isEmpty()) return emptyList()
+
+        val normalizedBase = baseUrl.trim().trimEnd('/')
+        val userIds = requests.mapNotNull { it.userId?.takeIf(String::isNotBlank) }.distinct()
+        val profilesById = runCatching {
+            fetchUserProfiles(normalizedBase, credentials, sessionCookie, userIds)
+        }.getOrDefault(emptyList()).associateBy { it._id }
+
+        return requests.map { request ->
+            val userId = request.userId.orEmpty()
+            val profile = profilesById[userId]
+            val username = userId.substringAfter("org.couchdb.user:", userId)
+            val fullName = listOfNotNull(
+                profile?.firstName,
+                profile?.middleName,
+                profile?.lastName,
+            ).filter { it.isNotBlank() }.joinToString(" ").ifBlank { username }
+
+            TeamJoinRequestDetails(
+                username = username,
+                fullName = fullName,
+                hasAvatar = profile?.attachments?.image != null,
+                request = request,
+            )
+        }.sortedBy { it.fullName.lowercase() }
+    }
+
     fun fetchTeamJoinRequests(
         baseUrl: String,
         credentials: StoredCredentials?,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepository.kt
@@ -119,6 +119,17 @@ class DashboardTeamsRepository(
             operations.fetchTeamJoinRequests(baseUrl, credentials, sessionCookie, teamId, teamPlanetCode)
         }
 
+    suspend fun fetchTeamJoinRequestDetails(
+        baseUrl: String,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        teamId: String,
+        teamPlanetCode: String,
+    ): Result<List<TeamJoinRequestDetails>> =
+        runInDispatcher {
+            operations.fetchTeamJoinRequestDetails(baseUrl, credentials, sessionCookie, teamId, teamPlanetCode)
+        }
+
     suspend fun hasExistingJoinRequest(
         baseUrl: String,
         credentials: StoredCredentials?,

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperationsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperationsTest.kt
@@ -41,6 +41,91 @@ class DashboardTeamsOperationsTest {
     }
 
     @Test
+    fun fetchTeamJoinRequestDetails_success() {
+        val requestsResponse = """
+            {
+                "docs": [
+                    {
+                        "_id": "req1",
+                        "userId": "org.couchdb.user:testuser",
+                        "teamId": "team1"
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(requestsResponse).setResponseCode(200))
+
+        val profilesResponse = """
+            {
+                "docs": [
+                    {
+                        "_id": "org.couchdb.user:testuser",
+                        "firstName": "Test",
+                        "lastName": "User",
+                        "_attachments": {
+                            "img": {
+                                "content_type": "image/png"
+                            }
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(profilesResponse).setResponseCode(200))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val details = operations.fetchTeamJoinRequestDetails(
+            baseUrl,
+            StoredCredentials("u", "p"),
+            "cookie",
+            "team1",
+            "code1",
+        )
+
+        assertEquals(1, details.size)
+        val detail = details[0]
+        assertEquals("testuser", detail.username)
+        assertEquals("Test User", detail.fullName)
+        assertTrue(detail.hasAvatar)
+        assertEquals("req1", detail.request.id)
+    }
+
+    @Test
+    fun fetchTeamJoinRequestDetails_profilesFailureGraceful() {
+        val requestsResponse = """
+            {
+                "docs": [
+                    {
+                        "_id": "req2",
+                        "userId": "org.couchdb.user:testuser2",
+                        "teamId": "team2"
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(requestsResponse).setResponseCode(200))
+
+        // Profiles fetch fails
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val baseUrl = mockWebServer.url("/").toString()
+        val details = operations.fetchTeamJoinRequestDetails(
+            baseUrl,
+            StoredCredentials("u", "p"),
+            "cookie",
+            "team2",
+            "code2",
+        )
+
+        assertEquals(1, details.size)
+        val detail = details[0]
+        assertEquals("testuser2", detail.username)
+        assertEquals("testuser2", detail.fullName) // Falls back to username
+        assertFalse(detail.hasAvatar)
+        assertEquals("req2", detail.request.id)
+    }
+
+    @Test
     fun addTeamMember_success() {
         val putResponse = "{\"ok\": true}"
         mockWebServer.enqueue(MockResponse().setBody(putResponse).setResponseCode(201))


### PR DESCRIPTION
Extracted user profile lookup and merging for team join requests out of the dashboard fragment and into the repository layer. The fragment now receives a fully enriched model out-of-the-box. Tests have been written to cover the network repository logic mapping and fallback handling.

---
*PR created automatically by Jules for task [4461920383103890043](https://jules.google.com/task/4461920383103890043) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the team join-request list with clearer member names, usernames, and avatar availability.
  * Join requests are now sorted alphabetically by member name.
  * Added graceful handling when member profile information is unavailable.
  * Empty join-request states are displayed consistently, including when no team planet is configured.

* **Tests**
  * Added coverage for successful join-request details loading and profile-fetch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->