### PR TITLE
Fix memory spike during large transformed media reading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 503
+        versionName = "0.5.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -389,7 +389,7 @@ object DashboardResourcesMediaUtils {
             val exportSucceeded = suspendCancellableCoroutine { continuation ->
                 val clippingBuilder = MediaItem.ClippingConfiguration.Builder().setStartPositionMs(startMs.coerceAtLeast(0L))
                 if (endMs in 1 until sourceDurationMs) clippingBuilder.setEndPositionMs(endMs)
-                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile!!)).setClippingConfiguration(clippingBuilder.build()).build()
+                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile)).setClippingConfiguration(clippingBuilder.build()).build()
                 val audioEncoderSettings = AudioEncoderSettings.Builder().setBitrate(bitrateKbps * 1000).build()
                 val editedMediaItem = EditedMediaItem.Builder(mediaItem).build()
                 val transformer = Transformer.Builder(context)
@@ -408,7 +408,7 @@ object DashboardResourcesMediaUtils {
                 transformer.start(editedMediaItem, outputFile!!.absolutePath)
             }
             if (!exportSucceeded) null else withContext(Dispatchers.IO) {
-                if (isTransformedFileOversized(outputFile!!.length())) null else outputFile!!.readBytes()
+                if (isTransformedFileOversized(outputFile!!.length())) null else outputFile.readBytes()
             }
         } catch (_: Throwable) {
             null
@@ -442,7 +442,7 @@ object DashboardResourcesMediaUtils {
             val exportSucceeded = suspendCancellableCoroutine { continuation ->
                 val clippingBuilder = MediaItem.ClippingConfiguration.Builder().setStartPositionMs(startMs.coerceAtLeast(0L))
                 if (endMs in 1 until sourceDurationMs) clippingBuilder.setEndPositionMs(endMs)
-                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile!!)).setClippingConfiguration(clippingBuilder.build()).build()
+                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile)).setClippingConfiguration(clippingBuilder.build()).build()
                 val editedMediaBuilder = EditedMediaItem.Builder(mediaItem)
                 if (shouldScale || rotationDegrees != 0f) {
                     val videoEffects = mutableListOf<Effect>()
@@ -475,7 +475,7 @@ object DashboardResourcesMediaUtils {
                 transformer.start(editedMediaItem, outputFile!!.absolutePath)
             }
             if (!exportSucceeded) null else withContext(Dispatchers.IO) {
-                if (isTransformedFileOversized(outputFile!!.length())) null else outputFile!!.readBytes()
+                if (isTransformedFileOversized(outputFile!!.length())) null else outputFile.readBytes()
             }
         } catch (_: Throwable) {
             null

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtils.kt
@@ -48,6 +48,11 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 object DashboardResourcesMediaUtils {
+
+    const val MAX_TRANSFORMED_FILE_SIZE_BYTES = 50L * 1024 * 1024
+
+    internal fun isTransformedFileOversized(fileLength: Long): Boolean = fileLength > MAX_TRANSFORMED_FILE_SIZE_BYTES
+
     data class ResourceUploadMetadata(
         val fileName: String,
         val defaultTitle: String,
@@ -376,13 +381,15 @@ object DashboardResourcesMediaUtils {
         endMs: Long,
         sourceDurationMs: Long
     ): ByteArray? {
-        val inputFile = withContext(Dispatchers.IO) { copyUriToTempFile(context, readFileErrorMessage, uri) }
-        val outputFile = withContext(Dispatchers.IO) { File.createTempFile("resource_output_audio", ".mp3", context.cacheDir) }
+        var inputFile: File? = null
+        var outputFile: File? = null
         return try {
+            inputFile = withContext(Dispatchers.IO) { copyUriToTempFile(context, readFileErrorMessage, uri) }
+            outputFile = withContext(Dispatchers.IO) { File.createTempFile("resource_output_audio", ".mp3", context.cacheDir) }
             val exportSucceeded = suspendCancellableCoroutine { continuation ->
                 val clippingBuilder = MediaItem.ClippingConfiguration.Builder().setStartPositionMs(startMs.coerceAtLeast(0L))
                 if (endMs in 1 until sourceDurationMs) clippingBuilder.setEndPositionMs(endMs)
-                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile)).setClippingConfiguration(clippingBuilder.build()).build()
+                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile!!)).setClippingConfiguration(clippingBuilder.build()).build()
                 val audioEncoderSettings = AudioEncoderSettings.Builder().setBitrate(bitrateKbps * 1000).build()
                 val editedMediaItem = EditedMediaItem.Builder(mediaItem).build()
                 val transformer = Transformer.Builder(context)
@@ -398,13 +405,18 @@ object DashboardResourcesMediaUtils {
                     })
                     .build()
                 continuation.invokeOnCancellation { transformer.cancel() }
-                transformer.start(editedMediaItem, outputFile.absolutePath)
+                transformer.start(editedMediaItem, outputFile!!.absolutePath)
             }
