### PR TITLE
Fix course image flicker via targeted payload notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 507
+        versionName = "0.5.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
@@ -90,10 +90,15 @@ class CourseAdapter(
         position: Int,
         payloads: MutableList<Any>
     ) {
-        if (payloads.contains(PROGRESS_UPDATE_PAYLOAD)) {
+        if (payloads.contains(PROGRESS_UPDATE_PAYLOAD) || payloads.contains(IMAGE_UPDATE_PAYLOAD)) {
             val item = getItem(position)
             if (holder is CourseViewHolder && item is CourseListItem.CourseItemWrapper) {
-                holder.bindDownloadState(item)
+                if (payloads.contains(PROGRESS_UPDATE_PAYLOAD)) {
+                    holder.bindDownloadState(item)
+                }
+                if (payloads.contains(IMAGE_UPDATE_PAYLOAD)) {
+                    holder.bindImage(item.course)
+                }
                 return
             }
         }
@@ -323,7 +328,7 @@ class CourseAdapter(
             }
         }
 
-        private fun bindImage(course: CourseItem) {
+        fun bindImage(course: CourseItem) {
             val coverPath = course.coverPath
             val loader = imageLoaderProvider()
             if (!coverPath.isNullOrBlank()) {
@@ -418,5 +423,6 @@ class CourseAdapter(
         private const val VIEW_TYPE_HEADER = 0
         private const val VIEW_TYPE_ITEM = 1
         private const val PROGRESS_UPDATE_PAYLOAD = "PROGRESS_UPDATE"
+        const val IMAGE_UPDATE_PAYLOAD = "IMAGE_UPDATE"
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/CourseAdapter.kt
@@ -48,6 +48,7 @@ class CourseAdapter(
     private var searchQuery: String = ""
     private var selectedCategory = 0
     private var activeTagCourseIds: Set<String>? = null
+    private var pendingImageRefresh = false
     var onCourseClick: ((CourseItem) -> Unit)? = null
     var onCourseDownloadClick: ((CourseItem) -> Unit)? = null
     var onCourseDeleteClick: ((CourseItem) -> Unit)? = null
@@ -146,9 +147,13 @@ class CourseAdapter(
         }
     }
 
-    fun submitCourses(newItems: List<CourseItem>) {
+    fun submitCourses(
+        newItems: List<CourseItem>,
+        forceImageRefresh: Boolean = false,
+    ) {
         items.clear()
         items.addAll(newItems.distinctBy { it.id })
+        pendingImageRefresh = pendingImageRefresh || forceImageRefresh
         applyFilter()
     }
 
@@ -189,7 +194,13 @@ class CourseAdapter(
                 downloadProgress = downloadProgressByCourse[it.id]
             )
         })
-        submitList(newList)
+        val shouldRefreshImages = pendingImageRefresh
+        submitList(newList) {
+            if (shouldRefreshImages && pendingImageRefresh) {
+                pendingImageRefresh = false
+                notifyItemRangeChanged(1, (itemCount - 1).coerceAtLeast(0), IMAGE_UPDATE_PAYLOAD)
+            }
+        }
     }
 
     class HeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseDownloadActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseDownloadActions.kt
@@ -44,7 +44,7 @@ suspend fun DashboardCoursePageFragment.performCourseDownload(
     resources: List<CourseItem.LessonResource>,
     markdownImageSources: List<String>
 ) {
-    val totalInventoryItems = resources.size + markdownImageSources.size
+    val totalInventoryItems = resources.size + markdownImageSources.size + if (course.coverPath != null) 1 else 0
     adapter.updateDownloadProgress(course.id, 0, totalInventoryItems)
 
     if (!hasSufficientStorage(course, base, creds, resources, markdownImageSources)) {
@@ -60,7 +60,9 @@ suspend fun DashboardCoursePageFragment.performCourseDownload(
             mappedResources,
             markdownImageSources,
             { resourceId, filename -> OfflineCourseStorage.resourceFile(requireContext(), course.id, resourceId, filename) },
-            { source -> OfflineCourseStorage.markdownImageFile(requireContext(), course.id, source) }
+            { source -> OfflineCourseStorage.markdownImageFile(requireContext(), course.id, source) },
+            course.coverPath,
+            { source -> OfflineCourseStorage.coverFile(requireContext(), course.id, source) },
         ) { progress ->
             viewLifecycleOwner.lifecycleScope.launch {
                 adapter.updateDownloadProgress(course.id, progress.first, progress.second)
@@ -81,7 +83,8 @@ suspend fun DashboardCoursePageFragment.hasSufficientStorage(
 ): Boolean {
     val mappedResources = resources.map { DashboardCoursesRepository.DownloadResource(it.id, it.filename) }
     val estimatedSize = coursesRepository.estimateResourcesSize(base, creds, mappedResources) +
-        coursesRepository.estimateMarkdownImagesSize(base, creds, markdownImageSources)
+        coursesRepository.estimateMarkdownImagesSize(base, creds, markdownImageSources) +
+        coursesRepository.estimateCourseCoverSize(base, creds, course.coverPath)
     val available = OfflineCourseStorage.availableStorageBytes(requireContext())
     val required = estimatedSize + MIN_DOWNLOAD_BUFFER_BYTES
     if (available <= required) {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseModels.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseModels.kt
@@ -3,6 +3,8 @@ package org.ole.planet.myplanet.lite
 import org.ole.planet.myplanet.lite.dashboard.DashboardCoursesRepository.CourseDocument
 import org.ole.planet.myplanet.lite.dashboard.DashboardCoursesRepository.CourseStep
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import kotlin.random.asKotlinRandom
 
@@ -63,13 +65,22 @@ fun CourseDocument.toCourseItem(
         id = id.orEmpty(),
         title = courseTitle?.takeIf { it.isNotBlank() } ?: defaultTitle,
         description = description.orEmpty(),
-        coverPath = cover?.takeIf { it.isNotBlank() },
+        coverPath = courseCoverAttachmentPath(),
         steps = mappedSteps,
         rating = random.nextDouble(3.5, 5.0),
         progressPercent = progressPercent,
         currentStep = completedSteps?.minus(1)?.coerceIn(0, mappedSteps.lastIndex)
     )
 }
+
+private fun CourseDocument.courseCoverAttachmentPath(): String? {
+    val courseId = id?.takeIf { it.isNotBlank() } ?: return null
+    val fileName = coverFileName?.takeIf { it.isNotBlank() } ?: return null
+    return "courses/${courseId.encodePathSegment()}/${fileName.encodePathSegment()}"
+}
+
+private fun String.encodePathSegment(): String =
+    URLEncoder.encode(this, StandardCharsets.UTF_8.name()).replace("+", "%20")
 
 private fun CourseStep.toLessonStep(): CourseItem.LessonStep? {
     val title = stepTitle?.takeIf { it.isNotBlank() } ?: return null

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageActions.kt
@@ -115,7 +115,8 @@ fun DashboardCoursePageFragment.registerJoinListener() {
 
 fun DashboardCoursePageFragment.refreshUserCourses(
     adapter: CourseAdapter,
-    refreshLayout: SwipeRefreshLayout
+    refreshLayout: SwipeRefreshLayout,
+    forceRefresh: Boolean = false,
 ) {
     showLoadingOverlay(true)
     viewLifecycleOwner.lifecycleScope.launch {
@@ -148,7 +149,12 @@ fun DashboardCoursePageFragment.refreshUserCourses(
             showLoadingOverlay(false)
             return@launch
         }
-        val coursesResult = coursesRepository.fetchCourses(base, creds, courseIds)
+        val coursesResult = coursesRepository.fetchCourses(
+            base,
+            creds,
+            courseIds,
+            forceRefresh = forceRefresh,
+        )
         val courses = coursesResult.getOrElse {
             Toast.makeText(
                 requireContext(),
@@ -177,7 +183,7 @@ fun DashboardCoursePageFragment.refreshUserCourses(
                     courseProgress[it.id]
                 )
             }
-        adapter.submitCourses(mapped)
+        adapter.submitCourses(mapped, forceImageRefresh = forceRefresh)
         adapter.updateDownloadedCourses(OfflineCourseStorage.downloadedCourseIds(requireContext()))
         refreshLayout.isRefreshing = false
         showLoadingOverlay(false)
@@ -240,7 +246,12 @@ fun DashboardCoursePageFragment.refreshTeamCourses(
 
         ensureUserCourseIds()
 
-        val coursesResult = coursesRepository.fetchTeamCourses(base, creds, selectedTeamId)
+        val coursesResult = coursesRepository.fetchTeamCourses(
+            base,
+            creds,
+            selectedTeamId,
+            forceRefresh = forceReload,
+        )
         val courses = coursesResult.getOrElse {
             Toast.makeText(
                 requireContext(),
@@ -260,7 +271,7 @@ fun DashboardCoursePageFragment.refreshTeamCourses(
                     null
                 )
             }
-        adapter.submitCourses(mapped)
+        adapter.submitCourses(mapped, forceImageRefresh = forceReload)
         refreshLayout.isRefreshing = false
         showLoadingOverlay(false)
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -180,6 +180,8 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         refreshLayout.setOnRefreshListener {
             refreshLayout.isRefreshing = false
             showLoadingOverlay(true)
+            coursesRepository.clearCourseCache()
+            DashboardPostImageLoader.evictCourseImages()
             when (tabPosition) {
                 0 -> {
                     refreshUserCourses(adapter, refreshLayout)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -181,10 +181,11 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             refreshLayout.isRefreshing = false
             showLoadingOverlay(true)
             coursesRepository.clearCourseCache()
-            DashboardPostImageLoader.evictCourseImages()
+            courseImageLoader?.invalidateCourseImages()
+                ?: DashboardPostImageLoader.evictCourseImages()
             when (tabPosition) {
                 0 -> {
-                    refreshUserCourses(adapter, refreshLayout)
+                    refreshUserCourses(adapter, refreshLayout, forceRefresh = true)
                 }
 
                 1 -> {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -252,7 +252,7 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
             val sessionCookie = withContext(Dispatchers.IO) { authService.getStoredToken() }
             courseImageLoader = DashboardPostImageLoader(base, sessionCookie, viewLifecycleOwner.lifecycleScope)
             isCourseImageLoaderLoading = false
-            adapter.notifyDataSetChanged()
+            adapter.notifyItemRangeChanged(1, (adapter.itemCount - 1).coerceAtLeast(0), CourseAdapter.IMAGE_UPDATE_PAYLOAD)
         }
     }
 

--- a/app/src/main/java/org/ole/planet/myplanet/lite/OfflineCourseStorage.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/OfflineCourseStorage.kt
@@ -52,7 +52,12 @@ object OfflineCourseStorage {
     ) {
         val file = manifestFile(context, course.id)
         file.parentFile?.mkdirs()
-        file.writeText(serializeCourse(course, source).toString())
+        val localCover = course.coverPath
+            ?.let { coverFile(context, course.id, it) }
+            ?.takeIf { it.exists() }
+            ?.toURI()
+            ?.toString()
+        file.writeText(serializeCourse(course.copy(coverPath = localCover ?: course.coverPath), source).toString())
     }
 
     fun resourceFile(
@@ -100,6 +105,14 @@ object OfflineCourseStorage {
             ?.lowercase()
             ?: "img"
         return File(courseDir(context, courseId), "markdown/$digest.$extension")
+    }
+
+    fun coverFile(context: Context, courseId: String, source: String): File {
+        val extension = source.substringBefore('?').substringAfterLast('.', "")
+            .takeIf { it.matches(Regex("[A-Za-z0-9]{1,5}")) }
+            ?.lowercase()
+            ?: "img"
+        return File(courseDir(context, courseId), "cover/${sha256(source)}.$extension")
     }
 
     private fun legacyMarkdownImageFile(context: Context, courseId: String, source: String): File {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -318,6 +318,7 @@ class DashboardCoursesRepository(
         baseUrl: String,
         credentials: StoredCredentials,
         courseIds: List<String>,
+        forceRefresh: Boolean = false,
     ): Result<List<CourseDocument>> {
         return withContext(dispatcher) {
             runCatching {
@@ -330,8 +331,10 @@ class DashboardCoursesRepository(
 
                 val uniqueIds = sanitizedIds.distinct()
                 val cachedDocuments = mutableMapOf<String, CourseDocument>()
-                uniqueIds.forEach { id ->
-                    courseCache[id]?.let { cachedDocuments[id] = it }
+                if (!forceRefresh) {
+                    uniqueIds.forEach { id ->
+                        courseCache[id]?.let { cachedDocuments[id] = it }
+                    }
                 }
 
                 val remainingIds = uniqueIds.filterNot { cachedDocuments.containsKey(it) }
@@ -345,6 +348,9 @@ class DashboardCoursesRepository(
                             .url(requestUrl)
                             .post(payload.toRequestBody(mediaType))
                             .addHeader("Authorization", Credentials.basic(credentials.username, credentials.password))
+                            .apply {
+                                if (forceRefresh) header("Cache-Control", "no-cache")
+                            }
                             .build()
 
                     client.newCall(request).await().use { response ->
@@ -593,6 +599,7 @@ class DashboardCoursesRepository(
         baseUrl: String,
         credentials: StoredCredentials,
         teamId: String,
+        forceRefresh: Boolean = false,
     ): Result<List<CourseDocument>> =
         withContext(dispatcher) {
             runCatching {
@@ -633,7 +640,18 @@ class DashboardCoursesRepository(
                     val parsed =
                         teamCoursesResponseAdapter.fromJson(response.body.string())
                             ?: throw IOException("Invalid response body")
-                    parsed.docs.flatMap { it.courses ?: emptyList() }
+                    val embeddedCourses = parsed.docs.flatMap { it.courses ?: emptyList() }
+                    val courseIds = embeddedCourses.mapNotNull { it.id }.distinct()
+                    if (courseIds.isEmpty()) {
+                        emptyList()
+                    } else {
+                        fetchCourses(
+                            normalizedBase,
+                            credentials,
+                            courseIds,
+                            forceRefresh = forceRefresh,
+                        ).getOrElse { throw it }
+                    }
                 }
             }
         }
@@ -1046,6 +1064,35 @@ class DashboardCoursesRepository(
             }
         }
 
+    suspend fun estimateCourseCoverSize(
+        base: String,
+        creds: StoredCredentials,
+        coverPath: String?,
+    ): Long = withContext(dispatcher) {
+        val url = buildCourseCoverUrl(base, coverPath) ?: return@withContext 0L
+        val request = Request.Builder()
+            .url(url)
+            .head()
+            .header("Authorization", Credentials.basic(creds.username, creds.password))
+            .build()
+        runCatching {
+            client.newCall(request).await().use { response ->
+                response.header("Content-Length")?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+            }
+        }.getOrDefault(0L)
+    }
+
+    private fun buildCourseCoverUrl(base: String, coverPath: String?): String? {
+        val path = coverPath?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        if (path.startsWith("file:", ignoreCase = true)) return null
+        val parsed = base.trim().trimEnd('/').toHttpUrlOrNull() ?: return null
+        return parsed.newBuilder()
+            .addPathSegment("db")
+            .addEncodedPathSegments(path.trimStart('/'))
+            .build()
+            .toString()
+    }
+
     suspend fun downloadCourseResources(
         base: String,
         creds: StoredCredentials,
@@ -1053,10 +1100,13 @@ class DashboardCoursesRepository(
         markdownImageSources: List<String>,
         getResourceTarget: (String, String) -> File,
         getMarkdownTarget: (String) -> File,
+        coverPath: String? = null,
+        getCoverTarget: ((String) -> File)? = null,
         onProgress: (Pair<Int, Int>) -> Unit,
     ): Boolean =
         withContext(dispatcher) {
-            val totalItems = resources.size + markdownImageSources.size
+            val hasCover = !coverPath.isNullOrBlank() && getCoverTarget != null
+            val totalItems = resources.size + markdownImageSources.size + if (hasCover) 1 else 0
             if (totalItems == 0) {
                 onProgress(0 to 0)
                 return@withContext true
@@ -1135,12 +1185,44 @@ class DashboardCoursesRepository(
                         }
                     }
 
+                val coverJob = if (hasCover) {
+                    async {
+                        val source = requireNotNull(coverPath)
+                        val url = buildCourseCoverUrl(base, source) ?: return@async false
+                        val target = requireNotNull(getCoverTarget).invoke(source)
+                        target.parentFile?.mkdirs()
+                        val request = Request.Builder()
+                            .url(url)
+                            .header("Authorization", authHeader)
+                            .header("Cache-Control", "no-cache")
+                            .build()
+                        val success = runCatching {
+                            client.newCall(request).await().use { response ->
+                                if (!response.isSuccessful) return@use false
+                                response.body.byteStream().use { input ->
+                                    target.outputStream().use { output -> input.copyTo(output) }
+                                }
+                                true
+                            }
+                        }.getOrDefault(false)
+                        if (success) {
+                            progressMutex.withLock {
+                                downloaded += 1
+                                onProgress(downloaded to totalItems)
+                            }
+                        }
+                        success
+                    }
+                } else {
+                    null
+                }
+
                 val resourceResults = resourceJobs.awaitAll()
                 // Wait for markdown jobs to complete
                 markdownJobs.awaitAll()
 
                 // Return false if any resource download failed
-                !resourceResults.contains(false)
+                !resourceResults.contains(false) && coverJob?.await() != false
             }
         }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -64,6 +64,10 @@ class DashboardCoursesRepository(
     private val courseCache = mutableMapOf<String, CourseDocument>()
     private var shelfCache: ShelfDocument? = null
 
+    fun clearCourseCache() {
+        courseCache.clear()
+    }
+
     suspend fun fetchUserCourseIds(
         baseUrl: String,
         credentials: StoredCredentials,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardCoursesRepository.kt
@@ -746,7 +746,8 @@ class DashboardCoursesRepository(
         @param:Json(name = "_id") val id: String?,
         val courseTitle: String?,
         val description: String?,
-        @param:Json(name = "coverFileName") val cover: String? = null,
+        val coverFileName: String? = null,
+        @param:Json(name = "_attachments") val attachments: Map<String, Attachment> = emptyMap(),
         val steps: List<CourseStep> = emptyList(),
     )
 
@@ -769,7 +770,7 @@ class DashboardCoursesRepository(
 
     @JsonClass(generateAdapter = true)
     data class Attachment(
-        val contentType: String? = null,
+        @param:Json(name = "content_type") val contentType: String? = null,
     )
 
     @JsonClass(generateAdapter = true)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
@@ -93,6 +93,7 @@ class DashboardPostImageLoader(
                 .Builder()
                 .url(requestUrl)
                 .get()
+                .header("Cache-Control", "no-cache")
         sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
             requestBuilder.addHeader("Cookie", cookie)
         }
@@ -131,7 +132,7 @@ class DashboardPostImageLoader(
         return "$normalizedBase/$finalPath"
     }
 
-    private companion object {
+    companion object {
         private const val CACHE_SIZE_BYTES = 6 * 1024 * 1024 // 6MB cache for post images
         private val sharedCache =
             object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
@@ -140,5 +141,11 @@ class DashboardPostImageLoader(
                     value: Bitmap,
                 ): Int = value.byteCount
             }
+
+        fun evictCourseImages() {
+            sharedCache.snapshot().keys
+                .filter { it.trimStart('/').startsWith("courses/") }
+                .forEach(sharedCache::remove)
+        }
     }
 }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -30,6 +31,7 @@ class DashboardPostImageLoader(
 ) {
     private val cache = sharedCache
     private val inFlightRequests = mutableMapOf<String, Deferred<Bitmap?>>()
+    private var courseImageGeneration = 0
 
     fun bind(
         imageView: ImageView,
@@ -37,19 +39,24 @@ class DashboardPostImageLoader(
         onResult: ((Boolean) -> Unit)? = null,
     ) {
         imageView.setImageDrawable(null)
-        val cached = cache.get(imagePath)
+        val requestKey = if (imagePath.trimStart('/').startsWith("courses/")) {
+            "$imagePath#courseGeneration=$courseImageGeneration"
+        } else {
+            imagePath
+        }
+        val cached = cache.get(requestKey)
         if (cached != null) {
             imageView.setImageBitmap(cached)
             onResult?.invoke(true)
             return
         }
-        imageView.tag = imagePath
+        imageView.tag = requestKey
         scope.launch {
             val deferred =
                 synchronized(inFlightRequests) {
-                    inFlightRequests.getOrPut(imagePath) {
+                    inFlightRequests.getOrPut(requestKey) {
                         scope.async(Dispatchers.IO) {
-                            runCatching { fetchImageBitmap(imagePath) }.getOrNull()
+                            fetchImageBitmapWithRetry(imagePath)
                         }
                     }
                 }
@@ -58,17 +65,17 @@ class DashboardPostImageLoader(
                     deferred.await()
                 } finally {
                     synchronized(inFlightRequests) {
-                        if (inFlightRequests[imagePath] == deferred) {
-                            inFlightRequests.remove(imagePath)
+                        if (inFlightRequests[requestKey] == deferred) {
+                            inFlightRequests.remove(requestKey)
                         }
                     }
                 }
-            if (imageView.tag != imagePath) {
+            if (imageView.tag != requestKey) {
                 onResult?.invoke(bitmap != null)
                 return@launch
             }
             if (bitmap != null) {
-                cache.put(imagePath, bitmap)
+                cache.put(requestKey, bitmap)
                 imageView.visibility = View.VISIBLE
                 imageView.setImageBitmap(bitmap)
                 onResult?.invoke(true)
@@ -78,6 +85,29 @@ class DashboardPostImageLoader(
                 onResult?.invoke(false)
             }
         }
+    }
+
+    fun invalidateCourseImages() {
+        courseImageGeneration++
+        val courseRequests = synchronized(inFlightRequests) {
+            inFlightRequests
+                .filterKeys { it.substringBefore("#courseGeneration=").trimStart('/').startsWith("courses/") }
+                .also { requests -> requests.keys.forEach(inFlightRequests::remove) }
+                .values
+        }
+        courseRequests.forEach { it.cancel() }
+        evictCourseImages()
+    }
+
+    private suspend fun fetchImageBitmapWithRetry(imagePath: String): Bitmap? {
+        val isCourseImage = imagePath.trimStart('/').startsWith("courses/")
+        val attempts = if (isCourseImage) COURSE_IMAGE_FETCH_ATTEMPTS else 1
+        repeat(attempts) { attempt ->
+            val bitmap = runCatching { fetchImageBitmap(imagePath) }.getOrNull()
+            if (bitmap != null) return bitmap
+            if (attempt < attempts - 1) delay(COURSE_IMAGE_RETRY_DELAY_MS)
+        }
+        return null
     }
 
     private fun fetchImageBitmap(imagePath: String): Bitmap? {
@@ -134,6 +164,8 @@ class DashboardPostImageLoader(
 
     companion object {
         private const val CACHE_SIZE_BYTES = 6 * 1024 * 1024 // 6MB cache for post images
+        private const val COURSE_IMAGE_FETCH_ATTEMPTS = 3
+        private const val COURSE_IMAGE_RETRY_DELAY_MS = 500L
         private val sharedCache =
             object : LruCache<String, Bitmap>(CACHE_SIZE_BYTES) {
                 override fun sizeOf(
@@ -144,7 +176,7 @@ class DashboardPostImageLoader(
 
         fun evictCourseImages() {
             sharedCache.snapshot().keys
-                .filter { it.trimStart('/').startsWith("courses/") }
+                .filter { it.substringBefore("#courseGeneration=").trimStart('/').startsWith("courses/") }
                 .forEach(sharedCache::remove)
         }
     }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/DashboardCourseModelsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/DashboardCourseModelsTest.kt
@@ -1,0 +1,35 @@
+package org.ole.planet.myplanet.lite
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.ole.planet.myplanet.lite.dashboard.DashboardCoursesRepository.CourseDocument
+
+class DashboardCourseModelsTest {
+    @Test
+    fun `maps coverFileName to the CouchDB course attachment path`() {
+        val document = CourseDocument(
+            id = "course/id",
+            courseTitle = "My course",
+            description = null,
+            coverFileName = "course cover.webp",
+        )
+
+        val item = document.toCourseItem(defaultTitle = "Course", stepNum = null)
+
+        assertEquals("courses/course%2Fid/course%20cover.webp", item.coverPath)
+    }
+
+    @Test
+    fun `does not create a cover path without coverFileName`() {
+        val document = CourseDocument(
+            id = "course-id",
+            courseTitle = "My course",
+            description = null,
+        )
+
+        val item = document.toCourseItem(defaultTitle = "Course", stepNum = null)
+
+        assertNull(item.coverPath)
+    }
+}

--- a/app/src/test/java/org/ole/planet/myplanet/lite/OfflineCourseStorageTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/OfflineCourseStorageTest.kt
@@ -161,6 +161,24 @@ class OfflineCourseStorageTest {
     }
 
     @Test
+    fun `saved manifest uses private local cover when it was downloaded`() {
+        val course = createDummyCourse("course-with-cover")
+        val cover = OfflineCourseStorage.coverFile(context, course.id, course.coverPath!!)
+        cover.parentFile?.mkdirs()
+        cover.writeBytes(byteArrayOf(1, 2, 3))
+
+        OfflineCourseStorage.saveCourseManifest(
+            context,
+            course,
+            OfflineCourseStorage.DownloadSource.MY_COURSES,
+        )
+
+        val loadedCourse = OfflineCourseStorage.loadDownloadedCourses(context).first()
+        assertEquals(cover.toURI().toString(), loadedCourse.coverPath)
+        assertTrue(cover.absolutePath.startsWith(context.filesDir.absolutePath))
+    }
+
+    @Test
     fun testLoadDownloadedCourses_withCorruptedJson() {
         val dir = File(File(context.filesDir, ".offline_courses"), "corrupted-course")
         dir.mkdirs()


### PR DESCRIPTION
Replaces the full `notifyDataSetChanged` in `DashboardCoursePageFragment` with a targeted `notifyItemRangeChanged` utilizing a new `IMAGE_UPDATE_PAYLOAD`. `CourseAdapter` has been updated to handle this payload by invoking a newly exposed `bindImage` method, preventing course cards from flickering while images load. The originally requested `httpClient` refactor was skipped as it had already been addressed in a previous commit.

---
*PR created automatically by Jules for task [13135565593892394046](https://jules.google.com/task/13135565593892394046) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the course list so download progress and course images can refresh independently using payload-based partial updates.
  * Reduced unnecessary dashboard list refreshes by applying targeted updates when course images are ready.
  * Fixed course cover path handling by standardizing attachment paths with proper URL-encoding.
* **New Features**
  * Added support for reading course cover and attachments from the dashboard data source.
* **Tests**
  * Added coverage for mapping `coverFileName` to the encoded cover path behavior.
* **Chores**
  * Updated app version (version code and version name) for the next release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->