### PR TITLE
🧹 Refactor moderately long `refreshTeamCourses` method in `DashboardCoursePageActions.kt`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 509
-        versionName = "0.5.9"
+        versionCode = 510
+        versionName = "0.5.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageActions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCoursePageActions.kt
@@ -231,39 +231,47 @@ fun DashboardCoursePageFragment.refreshTeamCourses(
     currentTeamId = selectedTeamId
 
     viewLifecycleOwner.lifecycleScope.launch {
-        val base = baseUrl
-        val creds = credentials
-        if (base.isNullOrBlank() || creds == null) {
-            handleMissingCredentials(adapter, refreshLayout)
-            return@launch
-        }
+        fetchAndSubmitTeamCourses(adapter, refreshLayout, selectedTeamId)
+    }
+}
 
-        ensureUserCourseIds()
+private suspend fun DashboardCoursePageFragment.fetchAndSubmitTeamCourses(
+    adapter: CourseAdapter,
+    refreshLayout: SwipeRefreshLayout,
+    selectedTeamId: String
+) {
+    val base = baseUrl
+    val creds = credentials
+    if (base.isNullOrBlank() || creds == null) {
+        handleMissingCredentials(adapter, refreshLayout)
+        return
+    }
 
-        val coursesResult = coursesRepository.fetchTeamCourses(base, creds, selectedTeamId)
-        val courses = coursesResult.getOrElse {
-            Toast.makeText(
-                requireContext(),
-                it.message ?: getString(R.string.dashboard_courses_loading_error),
-                Toast.LENGTH_SHORT
-            ).show()
-            refreshLayout.isRefreshing = false
-            showLoadingOverlay(false)
-            return@launch
-        }
-        val mapped = courses
-            .filter { !it.id.isNullOrBlank() }
-            .distinctBy { it.id }
-            .map {
-                it.toCourseItem(
-                    getString(R.string.dashboard_courses_title),
-                    null
-                )
-            }
-        adapter.submitCourses(mapped)
+    ensureUserCourseIds()
+
+    val coursesResult = coursesRepository.fetchTeamCourses(base, creds, selectedTeamId)
+    val courses = coursesResult.getOrElse {
+        Toast.makeText(
+            requireContext(),
+            it.message ?: getString(R.string.dashboard_courses_loading_error),
+            Toast.LENGTH_SHORT
+        ).show()
         refreshLayout.isRefreshing = false
         showLoadingOverlay(false)
+        return
     }
+    val mapped = courses
+        .filter { !it.id.isNullOrBlank() }
+        .distinctBy { it.id }
+        .map {
+            it.toCourseItem(
+                getString(R.string.dashboard_courses_title),
+                null
+            )
+        }
+    adapter.submitCourses(mapped)
+    refreshLayout.isRefreshing = false
+    showLoadingOverlay(false)
 }
 
 fun DashboardCoursePageFragment.handleJoinCourse(course: CourseItem) {


### PR DESCRIPTION
🎯 **What:** Extracted the coroutine fetching logic from `refreshTeamCourses` into a new private method `fetchAndSubmitTeamCourses` in `DashboardCoursePageActions.kt`.
💡 **Why:** To improve code health by breaking down a moderately long method. This reduces complexity and increases readability and maintainability.
✅ **Verification:** Verified locally that syntax is correct via `./gradlew compileDebugKotlin`, ran unit tests which all passed, ran lint which reported 0 errors, and had changes approved by the automated reviewer.
✨ **Result:** A much cleaner `refreshTeamCourses` method with preserved behavior and better logical grouping of network operations.

---
*PR created automatically by Jules for task [5311518917019415386](https://jules.google.com/task/5311518917019415386) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the team courses refresh flow while preserving existing behavior, including clearer early-exit handling when required data isn’t available.
  * Kept loading overlays, swipe-to-refresh state, course rendering, and error/toast messaging consistent across both user and team course refreshes.
* **Chores**
  * Updated the app version to **0.5.10** (version code **510**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->