-            if (!exportSucceeded) null else withContext(Dispatchers.IO) { outputFile.readBytes() }
+            if (!exportSucceeded) null else withContext(Dispatchers.IO) {
+                if (isTransformedFileOversized(outputFile!!.length())) null else outputFile!!.readBytes()
+            }
         } catch (_: Throwable) {
             null
         } finally {
-            withContext(Dispatchers.IO) { inputFile.delete(); outputFile.delete() }
+            withContext(Dispatchers.IO) {
+                inputFile?.delete()
+                outputFile?.delete()
+            }
         }
     }
 
@@ -421,14 +433,16 @@ object DashboardResourcesMediaUtils {
         sourceDurationMs: Long,
         rotationDegrees: Float
     ): ByteArray? {
-        val inputFile = withContext(Dispatchers.IO) { copyUriToTempFile(context, readFileErrorMessage, uri) }
-        val outputFile = withContext(Dispatchers.IO) { File.createTempFile("resource_output_video", ".mp4", context.cacheDir) }
+        var inputFile: File? = null
+        var outputFile: File? = null
         val shouldScale = selectedHeight < sourceHeight
         return try {
+            inputFile = withContext(Dispatchers.IO) { copyUriToTempFile(context, readFileErrorMessage, uri) }
+            outputFile = withContext(Dispatchers.IO) { File.createTempFile("resource_output_video", ".mp4", context.cacheDir) }
             val exportSucceeded = suspendCancellableCoroutine { continuation ->
                 val clippingBuilder = MediaItem.ClippingConfiguration.Builder().setStartPositionMs(startMs.coerceAtLeast(0L))
                 if (endMs in 1 until sourceDurationMs) clippingBuilder.setEndPositionMs(endMs)
-                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile)).setClippingConfiguration(clippingBuilder.build()).build()
+                val mediaItem = MediaItem.Builder().setUri(Uri.fromFile(inputFile!!)).setClippingConfiguration(clippingBuilder.build()).build()
                 val editedMediaBuilder = EditedMediaItem.Builder(mediaItem)
                 if (shouldScale || rotationDegrees != 0f) {
                     val videoEffects = mutableListOf<Effect>()
@@ -458,22 +472,32 @@ object DashboardResourcesMediaUtils {
                         }
                     }).build()
                 continuation.invokeOnCancellation { transformer.cancel() }
-                transformer.start(editedMediaItem, outputFile.absolutePath)
+                transformer.start(editedMediaItem, outputFile!!.absolutePath)
             }
