### PR TITLE
🧪 [testing improvement] Add test for DashboardTeamsOperations network failure

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperationsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperationsTest.kt
@@ -7,9 +7,11 @@ import java.util.concurrent.ConcurrentHashMap
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -180,5 +182,28 @@ class DashboardTeamsOperationsTest {
             )
         }
         assertTrue(exception.message?.startsWith("Unexpected response") == true)
+    }
+
+    @Test
+    fun fetchUserProfile_networkFailure() {
+        mockWebServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST))
+
+        val method = DashboardTeamsOperations::class.java.getDeclaredMethod(
+            "fetchUserProfile",
+            String::class.java,
+            String::class.java,
+            StoredCredentials::class.java,
+            String::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(
+            operations,
+            mockWebServer.url("/").toString(),
+            "testuser",
+            StoredCredentials("testuser", "pass"),
+            "cookie"
+        )
+        assertNull(result)
     }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing try/catch test for network request failures in `DashboardTeamsOperations`.
📊 **Coverage:** The private method `fetchUserProfile` is now tested for network failure by using `MockWebServer` with `SocketPolicy.DISCONNECT_AFTER_REQUEST`. It asserts that when the network request throws an `IOException`, the method catches it and returns `null`.
✨ **Result:** Increased test coverage for error conditions.

---
*PR created automatically by Jules for task [17675947195213747276](https://jules.google.com/task/17675947195213747276) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for handling network failures while fetching a user profile.
  * Verified that a disconnected network request produces a null result instead of causing unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->