### PR TITLE
🧹 Refactor ResourceSyncService to reduce method length and duplication

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 491
+        versionName = "0.4.91"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
@@ -35,21 +35,7 @@ internal class ResourceSyncService(
         val page = result.getOrDefault(emptyList())
         val mutableKeys = existingKeys.toMutableSet()
         val items = page.map { resource ->
-            val id = resource.id?.trim().orEmpty()
-            val filename = resource.filename?.trim().orEmpty()
-            ResourceUi(
-                id = id,
-                filename = filename,
-                name = resource.title?.takeIf { it.isNotBlank() }
-                    ?: resource.filename?.takeIf { it.isNotBlank() }
-                    ?: "-",
-                type = resource.mediaType?.uppercase(Locale.ROOT) ?: "PDF",
-                date = DateUtils.toDisplayDate(resource.createdDate),
-                createdDate = resource.createdDate,
-                isDownloaded = downloadService.findLocalResourceFile(id, filename, isTeamResource = false)?.exists() == true,
-                isDownloadable = ResourceSearchEngine.parseIsDownloadable(resource.isDownloadable),
-                isTeamResource = false
-            )
+            mapToUiModel(resource, isTeamResource = false)
         }.filter { item ->
             val key = item.resourceIdentityKey()
             if (mutableKeys.contains(key)) false else {
@@ -88,21 +74,7 @@ internal class ResourceSyncService(
         )
         val page = result.getOrDefault(emptyList())
         val allRemoteItems = page.map { resource ->
-            val id = resource.id?.trim().orEmpty()
-            val filename = resource.filename?.trim().orEmpty()
-            ResourceUi(
-                id = id,
-                filename = filename,
-                name = resource.title?.takeIf { it.isNotBlank() }
-                    ?: resource.filename?.takeIf { it.isNotBlank() }
-                    ?: "-",
-                type = resource.mediaType?.uppercase(Locale.ROOT) ?: "PDF",
-                date = DateUtils.toDisplayDate(resource.createdDate),
-                createdDate = resource.createdDate,
-                isDownloaded = downloadService.findLocalResourceFile(id, filename, isTeamResource = true)?.exists() == true,
-                isDownloadable = ResourceSearchEngine.parseIsDownloadable(resource.isDownloadable),
-                isTeamResource = true
-            )
+            mapToUiModel(resource, isTeamResource = true)
         }
         val remoteKeys = allRemoteItems.map { it.resourceIdentityKey() }.toSet()
         val downloaded = downloadedResources.filter { remoteKeys.contains(it.resourceIdentityKey()) }
@@ -141,6 +113,27 @@ internal class ResourceSyncService(
                 }
             },
             onFailure = { false }
+        )
+    }
+
+    private fun mapToUiModel(
+        resource: DashboardResourcesRepository.ResourceDocument,
+        isTeamResource: Boolean
+    ): ResourceUi {
+        val id = resource.id?.trim().orEmpty()
+        val filename = resource.filename?.trim().orEmpty()
+        return ResourceUi(
+            id = id,
+            filename = filename,
+            name = resource.title?.takeIf { it.isNotBlank() }
+                ?: resource.filename?.takeIf { it.isNotBlank() }
+                ?: "-",
+            type = resource.mediaType?.uppercase(Locale.ROOT) ?: "PDF",
+            date = DateUtils.toDisplayDate(resource.createdDate),
+            createdDate = resource.createdDate,
+            isDownloaded = downloadService.findLocalResourceFile(id, filename, isTeamResource = isTeamResource)?.exists() == true,
+            isDownloadable = ResourceSearchEngine.parseIsDownloadable(resource.isDownloadable),
+            isTeamResource = isTeamResource
         )
     }
 }


### PR DESCRIPTION
🎯 **What:** Extracted duplicated logic mapping a remote resource to a `ResourceUi` inside `fetchTeamResources` and `fetchCommunityResources` into a reusable private method `mapToUiModel`.
💡 **Why:** Reduces the overall length of `fetchTeamResources` and `fetchCommunityResources`, making them more maintainable, readable, and adhering to DRY principles.
✅ **Verification:** Verified using `git diff --staged` that the extracted logic matched exactly. Ran `./gradlew lint app:lintDebug` (successful) and `./gradlew testDebugUnitTest` (all tests passed), confirming no regressions.
✨ **Result:** Improved maintainability and readability by eliminating duplication and reducing method length.

---
*PR created automatically by Jules for task [14680670971161731316](https://jules.google.com/task/14680670971161731316) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated resource processing to provide consistent display details across community and team resources.
  * Preserved existing behavior for download status, resource naming, types, dates, and team-resource identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->