-            if (!exportSucceeded) null else withContext(Dispatchers.IO) { outputFile.readBytes() }
+            if (!exportSucceeded) null else withContext(Dispatchers.IO) {
+                if (isTransformedFileOversized(outputFile!!.length())) null else outputFile!!.readBytes()
+            }
         } catch (_: Throwable) {
             null
         } finally {
-            withContext(Dispatchers.IO) { inputFile.delete(); outputFile.delete() }
+            withContext(Dispatchers.IO) {
+                inputFile?.delete()
+                outputFile?.delete()
+            }
         }
     }
 
     fun copyUriToTempFile(context: Context, readFileErrorMessage: String, uri: Uri): File {
         val tempFile = File.createTempFile("resource_input_video", ".tmp", context.cacheDir)
-        context.contentResolver.openInputStream(uri)?.use { input ->
-            FileOutputStream(tempFile).use { output -> input.copyTo(output) }
-        } ?: throw IllegalStateException(readFileErrorMessage)
-        return tempFile
+        try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(tempFile).use { output -> input.copyTo(output) }
+            } ?: throw IllegalStateException(readFileErrorMessage)
+            return tempFile
+        } catch (e: Exception) {
+            tempFile.delete()
+            throw e
+        }
     }
 
     fun resolveDefaultLanguageIndex(context: Context, resources: Resources, options: List<String>): Int {

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1074,4 +1074,37 @@ class DashboardResourcesMediaUtilsTest {
         SecurePreferencesProvider.injectedPreferences = null
     }
 
+
+    // Testing oversized file size for transcodeAudio and transcodeVideoToMp4 requires integration with Transformer
+    // which is hard to unit test thoroughly with robolectric without a proper mock of the static MediaItem / Transformer.
+    // However, we can test that copyUriToTempFile correctly cleans up on exception.
+
+
+    @Test
+    fun testIsTransformedFileOversized() {
+        val maxSize = DashboardResourcesMediaUtils.MAX_TRANSFORMED_FILE_SIZE_BYTES
+        assertTrue(DashboardResourcesMediaUtils.isTransformedFileOversized(maxSize + 1))
+        org.junit.Assert.assertFalse(DashboardResourcesMediaUtils.isTransformedFileOversized(maxSize))
+        org.junit.Assert.assertFalse(DashboardResourcesMediaUtils.isTransformedFileOversized(maxSize - 1))
+    }
+
+    @Test
+    fun copyUriToTempFile_cleansUpOnException() {
+        val context = mock(Context::class.java)
+        val contentResolver = mock(ContentResolver::class.java)
+        val uri = mock(Uri::class.java)
+
+        `when`(context.cacheDir).thenReturn(File(System.getProperty("java.io.tmpdir")))
+        `when`(context.contentResolver).thenReturn(contentResolver)
+        `when`(contentResolver.openInputStream(uri)).thenThrow(RuntimeException("Simulated read exception"))
+
+        val beforeFiles = File(System.getProperty("java.io.tmpdir")).listFiles()?.size ?: 0
+
+        assertThrows(RuntimeException::class.java) {
+            DashboardResourcesMediaUtils.copyUriToTempFile(context, "Error", uri)
+        }
+
+        val afterFiles = File(System.getProperty("java.io.tmpdir")).listFiles()?.size ?: 0
+        assertEquals(beforeFiles, afterFiles)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardResourcesMediaUtilsTest.kt
@@ -1093,18 +1093,19 @@ class DashboardResourcesMediaUtilsTest {
         val context = mock(Context::class.java)
         val contentResolver = mock(ContentResolver::class.java)
         val uri = mock(Uri::class.java)
+        val tempDir = File(requireNotNull(System.getProperty("java.io.tmpdir")))
 
-        `when`(context.cacheDir).thenReturn(File(System.getProperty("java.io.tmpdir")))
+        `when`(context.cacheDir).thenReturn(tempDir)
         `when`(context.contentResolver).thenReturn(contentResolver)
         `when`(contentResolver.openInputStream(uri)).thenThrow(RuntimeException("Simulated read exception"))
 
-        val beforeFiles = File(System.getProperty("java.io.tmpdir")).listFiles()?.size ?: 0
+        val beforeFiles = tempDir.listFiles()?.size ?: 0
 
         assertThrows(RuntimeException::class.java) {
             DashboardResourcesMediaUtils.copyUriToTempFile(context, "Error", uri)
         }
 
-        val afterFiles = File(System.getProperty("java.io.tmpdir")).listFiles()?.size ?: 0
+        val afterFiles = tempDir.listFiles()?.size ?: 0
         assertEquals(beforeFiles, afterFiles)
     }
 }


### PR DESCRIPTION
Fix memory spike when reading excessively large transformed media. Adds a maximum transformed file size boundary guard before calling read bytes and properly manages file closure to prevent temporary file leaking.

---
*PR created automatically by Jules for task [2687175861916573144](https://jules.google.com/task/2687175861916573144) started by @dogi*