### PR TITLE
Refactor survey adapters to use shared DiffUtils

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 490
+        versionName = "0.4.90"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysAdapters.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardTeamSurveysAdapters.kt
@@ -189,20 +189,14 @@ internal data class SurveyItemUiModel(
     val savedRevision: String?,
 )
 
-private class SurveyItemUiModelDiffCallback : DiffUtil.ItemCallback<SurveyItemUiModel>() {
-    override fun areItemsTheSame(oldItem: SurveyItemUiModel, newItem: SurveyItemUiModel): Boolean =
-        oldItem.document.id == newItem.document.id
-
-    override fun areContentsTheSame(oldItem: SurveyItemUiModel, newItem: SurveyItemUiModel): Boolean =
-        oldItem == newItem
-}
-
 private class SurveyItemsAdapter(
     private val statusStore: DashboardSurveyStatusStore,
     private val onStatusChanged: () -> Unit,
     private val onSurveySelected: (SurveyDocument) -> Unit,
     private val onDownloadRequested: (SurveyDocument) -> Unit,
-) : ListAdapter<SurveyItemUiModel, SurveyItemsAdapter.SurveyViewHolder>(SurveyItemUiModelDiffCallback()) {
+) : ListAdapter<SurveyItemUiModel, SurveyItemsAdapter.SurveyViewHolder>(
+    org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback({ oldItem, newItem -> oldItem.document.id == newItem.document.id })
+) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SurveyViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -326,14 +320,11 @@ private val SurveyStatus.iconRes: Int
         SurveyStatus.COMPLETED -> R.drawable.ic_survey_completed_24
     }
 
-private class OutboxEntryDiffCallback : DiffUtil.ItemCallback<OutboxEntry>() {
-    override fun areItemsTheSame(oldItem: OutboxEntry, newItem: OutboxEntry): Boolean = oldItem.id == newItem.id
-    override fun areContentsTheSame(oldItem: OutboxEntry, newItem: OutboxEntry): Boolean = oldItem == newItem
-}
-
 private class SurveyOutboxAdapter(
     private val onOutboxSelected: (OutboxEntry) -> Unit,
-) : ListAdapter<OutboxEntry, SurveyOutboxAdapter.OutboxViewHolder>(OutboxEntryDiffCallback()) {
+) : ListAdapter<OutboxEntry, SurveyOutboxAdapter.OutboxViewHolder>(
+    org.ole.planet.myplanet.lite.util.DiffUtils.itemCallback({ oldItem, newItem -> oldItem.id == newItem.id })
+) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OutboxViewHolder {
         val view = LayoutInflater.from(parent.context)


### PR DESCRIPTION
Replaced boilerplate `DiffUtil.ItemCallback` implementations with the shared `DiffUtils.itemCallback` utility in `DashboardTeamSurveysAdapters.kt` to simplify the adapter definitions.

---
*PR created automatically by Jules for task [2268092344933542094](https://jules.google.com/task/2268092344933542094) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list update handling for team surveys and outbox entries.
  * Survey and outbox lists now more reliably recognize existing items, helping updates appear smoothly and accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->