### PR TITLE
Optimize CourseAdapter chip rendering and listener lifecycles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 508
+        versionName = "0.5.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 508
-        versionName = "0.5.8"
+        versionCode = 509
+        versionName = "0.5.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
@@ -90,10 +90,22 @@ class CourseAdapter(
         position: Int,
         payloads: MutableList<Any>
     ) {
+        val item = getItem(position)
         if (payloads.contains(PROGRESS_UPDATE_PAYLOAD)) {
-            val item = getItem(position)
             if (holder is CourseViewHolder && item is CourseListItem.CourseItemWrapper) {
                 holder.bindDownloadState(item)
+                return
+            }
+        }
+        if (payloads.contains(HEADER_UPDATE_PAYLOAD)) {
+            if (holder is HeaderViewHolder && item is CourseListItem.Header) {
+                holder.onCategorySelected = onCategorySelected
+                holder.bind(item.selectedIndex, item.categories, item.searchQuery, { index ->
+                    selectedCategory = index
+                    applyFilter()
+                }) { query ->
+                    updateSearchQuery(query)
+                }
                 return
             }
         }
@@ -190,9 +202,47 @@ class CourseAdapter(
     class HeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val chipGroup: ChipGroup = itemView.findViewById(R.id.dashboardCoursesCategories)
         private val searchInput: TextInputEditText = itemView.findViewById(R.id.dashboardCoursesSearch)
-        private var watcher: android.text.TextWatcher? = null
-        private var chipListener: ChipGroup.OnCheckedStateChangeListener? = null
+        private var currentCategories: List<CourseCategory>? = null
+        private var currentSelectedIndex: Int = -1
+        private val chipIds = mutableListOf<Int>()
+        private var activeOnSelectionChanged: ((Int) -> Unit)? = null
+        private var activeOnSearchChanged: ((String) -> Unit)? = null
         var onCategorySelected: ((String?) -> Unit)? = null
+
+        private var isBinding = false
+
+        init {
+            searchInput.addTextChangedListener(object : android.text.TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+                override fun afterTextChanged(s: android.text.Editable?) {
+                    if (!isBinding && searchInput.hasFocus()) {
+                        activeOnSearchChanged?.invoke(s?.toString().orEmpty())
+                    }
+                }
+            })
+            searchInput.setOnEditorActionListener { _, actionId, event ->
+                val isEnterKey = event?.keyCode == KeyEvent.KEYCODE_ENTER &&
+                    event.action == KeyEvent.ACTION_UP
+                if (actionId == EditorInfo.IME_ACTION_SEARCH || isEnterKey) {
+                    activeOnSearchChanged?.invoke(searchInput.text?.toString().orEmpty())
+                    hideKeyboard()
+                    true
+                } else {
+                    false
+                }
+            }
+            chipGroup.setOnCheckedStateChangeListener { _, checkedIds ->
+                if (isBinding) return@setOnCheckedStateChangeListener
+                val checkedId = checkedIds.firstOrNull() ?: return@setOnCheckedStateChangeListener
+                val newIndex = chipIds.indexOf(checkedId)
+                if (newIndex >= 0 && newIndex != currentSelectedIndex) {
+                    currentSelectedIndex = newIndex
+                    activeOnSelectionChanged?.invoke(newIndex)
+                    onCategorySelected?.invoke(currentCategories?.getOrNull(newIndex)?.id)
+                }
+            }
+        }
 
         fun bind(
             selectedIndex: Int,
@@ -201,60 +251,48 @@ class CourseAdapter(
             onSelectionChanged: (Int) -> Unit,
             onSearchChanged: (String) -> Unit
         ) {
-            chipGroup.setOnCheckedStateChangeListener(null)
-            chipGroup.removeAllViews()
-            val chipIds = categories.mapIndexed { index, category ->
-                val chip = Chip(itemView.context).apply {
-                    id = View.generateViewId()
-                    text = category.name
-                    isCheckable = true
-                    isChecked = index == selectedIndex
-                    setEnsureMinTouchTargetSize(false)
-                    layoutParams = ChipGroup.LayoutParams(
-                        ChipGroup.LayoutParams.WRAP_CONTENT,
-                        ChipGroup.LayoutParams.WRAP_CONTENT
-                    ).apply {
-                        marginEnd = itemView.resources.getDimensionPixelSize(
-                            R.dimen.dashboard_courses_chip_spacing
-                        )
+            isBinding = true
+            activeOnSelectionChanged = onSelectionChanged
+            activeOnSearchChanged = onSearchChanged
+
+            if (currentCategories != categories) {
+                currentCategories = categories
+                chipGroup.removeAllViews()
+                chipIds.clear()
+                categories.forEachIndexed { index, category ->
+                    val chip = Chip(itemView.context).apply {
+                        id = View.generateViewId()
+                        text = category.name
+                        isCheckable = true
+                        isChecked = index == selectedIndex
+                        setEnsureMinTouchTargetSize(false)
+                        layoutParams = ChipGroup.LayoutParams(
+                            ChipGroup.LayoutParams.WRAP_CONTENT,
+                            ChipGroup.LayoutParams.WRAP_CONTENT
+                        ).apply {
+                            marginEnd = itemView.resources.getDimensionPixelSize(
+                                R.dimen.dashboard_courses_chip_spacing
+                            )
+                        }
                     }
+                    chipGroup.addView(chip)
+                    chipIds.add(chip.id)
                 }
-                chipGroup.addView(chip)
-                chip.id
-            }
-
-            watcher?.let { searchInput.removeTextChangedListener(it) }
-            searchInput.setText(searchText)
-            searchInput.setSelection(searchInput.text?.length ?: 0)
-            watcher = object : android.text.TextWatcher {
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
-                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
-                override fun afterTextChanged(s: android.text.Editable?) {
-                    onSearchChanged(s?.toString().orEmpty())
-                }
-            }
-            searchInput.addTextChangedListener(watcher)
-            searchInput.setOnEditorActionListener { _, actionId, event ->
-                val isEnterKey = event?.keyCode == KeyEvent.KEYCODE_ENTER &&
-                    event.action == KeyEvent.ACTION_UP
-                if (actionId == EditorInfo.IME_ACTION_SEARCH || isEnterKey) {
-                    onSearchChanged(searchInput.text?.toString().orEmpty())
-                    hideKeyboard()
-                    true
-                } else {
-                    false
+                currentSelectedIndex = selectedIndex
+            } else if (currentSelectedIndex != selectedIndex) {
+                currentSelectedIndex = selectedIndex
+                for (i in 0 until chipGroup.childCount) {
+                    val chip = chipGroup.getChildAt(i) as? Chip
+                    chip?.isChecked = i == selectedIndex
                 }
             }
 
-            chipListener = ChipGroup.OnCheckedStateChangeListener { _, checkedIds ->
-                val checkedId = checkedIds.firstOrNull() ?: return@OnCheckedStateChangeListener
-                val newIndex = chipIds.indexOf(checkedId)
-                if (newIndex >= 0 && newIndex != selectedIndex) {
-                    onSelectionChanged(newIndex)
-                    onCategorySelected?.invoke(categories.getOrNull(newIndex)?.id)
-                }
+            if (searchInput.text?.toString() != searchText) {
+                searchInput.setText(searchText)
+                searchInput.setSelection(searchText.length)
             }
-            chipGroup.setOnCheckedStateChangeListener(chipListener)
+
+            isBinding = false
         }
 
         private fun hideKeyboard() {
@@ -405,6 +443,9 @@ class CourseAdapter(
         }
 
         override fun getChangePayload(oldItem: CourseListItem, newItem: CourseListItem): Any? {
+            if (oldItem is CourseListItem.Header && newItem is CourseListItem.Header) {
+                return HEADER_UPDATE_PAYLOAD
+            }
             if (oldItem is CourseListItem.CourseItemWrapper && newItem is CourseListItem.CourseItemWrapper) {
                 if (oldItem.course == newItem.course && oldItem.isDownloaded == newItem.isDownloaded) {
                     return PROGRESS_UPDATE_PAYLOAD
@@ -418,5 +459,6 @@ class CourseAdapter(
         private const val VIEW_TYPE_HEADER = 0
         private const val VIEW_TYPE_ITEM = 1
         private const val PROGRESS_UPDATE_PAYLOAD = "PROGRESS_UPDATE"
+        private const val HEADER_UPDATE_PAYLOAD = "HEADER_UPDATE"
     }
 }


### PR DESCRIPTION
Optimized `CourseAdapter` to prevent recreating the entire chip header set on every update when categories haven't changed. \n\nListener configurations were shifted to the initialization block, preventing redundant TextWatcher/ChipGroup updates on rebinding. The payload mechanism was expanded to separate Header state diffs from regular Row progression diffs, minimizing lifecycle thrash during rapid course view filtering.

---
*PR created automatically by Jules for task [990314974374842467](https://jules.google.com/task/990314974374842467) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course list updates when categories or search criteria change.
  * Category selections and search text now remain synchronized during list refreshes.
  * Download progress updates continue to display accurately without disrupting the course header.
  * Reduced unnecessary visual refreshes for smoother navigation and interaction.

* **Release**
  * Updated the app version to 0.5.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->