### PR TITLE
Delegate ProfileActivity birth-date helpers to DateUtils

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 495
+        versionName = "0.4.95"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivityBirthDateExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/profile/ProfileActivityBirthDateExtensions.kt
@@ -11,62 +11,20 @@ import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.textfield.TextInputEditText
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.util.BirthDateConstraints
+import org.ole.planet.myplanet.lite.util.DateUtils
 import java.text.SimpleDateFormat
 import java.time.Instant
-import java.time.LocalDate
-import java.time.Period
 import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
 internal fun ProfileActivity.formatBirthDateImpl(raw: String?): String {
-    if (raw.isNullOrBlank()) {
-        return ""
-    }
-    val targetPattern = "MMM d, yyyy"
-
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        val instant =
-            runCatching { Instant.parse(raw) }.getOrNull()
-                ?: runCatching { LocalDate.parse(raw).atStartOfDay(ZoneOffset.UTC).toInstant() }.getOrNull()
-
-        if (instant != null) {
-            val zonedDate = instant.atZone(ZoneOffset.UTC).toLocalDate()
-            val formatter = DateTimeFormatter.ofPattern(targetPattern, Locale.getDefault())
-            zonedDate.format(formatter)
-        } else {
-            raw
-        }
-    } else {
-        val inputPatterns =
-            listOf(
-                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                "yyyy-MM-dd'T'HH:mm:ss'Z'",
-                "yyyy-MM-dd",
-            )
-        val outputFormat =
-            SimpleDateFormat(targetPattern, Locale.getDefault()).apply {
-                timeZone = TimeZone.getTimeZone("UTC")
-            }
-
-        inputPatterns.firstNotNullOfOrNull { pattern ->
-            runCatching {
-                SimpleDateFormat(pattern, Locale.US)
-                    .apply {
-                        timeZone = TimeZone.getTimeZone("UTC")
-                    }.parse(raw)
-            }.getOrNull()?.let { date ->
-                outputFormat.format(date)
-            }
-        } ?: raw
-    }
+    return DateUtils.formatBirthDate(raw, raw ?: "", "MMM d, yyyy")
 }
 
 internal fun ProfileActivity.showBirthDatePickerImpl(targetView: TextInputEditText) {
-    val selection = BirthDateConstraints.coerceSelection(parseBirthDateToMillis(selectedBirthDateIso))
+    val selection = BirthDateConstraints.coerceSelection(DateUtils.parseBirthDateToMillis(selectedBirthDateIso))
     val picker =
         MaterialDatePicker.Builder
             .datePicker()
@@ -101,96 +59,14 @@ internal fun ProfileActivity.showBirthDatePickerImpl(targetView: TextInputEditTe
 }
 
 internal fun ProfileActivity.normalizeBirthDateIsoImpl(raw: String?): String? {
-    val millis = parseBirthDateToMillis(raw)
+    val millis = DateUtils.parseBirthDateToMillis(raw)
     return raw?.takeIf { millis != null && !BirthDateConstraints.isFuture(millis) }
 }
 
-private fun ProfileActivity.parseBirthDateToMillis(raw: String?): Long? {
-    if (raw.isNullOrBlank()) {
-        return null
-    }
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        runCatching { Instant.parse(raw).toEpochMilli() }.getOrNull()
-            ?: runCatching {
-                LocalDate
-                    .parse(raw)
-                    .atStartOfDay(ZoneOffset.UTC)
-                    .toInstant()
-                    .toEpochMilli()
-            }.getOrNull()
-    } else {
-        val patterns =
-            listOf(
-                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                "yyyy-MM-dd'T'HH:mm:ss'Z'",
-                "yyyy-MM-dd",
-            )
-        patterns.firstNotNullOfOrNull { pattern ->
-            runCatching {
-                SimpleDateFormat(pattern, Locale.US)
-                    .apply {
-                        timeZone = TimeZone.getTimeZone("UTC")
-                    }.parse(raw)
-                    ?.time
-            }.getOrNull()
-        }
-    }
-}
-
 internal fun ProfileActivity.extractBirthYearFromIsoImpl(iso: String?): String? {
-    if (iso.isNullOrBlank()) {
-        return null
-    }
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        runCatching {
-            Instant
-                .parse(iso)
-                .atZone(ZoneOffset.UTC)
-                .year
-                .toString()
-        }.getOrNull()
-    } else {
-        runCatching {
-            val format =
-                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-                    timeZone = TimeZone.getTimeZone("UTC")
-                }
-            val date = format.parse(iso) ?: return@runCatching null
-            val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-            calendar.time = date
-            calendar.get(Calendar.YEAR).toString()
-        }.getOrNull()
-    }
+    return DateUtils.extractBirthYearFromIso(iso)
 }
 
 internal fun ProfileActivity.calculateAgeFromIsoImpl(iso: String?): String? {
-    if (iso.isNullOrBlank()) {
-        return null
-    }
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        runCatching {
-            val birthDate = Instant.parse(iso).atZone(ZoneOffset.UTC).toLocalDate()
-            val now = Instant.now().atZone(ZoneOffset.UTC).toLocalDate()
-            Period
-                .between(birthDate, now)
-                .years
-                .takeIf { it >= 0 }
-                ?.toString()
-        }.getOrNull()
-    } else {
-        runCatching {
-            val format =
-                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-                    timeZone = TimeZone.getTimeZone("UTC")
-                }
-            val date = format.parse(iso) ?: return@runCatching null
-            val birthCalendar = Calendar.getInstance().apply { time = date }
-            val today = Calendar.getInstance()
-            var age = today.get(Calendar.YEAR) - birthCalendar.get(Calendar.YEAR)
-            if (today.get(Calendar.DAY_OF_YEAR) < birthCalendar.get(Calendar.DAY_OF_YEAR)) {
-                age -= 1
-            }
-            age.takeIf { it >= 0 }?.toString()
-        }.getOrNull()
-    }
+    return DateUtils.calculateAgeFromIso(iso)
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/util/DateUtils.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/util/DateUtils.kt
@@ -5,7 +5,9 @@ import androidx.annotation.VisibleForTesting
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.LocalDate
+import java.time.Period
 import java.time.ZoneOffset
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -68,12 +70,10 @@ object DateUtils {
     @VisibleForTesting
     var sdkInt: Int = Build.VERSION.SDK_INT
 
-    fun formatBirthDate(value: String?, fallback: String): String {
+    fun formatBirthDate(value: String?, fallback: String, targetPattern: String = "yyyy-MM-dd"): String {
         if (value.isNullOrBlank()) {
             return fallback
         }
-
-        val targetPattern = "yyyy-MM-dd"
 
         return if (sdkInt >= Build.VERSION_CODES.O) {
             val date = runCatching { Instant.parse(value).atZone(ZoneOffset.UTC).toLocalDate() }.getOrNull()
@@ -107,5 +107,95 @@ object DateUtils {
         if (dateLong == null || dateLong <= 0L) return "-"
         val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)
         return formatter.format(Date(dateLong))
+    }
+
+    fun parseBirthDateToMillis(raw: String?): Long? {
+        if (raw.isNullOrBlank()) {
+            return null
+        }
+        return if (sdkInt >= Build.VERSION_CODES.O) {
+            runCatching { Instant.parse(raw).toEpochMilli() }.getOrNull()
+                ?: runCatching {
+                    LocalDate
+                        .parse(raw)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant()
+                        .toEpochMilli()
+                }.getOrNull()
+        } else {
+            val patterns =
+                listOf(
+                    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                    "yyyy-MM-dd",
+                )
+            patterns.firstNotNullOfOrNull { pattern ->
+                runCatching {
+                    SimpleDateFormat(pattern, Locale.US)
+                        .apply {
+                            timeZone = TimeZone.getTimeZone("UTC")
+                        }.parse(raw)
+                        ?.time
+                }.getOrNull()
+            }
+        }
+    }
+
+    fun extractBirthYearFromIso(iso: String?): String? {
+        if (iso.isNullOrBlank()) {
+            return null
+        }
+        return if (sdkInt >= Build.VERSION_CODES.O) {
+            runCatching {
+                Instant
+                    .parse(iso)
+                    .atZone(ZoneOffset.UTC)
+                    .year
+                    .toString()
+            }.getOrNull()
+        } else {
+            runCatching {
+                val format =
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+                        timeZone = TimeZone.getTimeZone("UTC")
+                    }
+                val date = format.parse(iso) ?: return@runCatching null
+                val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+                calendar.time = date
+                calendar.get(Calendar.YEAR).toString()
+            }.getOrNull()
+        }
+    }
+
+    fun calculateAgeFromIso(iso: String?): String? {
+        if (iso.isNullOrBlank()) {
+            return null
+        }
+        return if (sdkInt >= Build.VERSION_CODES.O) {
+            runCatching {
+                val birthDate = Instant.parse(iso).atZone(ZoneOffset.UTC).toLocalDate()
+                val now = Instant.now().atZone(ZoneOffset.UTC).toLocalDate()
+                Period
+                    .between(birthDate, now)
+                    .years
+                    .takeIf { it >= 0 }
+                    ?.toString()
+            }.getOrNull()
+        } else {
+            runCatching {
+                val format =
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+                        timeZone = TimeZone.getTimeZone("UTC")
+                    }
+                val date = format.parse(iso) ?: return@runCatching null
+                val birthCalendar = Calendar.getInstance().apply { time = date }
+                val today = Calendar.getInstance()
+                var age = today.get(Calendar.YEAR) - birthCalendar.get(Calendar.YEAR)
+                if (today.get(Calendar.DAY_OF_YEAR) < birthCalendar.get(Calendar.DAY_OF_YEAR)) {
+                    age -= 1
+                }
+                age.takeIf { it >= 0 }?.toString()
+            }.getOrNull()
+        }
     }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DateUtilsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DateUtilsTest.kt
@@ -92,4 +92,76 @@ class DateUtilsTest {
         assertEquals("-", DateUtils.toDisplayDate(0L))
         assertEquals("-", DateUtils.toDisplayDate(-1L))
     }
+
+    @Test
+    fun `parseBirthDateToMillis returns null for blank input`() {
+        assertEquals(null, DateUtils.parseBirthDateToMillis(null))
+        assertEquals(null, DateUtils.parseBirthDateToMillis(""))
+        assertEquals(null, DateUtils.parseBirthDateToMillis("   "))
+    }
+
+    @Test
+    fun `parseBirthDateToMillis returns correct millis (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        val input = "1990-05-15T14:30:00.000Z"
+        val expected = 642781800000L
+        assertEquals(expected, DateUtils.parseBirthDateToMillis(input))
+    }
+
+    @Test
+    fun `parseBirthDateToMillis returns correct millis (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "1990-05-15T14:30:00.000Z"
+        val expected = 642781800000L
+        assertEquals(expected, DateUtils.parseBirthDateToMillis(input))
+    }
+
+    @Test
+    fun `extractBirthYearFromIso returns null for blank input`() {
+        assertEquals(null, DateUtils.extractBirthYearFromIso(null))
+        assertEquals(null, DateUtils.extractBirthYearFromIso(""))
+        assertEquals(null, DateUtils.extractBirthYearFromIso("   "))
+    }
+
+    @Test
+    fun `extractBirthYearFromIso returns correct year (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        val input = "1990-05-15T14:30:00.000Z"
+        val expected = "1990"
+        assertEquals(expected, DateUtils.extractBirthYearFromIso(input))
+    }
+
+    @Test
+    fun `extractBirthYearFromIso returns correct year (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "1990-05-15T14:30:00.000Z"
+        val expected = "1990"
+        assertEquals(expected, DateUtils.extractBirthYearFromIso(input))
+    }
+
+    @Test
+    fun `calculateAgeFromIso returns null for blank input`() {
+        assertEquals(null, DateUtils.calculateAgeFromIso(null))
+        assertEquals(null, DateUtils.calculateAgeFromIso(""))
+        assertEquals(null, DateUtils.calculateAgeFromIso("   "))
+    }
+
+    @Test
+    fun `calculateAgeFromIso returns correct age (Pre-O)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.N
+        // Choosing a very old date so age is always > 0 and consistent across years if we don't care about the exact number,
+        // but for exact number we can just check it doesn't crash and returns a non-null string, or we mock the current date.
+        // Since we can't easily mock Calendar.getInstance() without Robolectric/PowerMock, we'll just check if it's not null and a number.
+        val input = "1990-05-15T14:30:00.000Z"
+        val result = DateUtils.calculateAgeFromIso(input)
+        assert(result != null && result.toInt() > 0)
+    }
+
+    @Test
+    fun `calculateAgeFromIso returns correct age (O and above)`() {
+        DateUtils.sdkInt = Build.VERSION_CODES.O
+        val input = "1990-05-15T14:30:00.000Z"
+        val result = DateUtils.calculateAgeFromIso(input)
+        assert(result != null && result.toInt() > 0)
+    }
 }


### PR DESCRIPTION
This change delegates the internal birth date logic of ProfileActivity into the shared DateUtils utility, ensuring pure-function behavior and adding explicit unit testing for those behaviors.

---
*PR created automatically by Jules for task [7406937200837409020](https://jules.google.com/task/7406937200837409020) started by @dogi*