### PR TITLE
🧹 Refactor openSurvey method in DeepLinkResolverActivity

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DeepLinkResolverActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerCatalog
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepositoryProvider
 import org.ole.planet.myplanet.lite.util.IntentUtils
 
@@ -158,26 +159,40 @@ class DeepLinkResolverActivity : ComponentActivity() {
                 finish()
                 return@launch
             }
-            DashboardServerCatalog.addObservedServer(
-                context = applicationContext,
-                baseUrl = link.baseUrl,
-                displayName = DashboardServerCatalog.displayNameFromBaseUrl(link.baseUrl),
+            launchSurveyWizard(
+                link = link,
+                document = document,
+                teamName = publicSurvey.team?.name,
+                includeUserContext = includeUserContext,
             )
-            val nextIntent =
-                SurveyWizardActivity
-                    .newIntent(
-                        context = this@DeepLinkResolverActivity,
-                        document = document,
-                        teamId = link.teamId,
-                        teamName = publicSurvey.team?.name,
-                        baseUrl = link.baseUrl,
-                        includeUserContext = includeUserContext,
-                    ).apply {
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    }
-            startActivity(nextIntent)
-            finish()
         }
+    }
+
+    private fun launchSurveyWizard(
+        link: IntentUtils.DeepLinkSurvey,
+        document: DashboardSurveysRepository.SurveyDocument,
+        teamName: String?,
+        includeUserContext: Boolean,
+    ) {
+        DashboardServerCatalog.addObservedServer(
+            context = applicationContext,
+            baseUrl = link.baseUrl,
+            displayName = DashboardServerCatalog.displayNameFromBaseUrl(link.baseUrl),
+        )
+        val nextIntent =
+            SurveyWizardActivity
+                .newIntent(
+                    context = this@DeepLinkResolverActivity,
+                    document = document,
+                    teamId = link.teamId,
+                    teamName = teamName,
+                    baseUrl = link.baseUrl,
+                    includeUserContext = includeUserContext,
+                ).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+        startActivity(nextIntent)
+        finish()
     }
 
     companion object {


### PR DESCRIPTION
🎯 **What:** Extracted the survey launch logic from `openSurvey` into a new `launchSurveyWizard` helper method in `DeepLinkResolverActivity`.
💡 **Why:** To improve code maintainability and readability by breaking down a moderately long method.
✅ **Verification:** Ran `./gradlew compileDebugKotlin`, verified test suite (`testDebugUnitTest --tests '*DeepLinkResolverActivityTest*'`), and `./gradlew lint app:lintDebug`. Tested changes via `git diff --staged` and Code Review.
✨ **Result:** A cleaner, more readable `openSurvey` method with logic appropriately separated without any behavioral changes.

---
*PR created automatically by Jules for task [9822076995751068126](https://jules.google.com/task/9822076995751068126) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined survey deep-link handling while preserving existing navigation behavior.
  * Survey links continue to open the appropriate survey wizard with the same context and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->