### PR TITLE
Inject shared dependencies into DashboardResourcesRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 493
+        versionName = "0.4.93"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 493
-        versionName = "0.4.93"
+        versionCode = 492
+        versionName = "0.4.92"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourceDownloads.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourceDownloads.kt
@@ -1,0 +1,99 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import java.io.File
+import java.io.IOException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okio.Buffer
+
+internal class DashboardResourceDownloads(
+    private val client: OkHttpClient,
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend fun downloadResourceBytes(
+        baseUrl: String,
+        sessionCookie: String?,
+        resourceId: String,
+        filename: String,
+        onProgress: ((Int?) -> Unit)?
+    ): Result<ByteArray> = withContext(ioDispatcher) {
+        runCatching {
+            val normalizedBase = baseUrl.trim().trimEnd('/')
+            if (normalizedBase.isEmpty()) throw IOException("Missing server base URL")
+            if (resourceId.isBlank() || filename.isBlank()) {
+                throw IOException("Missing resource id or filename")
+            }
+
+            val requestBuilder = Request.Builder()
+                .url("$normalizedBase/db/resources/${resourceId.trim()}/${filename.trim()}")
+                .get()
+            sessionCookie?.takeIf { it.isNotBlank() }?.let { requestBuilder.addHeader("Cookie", it) }
+
+            client.newCall(requestBuilder.build()).execute().use { response ->
+                if (!response.isSuccessful) throw IOException("Unexpected response ${response.code}")
+                readResponseBytes(response, onProgress)
+            }
+        }
+    }
+
+    suspend fun downloadPdfToCache(url: String, authHeader: String?, cacheDir: File): File? {
+        return withContext(ioDispatcher) {
+            runCatching {
+                val parsedUri = android.net.Uri.parse(url)
+                if (parsedUri.scheme == "file") {
+                    val localFile = File(parsedUri.path.orEmpty())
+                    if (localFile.exists()) return@withContext localFile
+                }
+
+                val request = Request.Builder()
+                    .url(url)
+                    .apply {
+                        if (!authHeader.isNullOrBlank() && url.startsWith("https://", ignoreCase = true)) {
+                            addHeader("Authorization", authHeader)
+                        }
+                    }
+                    .build()
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@withContext null
+                    saveToTempFile(response, cacheDir)
+                }
+            }.getOrNull()
+        }
+    }
+
+    private fun readResponseBytes(response: Response, onProgress: ((Int?) -> Unit)?): ByteArray {
+        val body = response.body
+        val totalBytes = body.contentLength()
+        val source = body.source()
+        val sink = Buffer()
+        val chunkSize = 8_192L
+        var downloadedBytes = 0L
+        var lastProgress: Int? = null
+        onProgress?.invoke(if (totalBytes > 0L) 0 else null)
+        while (true) {
+            val read = source.read(sink, chunkSize)
+            if (read == -1L) break
+            downloadedBytes += read
+            if (totalBytes > 0L) {
+                val progress = ((downloadedBytes * 100L) / totalBytes).toInt().coerceIn(0, 100)
+                if (progress != lastProgress) {
+                    lastProgress = progress
+                    onProgress?.invoke(progress)
+                }
+            }
+        }
+        if (totalBytes > 0L && lastProgress != 100) onProgress?.invoke(100)
+        return sink.readByteArray()
+    }
+
+    private fun saveToTempFile(response: Response, cacheDir: File): File {
+        val file = File.createTempFile("course_resource_", ".pdf", cacheDir)
+        response.body.byteStream().use { input ->
+            file.outputStream().use { output -> input.copyTo(output) }
+        }
+        return file
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcePersistence.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcePersistence.kt
@@ -1,0 +1,188 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import java.io.IOException
+import java.net.URLEncoder
+import java.util.Locale
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+internal class DashboardResourcePersistence(
+    private val client: OkHttpClient,
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend fun createDatabaseDocument(
+        baseUrl: String,
+        dbName: String,
+        sessionCookie: String?,
+        username: String?,
+        password: String?,
+        payload: JSONObject
+    ): Result<JSONObject> = withContext(ioDispatcher) {
+        runCatching {
+            val normalizedBase = normalizedBaseUrl(baseUrl)
+            val request = Request.Builder()
+                .url("$normalizedBase/db/$dbName")
+                .post(payload.toString().toRequestBody(JSON_MEDIA_TYPE))
+                .addAuthentication(username, password, sessionCookie)
+                .build()
+
+            client.newCall(request).execute().use(::parseJsonResponse)
+        }
+    }
+
+    suspend fun updateResourceDocument(
+        baseUrl: String,
+        sessionCookie: String?,
+        username: String?,
+        password: String?,
+        resourceId: String,
+        payload: JSONObject
+    ): Result<JSONObject> = withContext(ioDispatcher) {
+        runCatching {
+            val normalizedBase = normalizedBaseUrl(baseUrl)
+            val request = Request.Builder()
+                .url("$normalizedBase/db/resources/${resourceId.trim()}")
+                .put(payload.toString().toRequestBody(JSON_MEDIA_TYPE))
+                .addAuthentication(username, password, sessionCookie)
+                .build()
+
+            client.newCall(request).execute().use(::parseJsonResponse)
+        }
+    }
+
+    suspend fun createAndUploadResourceSequence(
+        request: DashboardResourcesRepository.CreateAndUploadResourceRequest
+    ): Result<Unit> = withContext(ioDispatcher) {
+        runCatching {
+            val creationResponse = createDatabaseDocument(
+                baseUrl = request.baseUrl,
+                dbName = "resources",
+                sessionCookie = request.sessionCookie,
+                username = request.credentials?.username,
+                password = request.credentials?.password,
+                payload = request.payload
+            ).getOrThrow()
+
+            val resourceId = creationResponse.optString("id").orEmpty()
+            val creationRevision = creationResponse.optString("rev").orEmpty()
+            if (resourceId.isBlank() || creationRevision.isBlank()) {
+                throw DashboardResourcesRepository.InvalidServerResponseException("Invalid server response")
+            }
+
+            val renamedFileName = "${resourceId}.${request.fileExtension.lowercase(Locale.ROOT)}"
+            val updatePayload = JSONObject(request.payload.toString())
+                .put("_id", resourceId)
+                .put("_rev", creationRevision)
+                .put("filename", renamedFileName)
+                .put("mediaType", request.mediaType)
+
+            val updateResponse = updateResourceDocument(
+                baseUrl = request.baseUrl,
+                sessionCookie = request.sessionCookie,
+                username = request.credentials?.username,
+                password = request.credentials?.password,
+                resourceId = resourceId,
+                payload = updatePayload
+            ).getOrThrow()
+            val updateRevision = updateResponse.optString("rev").orEmpty().ifBlank { creationRevision }
+
+            uploadResourceAttachment(
+                DashboardResourcesRepository.UploadAttachmentRequest(
+                    baseUrl = request.baseUrl,
+                    sessionCookie = request.sessionCookie,
+                    username = request.credentials?.username,
+                    password = request.credentials?.password,
+                    resourceId = resourceId,
+                    filename = renamedFileName,
+                    revision = updateRevision,
+                    mimeType = request.mimeType,
+                    bytes = request.bytes
+                )
+            ).getOrThrow()
+
+            if (!request.teamId.isNullOrBlank() && !request.planetCode.isNullOrBlank()) {
+                val linkPayload = JSONObject()
+                    .put("resourceId", resourceId)
+                    .put("sourcePlanet", request.planetCode)
+                    .put("title", request.payload.optString("title"))
+                    .put("teamId", request.teamId)
+                    .put("teamPlanetCode", request.planetCode)
+                    .put("teamType", "local")
+                    .put("docType", "resourceLink")
+
+                createDatabaseDocument(
+                    baseUrl = request.baseUrl,
+                    dbName = "teams",
+                    sessionCookie = request.sessionCookie,
+                    username = request.credentials?.username,
+                    password = request.credentials?.password,
+                    payload = linkPayload
+                ).getOrNull()
+            }
+        }
+    }
+
+    suspend fun uploadResourceAttachment(
+        request: DashboardResourcesRepository.UploadAttachmentRequest
+    ): Result<JSONObject> = withContext(ioDispatcher) {
+        runCatching {
+            val normalizedBase = normalizedBaseUrl(request.baseUrl)
+            val encodedRev = URLEncoder.encode(request.revision, Charsets.UTF_8.name())
+            val requestUrl =
+                "$normalizedBase/db/resources/${request.resourceId.trim()}/${request.filename.trim()}?rev=$encodedRev"
+            val httpRequest = Request.Builder()
+                .url(requestUrl)
+                .put(request.bytes.toRequestBody(request.mimeType.toMediaType()))
+                .addAuthentication(request.username, request.password, request.sessionCookie)
+                .build()
+
+            client.newCall(httpRequest).execute().use(::parseJsonResponse)
+        }
+    }
+
+    private fun normalizedBaseUrl(baseUrl: String): String {
+        return baseUrl.trim().trimEnd('/').also {
+            if (it.isEmpty()) throw IOException("Missing server base URL")
+        }
+    }
+
+    private fun Request.Builder.addAuthentication(
+        username: String?,
+        password: String?,
+        sessionCookie: String?
+    ): Request.Builder = apply {
+        if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
+            addHeader("Authorization", Credentials.basic(username, password))
+        }
+        sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
+            addHeader("Cookie", cookie.substringBefore(";"))
+        }
+    }
+
+    private fun parseJsonResponse(response: Response): JSONObject {
+        val body = response.body.string()
+        if (!response.isSuccessful) {
+            val reason = runCatching { JSONObject(body).optString("reason") }.getOrNull()
+            val message = if (!reason.isNullOrBlank()) {
+                "Error ${response.code}: $reason"
+            } else {
+                "Unexpected response ${response.code}"
+            }
+            throw IOException(message)
+        }
+        return runCatching { JSONObject(body) }.getOrElse {
+            JSONObject().put("raw", body)
+        }
+    }
+
+    private companion object {
+        val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -3,27 +3,22 @@ package org.ole.planet.myplanet.lite.dashboard
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.io.File
 import java.io.IOException
-import java.net.URLEncoder
-import java.util.Locale
-import kotlinx.coroutines.CoroutineDispatcher
 import java.util.regex.Pattern
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Credentials
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.Response
 import okhttp3.RequestBody.Companion.toRequestBody
-import okio.Buffer
 import org.json.JSONArray
 import org.json.JSONObject
-import org.ole.planet.myplanet.lite.util.BirthDateString
-import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
+import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.ole.planet.myplanet.lite.util.BirthDateString
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 
 class DashboardResourcesRepository(
@@ -33,6 +28,8 @@ class DashboardResourcesRepository(
 ) {
     private val responseAdapter = moshi.adapter(ResourcesFindResponse::class.java)
     private val teamLinksResponseAdapter = moshi.adapter(TeamLinksFindResponse::class.java)
+    private val persistence = DashboardResourcePersistence(client, ioDispatcher)
+    private val downloads = DashboardResourceDownloads(client, ioDispatcher)
 
     suspend fun fetchCommunityResources(
         baseUrl: String,
@@ -102,7 +99,7 @@ class DashboardResourcesRepository(
         password: String?,
         payload: JSONObject
     ): Result<JSONObject> {
-        return createDatabaseDocument(baseUrl, "teams", sessionCookie, username, password, payload)
+        return persistence.createDatabaseDocument(baseUrl, "teams", sessionCookie, username, password, payload)
     }
 
     data class ResourceMetadataRequest(
@@ -139,49 +136,7 @@ class DashboardResourcesRepository(
         password: String?,
         payload: JSONObject
     ): Result<JSONObject> {
-        return createDatabaseDocument(baseUrl, "resources", sessionCookie, username, password, payload)
-    }
-
-    private suspend fun createDatabaseDocument(
-        baseUrl: String,
-        dbName: String,
-        sessionCookie: String?,
-        username: String?,
-        password: String?,
-        payload: JSONObject
-    ): Result<JSONObject> {
-        return withContext(ioDispatcher) {
-            runCatching {
-                val normalizedBase = baseUrl.trim().trimEnd('/')
-                if (normalizedBase.isEmpty()) {
-                    throw IOException("Missing server base URL")
-                }
-                val requestUrl = "$normalizedBase/db/$dbName"
-                val json = payload.toString()
-                val requestBuilder = Request.Builder()
-                    .url(requestUrl)
-                    .post(json.toRequestBody("application/json; charset=utf-8".toMediaType()))
-
-                if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
-                    requestBuilder.addHeader("Authorization", Credentials.basic(username, password))
-                }
-                sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
-                    requestBuilder.addHeader("Cookie", cookie.substringBefore(";"))
-                }
-
-                client.newCall(requestBuilder.build()).execute().use { response ->
-                    val body = response.body.string()
-                    if (!response.isSuccessful) {
-                        val reason = runCatching { JSONObject(body).optString("reason") }.getOrNull()
-                        val message = if (!reason.isNullOrBlank()) "Error ${response.code}: $reason" else "Unexpected response ${response.code}"
-                        throw IOException(message)
-                    }
-                    runCatching { JSONObject(body) }.getOrElse {
-                        JSONObject().put("raw", body)
-                    }
-                }
-            }.onFailure { }
-        }
+        return persistence.createDatabaseDocument(baseUrl, "resources", sessionCookie, username, password, payload)
     }
 
     suspend fun updateResourceDocument(
@@ -192,38 +147,9 @@ class DashboardResourcesRepository(
         resourceId: String,
         payload: JSONObject
     ): Result<JSONObject> {
-        return withContext(ioDispatcher) {
-            runCatching {
-                val normalizedBase = baseUrl.trim().trimEnd('/')
-                if (normalizedBase.isEmpty()) {
-                    throw IOException("Missing server base URL")
-                }
-                val requestUrl = "$normalizedBase/db/resources/${resourceId.trim()}"
-                val json = payload.toString()
-                val requestBuilder = Request.Builder()
-                    .url(requestUrl)
-                    .put(json.toRequestBody("application/json; charset=utf-8".toMediaType()))
-
-                if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
-                    requestBuilder.addHeader("Authorization", Credentials.basic(username, password))
-                }
-                sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
-                    requestBuilder.addHeader("Cookie", cookie.substringBefore(";"))
-                }
-
-                client.newCall(requestBuilder.build()).execute().use { response ->
-                    val body = response.body.string()
-                    if (!response.isSuccessful) {
-                        val reason = runCatching { JSONObject(body).optString("reason") }.getOrNull()
-                        val message = if (!reason.isNullOrBlank()) "Error ${response.code}: $reason" else "Unexpected response ${response.code}"
-                        throw IOException(message)
-                    }
-                    runCatching { JSONObject(body) }.getOrElse {
-                        JSONObject().put("raw", body)
-                    }
-                }
-            }.onFailure { }
-        }
+        return persistence.updateResourceDocument(
+            baseUrl, sessionCookie, username, password, resourceId, payload
+        )
     }
 
 
@@ -246,74 +172,7 @@ class DashboardResourcesRepository(
     suspend fun createAndUploadResourceSequence(
         request: CreateAndUploadResourceRequest
     ): Result<Unit> {
-        return withContext(ioDispatcher) {
-            runCatching {
-                val creationResponse = createResourceDocument(
-                    baseUrl = request.baseUrl,
-                    sessionCookie = request.sessionCookie,
-                    username = request.credentials?.username,
-                    password = request.credentials?.password,
-                    payload = request.payload
-                ).getOrThrow()
-
-                val resourceId = creationResponse.optString("id").orEmpty()
-                val creationRevision = creationResponse.optString("rev").orEmpty()
-                if (resourceId.isBlank() || creationRevision.isBlank()) {
-                    throw InvalidServerResponseException("Invalid server response")
-                }
-
-                val renamedFileName = "${resourceId}.${request.fileExtension.lowercase(Locale.ROOT)}"
-                val updatePayload = JSONObject(request.payload.toString())
-                    .put("_id", resourceId)
-                    .put("_rev", creationRevision)
-                    .put("filename", renamedFileName)
-                    .put("mediaType", request.mediaType)
-
-                val updateResponse = updateResourceDocument(
-                    baseUrl = request.baseUrl,
-                    sessionCookie = request.sessionCookie,
-                    username = request.credentials?.username,
-                    password = request.credentials?.password,
-                    resourceId = resourceId,
-                    payload = updatePayload
-                ).getOrThrow()
-
-                val updateRevision = updateResponse.optString("rev").orEmpty().ifBlank { creationRevision }
-
-                uploadResourceAttachment(
-                    UploadAttachmentRequest(
-                        baseUrl = request.baseUrl,
-                        sessionCookie = request.sessionCookie,
-                        username = request.credentials?.username,
-                        password = request.credentials?.password,
-                        resourceId = resourceId,
-                        filename = renamedFileName,
-                        revision = updateRevision,
-                        mimeType = request.mimeType,
-                        bytes = request.bytes
-                    )
-                ).getOrThrow()
-
-                if (!request.teamId.isNullOrBlank() && !request.planetCode.isNullOrBlank()) {
-                    val linkPayload = JSONObject()
-                        .put("resourceId", resourceId)
-                        .put("sourcePlanet", request.planetCode)
-                        .put("title", request.payload.optString("title"))
-                        .put("teamId", request.teamId)
-                        .put("teamPlanetCode", request.planetCode)
-                        .put("teamType", "local")
-                        .put("docType", "resourceLink")
-
-                    createTeamDocument(
-                        baseUrl = request.baseUrl,
-                        sessionCookie = request.sessionCookie,
-                        username = request.credentials?.username,
-                        password = request.credentials?.password,
-                        payload = linkPayload
-                    ).getOrNull()
-                }
-            }
-        }
+        return persistence.createAndUploadResourceSequence(request)
     }
 
     data class UploadAttachmentRequest(
@@ -331,38 +190,7 @@ class DashboardResourcesRepository(
     suspend fun uploadResourceAttachment(
         request: UploadAttachmentRequest
     ): Result<JSONObject> {
-        return withContext(ioDispatcher) {
-            runCatching {
-                val normalizedBase = request.baseUrl.trim().trimEnd('/')
-                if (normalizedBase.isEmpty()) {
-                    throw IOException("Missing server base URL")
-                }
-                val encodedRev = URLEncoder.encode(request.revision, Charsets.UTF_8.name())
-                val requestUrl = "$normalizedBase/db/resources/${request.resourceId.trim()}/${request.filename.trim()}?rev=$encodedRev"
-                val requestBuilder = Request.Builder()
-                    .url(requestUrl)
-                    .put(request.bytes.toRequestBody(request.mimeType.toMediaType()))
-
-                if (!request.username.isNullOrBlank() && !request.password.isNullOrBlank()) {
-                    requestBuilder.addHeader("Authorization", Credentials.basic(request.username, request.password))
-                }
-                request.sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
-                    requestBuilder.addHeader("Cookie", cookie.substringBefore(";"))
-                }
-
-                client.newCall(requestBuilder.build()).execute().use { response ->
-                    val body = response.body.string()
-                    if (!response.isSuccessful) {
-                        val reason = runCatching { JSONObject(body).optString("reason") }.getOrNull()
-                        val message = if (!reason.isNullOrBlank()) "Error ${response.code}: $reason" else "Unexpected response ${response.code}"
-                        throw IOException(message)
-                    }
-                    runCatching { JSONObject(body) }.getOrElse {
-                        JSONObject().put("raw", body)
-                    }
-                }
-            }.onFailure { }
-        }
+        return persistence.uploadResourceAttachment(request)
     }
 
     suspend fun downloadResourceBytes(
@@ -372,53 +200,9 @@ class DashboardResourcesRepository(
         filename: String,
         onProgress: ((Int?) -> Unit)? = null
     ): Result<ByteArray> {
-        return withContext(ioDispatcher) {
-            runCatching {
-                val normalizedBase = baseUrl.trim().trimEnd('/')
-                if (normalizedBase.isEmpty()) {
-                    throw IOException("Missing server base URL")
-                }
-                if (resourceId.isBlank() || filename.isBlank()) {
-                    throw IOException("Missing resource id or filename")
-                }
-                val requestUrl = "$normalizedBase/db/resources/${resourceId.trim()}/${filename.trim()}"
-                val requestBuilder = Request.Builder()
-                    .url(requestUrl)
-                    .get()
-                sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
-                    requestBuilder.addHeader("Cookie", cookie)
-                }
-                client.newCall(requestBuilder.build()).execute().use { response ->
-                    if (!response.isSuccessful) {
-                        throw IOException("Unexpected response ${response.code}")
-                    }
-                    val body = response.body
-                    val totalBytes = body.contentLength()
-                    val source = body.source()
-                    val sink = Buffer()
-                    val chunkSize = 8_192L
-                    var downloadedBytes = 0L
-                    var lastProgress: Int? = null
-                    onProgress?.invoke(if (totalBytes > 0L) 0 else null)
-                    while (true) {
-                        val read = source.read(sink, chunkSize)
-                        if (read == -1L) break
-                        downloadedBytes += read
-                        if (totalBytes > 0L) {
-                            val progress = ((downloadedBytes * 100L) / totalBytes).toInt().coerceIn(0, 100)
-                            if (progress != lastProgress) {
-                                lastProgress = progress
-                                onProgress?.invoke(progress)
-                            }
-                        }
-                    }
-                    if (totalBytes > 0L && lastProgress != 100) {
-                        onProgress?.invoke(100)
-                    }
-                    sink.readByteArray()
-                }
-            }.onFailure { }
-        }
+        return downloads.downloadResourceBytes(
+            baseUrl, sessionCookie, resourceId, filename, onProgress
+        )
     }
 
     data class TeamResourcesRequest(
@@ -575,41 +359,8 @@ class DashboardResourcesRepository(
 
 
 
-    private fun saveToTempFile(response: Response, cacheDir: File): File? {
-        val body = response.body
-        val file = File.createTempFile("course_resource_", ".pdf", cacheDir)
-        body.byteStream().use { input ->
-            file.outputStream().use { output ->
-                input.copyTo(output)
-            }
-        }
-        return file
-    }
-
     suspend fun downloadPdfToCache(url: String, authHeader: String?, cacheDir: File): File? {
-        return withContext(ioDispatcher) {
-            runCatching {
-                val parsedUri = android.net.Uri.parse(url)
-                if (parsedUri.scheme == "file") {
-                    val localFile = File(parsedUri.path.orEmpty())
-                    if (localFile.exists()) {
-                        return@withContext localFile
-                    }
-                }
-                val request = Request.Builder()
-                    .url(url)
-                    .apply {
-                        if (!authHeader.isNullOrBlank() && url.startsWith("https://", ignoreCase = true)) {
-                            addHeader("Authorization", authHeader)
-                        }
-                    }
-                    .build()
-                client.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) return@withContext null
-                    saveToTempFile(response, cacheDir)
-                }
-            }.getOrNull()
-        }
+        return downloads.downloadPdfToCache(url, authHeader, cacheDir)
     }
 
     @JsonClass(generateAdapter = true)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepository.kt
@@ -23,15 +23,14 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.ole.planet.myplanet.lite.util.BirthDateString
 import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.util.DateStringAdapter
 
-class DashboardResourcesRepository(private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
-
-    private val client: OkHttpClient = OkHttpClient.Builder().build()
-    private val moshi: Moshi = Moshi.Builder()
-        .add(DateStringAdapter())
-        .addLast(KotlinJsonAdapterFactory())
-        .build()
+class DashboardResourcesRepository(
+    private val client: OkHttpClient = AuthDependencies.client,
+    private val moshi: Moshi = AuthDependencies.moshi.newBuilder().add(DateStringAdapter()).build(),
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
     private val responseAdapter = moshi.adapter(ResourcesFindResponse::class.java)
     private val teamLinksResponseAdapter = moshi.adapter(TeamLinksFindResponse::class.java)
 
@@ -247,7 +246,7 @@ class DashboardResourcesRepository(private val ioDispatcher: CoroutineDispatcher
     suspend fun createAndUploadResourceSequence(
         request: CreateAndUploadResourceRequest
     ): Result<Unit> {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val creationResponse = createResourceDocument(
                     baseUrl = request.baseUrl,
@@ -588,7 +587,7 @@ class DashboardResourcesRepository(private val ioDispatcher: CoroutineDispatcher
     }
 
     suspend fun downloadPdfToCache(url: String, authHeader: String?, cacheDir: File): File? {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             runCatching {
                 val parsedUri = android.net.Uri.parse(url)
                 if (parsedUri.scheme == "file") {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
@@ -24,7 +24,7 @@ class DashboardResourcesRepositoryTest {
     fun setup() {
         server = MockWebServer()
         server.start()
-        repository = DashboardResourcesRepository(UnconfinedTestDispatcher())
+        repository = DashboardResourcesRepository(ioDispatcher = UnconfinedTestDispatcher())
     }
 
     @After

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardResourcesRepositoryTest.kt
@@ -1,18 +1,21 @@
 package org.ole.planet.myplanet.lite.dashboard
 
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.json.JSONObject
-import java.io.File
 import org.junit.After
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class DashboardResourcesRepositoryTest {
@@ -201,12 +204,12 @@ class DashboardResourcesRepositoryTest {
 
         val result = repository.downloadPdfToCache(server.url("/test.pdf").toString(), "Basic auth", cacheDir)
 
-        org.junit.Assert.assertNotNull(result)
-        org.junit.Assert.assertTrue(result!!.exists())
-        org.junit.Assert.assertEquals(pdfContent, result.readText())
+        assertNotNull(result)
+        assertTrue(result!!.exists())
+        assertEquals(pdfContent, result.readText())
 
         val request = server.takeRequest()
-        org.junit.Assert.assertNull(request.getHeader("Authorization"))
+        assertNull(request.getHeader("Authorization"))
 
         result.delete()
         cacheDir.delete()
@@ -221,7 +224,7 @@ class DashboardResourcesRepositoryTest {
 
         val result = repository.downloadPdfToCache(server.url("/test.pdf").toString(), "Basic auth", cacheDir)
 
-        org.junit.Assert.assertNull(result)
+        assertNull(result)
 
         cacheDir.delete()
     }


### PR DESCRIPTION
Replaces internal instantiations of `OkHttpClient` and `Moshi` in `DashboardResourcesRepository` with constructor parameters that default to the shared `AuthDependencies` instances. Also introduces an `ioDispatcher` constructor parameter to replace hardcoded `Dispatchers.IO` calls, improving testability. The API remains backwards compatible.

---
*PR created automatically by Jules for task [1289849921520368890](https://jules.google.com/task/1289849921520368890) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved resource upload workflows, including document creation, file attachments, and optional team links.
  - Added resource file downloads with progress reporting.
  - Added PDF downloads to local cache, including handling existing local files and authenticated requests.
- **Bug Fixes**
  - Improved handling of unsuccessful download responses and missing required resource details.
- **Chores**
  - Updated app version to **0.4.92** (version code **492**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->