### PR TITLE
Refactor DashboardPostDetailActivity for shared client and ApplicationScope

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 517
+        versionName = "0.5.17"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailActivity.kt
@@ -43,18 +43,20 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
     internal lateinit var recyclerView: RecyclerView
     internal lateinit var loadingView: View
 
+    private val reusedMoshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+
     internal val repository =
         DashboardNewsRepository(
-            client = OkHttpClient.Builder().build(),
-            moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
+            client = SharedBitmapDependencies.client,
+            moshi = reusedMoshi,
         )
     internal val actionsRepository = DashboardNewsActionsRepository(AuthDependencies.client, AuthDependencies.moshi, Dispatchers.IO)
     internal val composerRepository =
         VoicesComposerRepository(
-            client = OkHttpClient.Builder().build(),
-            moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build(),
+            client = SharedBitmapDependencies.client,
+            moshi = reusedMoshi,
         )
-    internal val httpClient = OkHttpClient.Builder().build()
+    internal val httpClient = SharedBitmapDependencies.client
     internal lateinit var adapter: PostDetailAdapter
     internal lateinit var markwon: Markwon
 
@@ -269,6 +271,7 @@ class DashboardPostDetailActivity : org.ole.planet.myplanet.lite.BaseActivity() 
 
         internal val NUMBERED_LIST_REGEX = Regex("^(\\d+)\\.\\s*(.*)$")
         internal val IMAGE_MARKDOWN_REGEX = Regex("!\\[([^]]*)]\\(([^)]+)\\)")
+        internal val GLOBAL_PATTERN = Regex("(!\\[[^]]*]\\()(.*?)(\\))")
         internal val RESOURCES_MARKDOWN_REGEX = Regex("!\\[[^]]*]\\((resources/[^)]+)\\)")
         internal val RESOURCES_PATH_REGEX = Regex("resources/[^/]+/[^/]+", RegexOption.IGNORE_CASE)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyFormattingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyFormattingExtensions.kt
@@ -243,9 +243,8 @@ internal fun DashboardPostDetailActivity.transformReplyMarkdownForPreview(markdo
 
     val pendingByFileName = pendingReplyImages.values.associateBy { it.fileName }
     if (pendingByFileName.isNotEmpty()) {
-        val globalPattern = Regex("(!\\[[^]]*]\\()(.*?)(\\))")
         processed =
-            globalPattern.replace(processed) { matchResult ->
+            DashboardPostDetailActivity.GLOBAL_PATTERN.replace(processed) { matchResult ->
                 val path = matchResult.groupValues.getOrNull(2).orEmpty()
                 val pending = pendingByFileName[path]
                 if (pending != null) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyUiExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyUiExtensions.kt
@@ -24,7 +24,6 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity.Companion.COLLAPSED_REPLY_MIN_LINES
@@ -273,8 +272,7 @@ internal fun DashboardPostDetailActivity.clearPendingReplyImages() {
     val filesToDelete = pendingReplyImages.values.map { it.file }.toList()
     pendingReplyImages.clear()
 
-    @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-    GlobalScope.launch(Dispatchers.IO) {
+    org.ole.planet.myplanet.lite.util.ApplicationScope.io.launch {
         filesToDelete.forEach { file ->
             if (file.exists()) {
                 file.delete()


### PR DESCRIPTION
Refactored `DashboardPostDetailActivity` to use a shared `OkHttpClient` instance via `SharedBitmapDependencies.client`, significantly reducing the number of unnecessary client initializations. Reused a single `Moshi` instance across repositories. Removed the delicate `GlobalScope` by migrating background temporary file cleanup tasks to a new `ApplicationScope.io`. Hoisted the frequently instantiated `globalPattern` regex up to the companion object to improve performance.

---
*PR created automatically by Jules for task [15389988588790886545](https://jules.google.com/task/15389988588790886545) started by @dogi*