### PR TITLE
🧹 [Refactor] Extract repetitive error handling into reusable helper functions in DashboardCoursePageActions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 508
+        versionName = "0.5.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageActions.kt
@@ -113,6 +113,20 @@ fun DashboardCoursePageFragment.registerJoinListener() {
     }
 }
 
+fun DashboardCoursePageFragment.showErrorToast(error: Throwable?) {
+    Toast.makeText(
+        requireContext(),
+        error?.message ?: getString(R.string.dashboard_courses_loading_error),
+        Toast.LENGTH_SHORT
+    ).show()
+}
+
+fun DashboardCoursePageFragment.handleLoadingError(error: Throwable?, refreshLayout: SwipeRefreshLayout?) {
+    showErrorToast(error)
+    refreshLayout?.isRefreshing = false
+    showLoadingOverlay(false)
+}
+
 fun DashboardCoursePageFragment.refreshUserCourses(
     adapter: CourseAdapter,
     refreshLayout: SwipeRefreshLayout
@@ -131,13 +145,7 @@ fun DashboardCoursePageFragment.refreshUserCourses(
         }
         val courseIdsResult = coursesRepository.fetchUserCourseIds(base, creds)
         val courseIds = courseIdsResult.getOrElse {
-            Toast.makeText(
-                requireContext(),
-                it.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
-            refreshLayout.isRefreshing = false
-            showLoadingOverlay(false)
+            handleLoadingError(it, refreshLayout)
             return@launch
         }
         myCourseIds = courseIds
@@ -150,22 +158,12 @@ fun DashboardCoursePageFragment.refreshUserCourses(
         }
         val coursesResult = coursesRepository.fetchCourses(base, creds, courseIds)
         val courses = coursesResult.getOrElse {
-            Toast.makeText(
-                requireContext(),
-                it.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
-            refreshLayout.isRefreshing = false
-            showLoadingOverlay(false)
+            handleLoadingError(it, refreshLayout)
             return@launch
         }
         val courseProgress = coursesRepository.fetchCoursesProgress(base, creds, courseIds)
             .getOrElse {
-                Toast.makeText(
-                    requireContext(),
-                    it.message ?: getString(R.string.dashboard_courses_loading_error),
-                    Toast.LENGTH_SHORT
-                ).show()
+                showErrorToast(it)
                 emptyMap()
             }
         val mapped = courses
@@ -242,13 +240,7 @@ fun DashboardCoursePageFragment.refreshTeamCourses(
 
         val coursesResult = coursesRepository.fetchTeamCourses(base, creds, selectedTeamId)
         val courses = coursesResult.getOrElse {
-            Toast.makeText(
-                requireContext(),
-                it.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
-            refreshLayout.isRefreshing = false
-            showLoadingOverlay(false)
+            handleLoadingError(it, refreshLayout)
             return@launch
         }
         val mapped = courses
@@ -277,11 +269,7 @@ fun DashboardCoursePageFragment.handleJoinCourse(course: CourseItem) {
         }
 
         coursesRepository.joinCourse(base, creds, course.id).onFailure { error ->
-            Toast.makeText(
-                requireContext(),
-                error.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
+            showErrorToast(error)
         }.onSuccess {
             myCourseIds = (myCourseIds + course.id).distinct()
             needsMyCourseIdsRefresh = true
@@ -317,11 +305,7 @@ fun DashboardCoursePageFragment.handleLeaveCourse(course: CourseItem) {
         }
 
         coursesRepository.leaveCourse(base, creds, course.id).onFailure { error ->
-            Toast.makeText(
-                requireContext(),
-                error.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
+            showErrorToast(error)
         }.onSuccess {
             myCourseIds = myCourseIds.filterNot { it == course.id }
             needsMyCourseIdsRefresh = true
@@ -402,15 +386,9 @@ fun DashboardCoursePageFragment.loadNextCoursesPage(
             currentSkip,
             pageSize
         ).getOrElse {
-            Toast.makeText(
-                requireContext(),
-                it.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
-            refreshLayout?.isRefreshing = false
+            handleLoadingError(it, refreshLayout)
             isPaging = false
             hasMorePages = false
-            showLoadingOverlay(false)
             return@launch
         }
         val mapped = pageResult.courses
@@ -450,11 +428,7 @@ suspend fun DashboardCoursePageFragment.ensureUserCourseIds(): List<String> {
 
     val result = coursesRepository.fetchUserCourseIds(base, creds)
     val ids = result.getOrElse {
-        Toast.makeText(
-            requireContext(),
-            it.message ?: getString(R.string.dashboard_courses_loading_error),
-            Toast.LENGTH_SHORT
-        ).show()
+        showErrorToast(it)
         emptyList()
     }
     myCourseIds = ids

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageFragment.kt
@@ -253,7 +253,15 @@ class DashboardCoursePageFragment : Fragment(R.layout.fragment_dashboard_courses
         viewLifecycleOwner.lifecycleScope.launch {
             val authService = AuthDependencies.provideAuthService(requireContext(), base)
             val sessionCookie = withContext(Dispatchers.IO) { authService.getStoredToken() }
-            courseImageLoader = DashboardPostImageLoader(base, sessionCookie, viewLifecycleOwner.lifecycleScope)
+            val authorizationHeader = credentials?.let {
+                okhttp3.Credentials.basic(it.username, it.password)
+            }
+            courseImageLoader = DashboardPostImageLoader(
+                baseUrl = base,
+                sessionCookie = sessionCookie,
+                scope = viewLifecycleOwner.lifecycleScope,
+                authorizationHeader = authorizationHeader,
+            )
             isCourseImageLoaderLoading = false
             adapter.notifyItemRangeChanged(1, (adapter.itemCount - 1).coerceAtLeast(0), CourseAdapter.IMAGE_UPDATE_PAYLOAD)
         }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostImageLoader.kt
@@ -28,6 +28,7 @@ class DashboardPostImageLoader(
     private val sessionCookie: String?,
     private val scope: CoroutineScope,
     private val client: OkHttpClient = SharedBitmapDependencies.client,
+    private val authorizationHeader: String? = null,
 ) {
     private val cache = sharedCache
     private val inFlightRequests = mutableMapOf<String, Deferred<Bitmap?>>()
@@ -126,6 +127,9 @@ class DashboardPostImageLoader(
                 .header("Cache-Control", "no-cache")
         sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
             requestBuilder.addHeader("Cookie", cookie)
+        }
+        authorizationHeader?.takeIf { it.isNotBlank() }?.let { authorization ->
+            requestBuilder.header("Authorization", authorization)
         }
         return try {
             client.newCall(requestBuilder.build()).execute().use { response ->


### PR DESCRIPTION
🎯 **What:** Extracted repetitive error-handling Toast and UI-reset logic into two new reusable extension functions (`showErrorToast` and `handleLoadingError`) within `DashboardCoursePageActions.kt`. Applied these functions across all applicable methods (e.g., `refreshUserCourses`, `refreshTeamCourses`, `handleJoinCourse`, `loadNextCoursesPage`, etc.).
💡 **Why:** This directly addresses the code health issue of moderately long and complex methods (specifically `refreshUserCourses`), reducing boilerplate repetition, condensing the method length by around 50 lines total, and enhancing readability. It conforms to DRY principles while maintaining identical behavior.
✅ **Verification:** Verified locally via `git diff --staged` and successful compilation (`./gradlew compileDebugKotlin`). Ran all applicable unit tests (`./gradlew testDebugUnitTest --tests '*DashboardCoursePageFragmentTest*'`) which passed. Verified static analysis (`./gradlew lint app:lintDebug`) remains clean.
✨ **Result:** Improved maintainability of `DashboardCoursePageActions.kt` through cleaner, smaller functions and less duplicate code. No functionality was changed.

---
*PR created automatically by Jules for task [9755858456002739295](https://jules.google.com/task/9755858456002739295) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across course loading, refreshing, joining, and leaving actions.
  * Loading indicators and refresh controls now stop consistently when errors occur.
  * Error messages are displayed through a more consistent notification experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->