### PR TITLE
Constructor-inject CoroutineDispatchers into Survey Stores

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 494
+        versionName = "0.4.94
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 28
         targetSdk = 36
         versionCode = 494
-        versionName = "0.4.94
+        versionName = "0.4.94"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/androidTest/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
+++ b/app/src/androidTest/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,7 +33,8 @@ class DashboardOfflineSurveyStoreTest {
         context.getSharedPreferences("dashboard_offline_surveys", Context.MODE_PRIVATE).edit().clear().commit()
 
         // Pass both context and explicit moshi instance as mentioned in prompt
-        store = DashboardOfflineSurveyStore(context, moshi)
+        val testDispatcher = UnconfinedTestDispatcher()
+        store = DashboardOfflineSurveyStore(context, testDispatcher, moshi)
     }
 
     @After

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStore.kt
@@ -12,6 +12,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
@@ -19,6 +20,7 @@ import org.ole.planet.myplanet.lite.util.getStringOrNull
 
 class DashboardOfflineSurveyStore(
     context: Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     moshi: Moshi =
         Moshi
             .Builder()
@@ -61,7 +63,7 @@ class DashboardOfflineSurveyStore(
         val serialized = documentAdapter.toJson(document) ?: return false
         val rev = document.rev
         val teamId = document.teamId ?: fallbackTeamId
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             val values =
                 ContentValues().apply {
                     put(COLUMN_ID, id)
@@ -79,7 +81,7 @@ class DashboardOfflineSurveyStore(
     }
 
     suspend fun getSavedSurveyIds(): Set<String> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             readableDatabase
                 .query(
                     TABLE_SURVEYS,
@@ -100,7 +102,7 @@ class DashboardOfflineSurveyStore(
         }
 
     suspend fun getSavedSurveysForTeam(teamId: String): List<SurveyDocument> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val jsons =
                 readableDatabase
                     .query(
@@ -124,7 +126,7 @@ class DashboardOfflineSurveyStore(
         }
 
     suspend fun getSavedSurveyRevisions(): Map<String, String?> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             readableDatabase
                 .query(
                     TABLE_SURVEYS,
@@ -168,9 +170,15 @@ class DashboardOfflineSurveyStore(
         @Volatile
         private var instance: DashboardOfflineSurveyStore? = null
 
-        fun getInstance(context: Context): DashboardOfflineSurveyStore =
+        fun getInstance(
+            context: Context,
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+        ): DashboardOfflineSurveyStore =
             instance ?: synchronized(this) {
-                instance ?: DashboardOfflineSurveyStore(context.applicationContext).also { instance = it }
+                instance ?: DashboardOfflineSurveyStore(
+                    context.applicationContext,
+                    ioDispatcher,
+                ).also { instance = it }
             }
 
         fun resetForTesting(context: Context) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStore.kt
@@ -12,6 +12,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
@@ -19,6 +20,8 @@ import org.ole.planet.myplanet.lite.util.getStringOrNull
 
 class DashboardSurveyOutboxStore private constructor(
     context: Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
     moshi: Moshi =
         Moshi
             .Builder()
@@ -64,7 +67,7 @@ class DashboardSurveyOutboxStore private constructor(
         teamName: String?,
     ): Boolean {
         val serialized = submissionAdapter.toJson(submission) ?: return false
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             val values =
                 ContentValues().apply {
                     put(COLUMN_SURVEY_ID, surveyId)
@@ -79,7 +82,7 @@ class DashboardSurveyOutboxStore private constructor(
     }
 
     suspend fun getPendingForTeam(teamId: String?): List<OutboxEntry> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val rawEntries =
                 readableDatabase
                     .query(
@@ -125,7 +128,7 @@ class DashboardSurveyOutboxStore private constructor(
                         }
                     }
 
-            withContext(Dispatchers.Default) {
+            withContext(defaultDispatcher) {
                 rawEntries.mapNotNull { raw ->
                     val parsed =
                         try {
@@ -147,7 +150,7 @@ class DashboardSurveyOutboxStore private constructor(
         }
 
     suspend fun getEntry(id: Long): OutboxEntry? =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val rawEntry =
                 readableDatabase
                     .query(
@@ -193,7 +196,7 @@ class DashboardSurveyOutboxStore private constructor(
                     }
 
             if (rawEntry != null) {
-                withContext(Dispatchers.Default) {
+                withContext(defaultDispatcher) {
                     val parsed =
                         try {
                             submissionAdapter.fromJson(rawEntry.payload)
@@ -216,12 +219,12 @@ class DashboardSurveyOutboxStore private constructor(
         }
 
     suspend fun deleteEntry(id: Long): Boolean =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             writableDatabase.delete(TABLE_SUBMISSIONS, "$COLUMN_ID = ?", arrayOf(id.toString())) > 0
         }
 
     suspend fun deleteEntries(ids: Collection<Long>): Boolean =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             if (ids.isEmpty()) return@withContext false
             var deletedCount = 0
             val db = writableDatabase
@@ -288,9 +291,17 @@ class DashboardSurveyOutboxStore private constructor(
         @Volatile
         private var instance: DashboardSurveyOutboxStore? = null
 
-        fun getInstance(context: Context): DashboardSurveyOutboxStore =
+        fun getInstance(
+            context: Context,
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+            defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+        ): DashboardSurveyOutboxStore =
             instance ?: synchronized(this) {
-                instance ?: DashboardSurveyOutboxStore(context.applicationContext).also { instance = it }
+                instance ?: DashboardSurveyOutboxStore(
+                    context.applicationContext,
+                    ioDispatcher,
+                    defaultDispatcher,
+                ).also { instance = it }
             }
 
         fun resetForTesting(context: Context) {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardOfflineSurveyStoreTest.kt
@@ -3,6 +3,7 @@ package org.ole.planet.myplanet.lite.dashboard
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -28,7 +29,8 @@ class DashboardOfflineSurveyStoreTest {
         org.ole.planet.myplanet.lite.util.SecurePreferencesProvider.injectedPreferences = mockPrefs
 
         val context = ApplicationProvider.getApplicationContext<Context>()
-        store = DashboardOfflineSurveyStore.getInstance(context)
+        val testDispatcher = UnconfinedTestDispatcher()
+        store = DashboardOfflineSurveyStore.getInstance(context, testDispatcher)
         // Clear db before test
         store.writableDatabase.delete("surveys", null, null)
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStoreTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardSurveyOutboxStoreTest.kt
@@ -4,6 +4,7 @@ import android.content.ContentValues
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -34,7 +35,8 @@ class DashboardSurveyOutboxStoreTest {
     @Before
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        store = DashboardSurveyOutboxStore.getInstance(context)
+        val testDispatcher = UnconfinedTestDispatcher()
+        store = DashboardSurveyOutboxStore.getInstance(context, testDispatcher, testDispatcher)
         store.writableDatabase.delete("outbox_submissions", null, null)
     }
 


### PR DESCRIPTION
This PR constructor-injects CoroutineDispatchers into `DashboardSurveyOutboxStore` and `DashboardOfflineSurveyStore` to improve testability and replace hardcoded `withContext(Dispatchers.IO)` and `withContext(Dispatchers.Default)` calls. Tests have been updated to use `UnconfinedTestDispatcher` to avoid real IO waits.

---
*PR created automatically by Jules for task [2077119326589757429](https://jules.google.com/task/2077119326589757429) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of offline survey and submission storage operations by making coroutine execution more predictable.

* **Tests**
  * Updated automated tests to use controlled coroutine dispatchers, improving consistency and stability during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->