### PR TITLE
🧹 [Code Health] Refactor moderately long attemptSurveyTranslation method

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 499
+        versionName = "0.4.99"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardNavigationExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardNavigationExtensions.kt
@@ -97,31 +97,9 @@ internal suspend fun SurveyWizardFragment.initializeSession() {
 
 internal suspend fun SurveyWizardFragment.attemptSurveyTranslation() {
     val survey = document ?: return
-    val translationPreferenceEnabled = DashboardActivity.isSurveyTranslationEnabled(requireContext())
-    val translationConsentAccepted = DashboardActivity.isSurveyTranslationConsentAccepted(requireContext())
-    val translationAllowed = translationPreferenceEnabled && translationConsentAccepted
-    if (!translationAllowed) {
-        translatedTitle = null
-        translatedDescription = null
-        questionTranslations = emptyMap()
-        translationApplied = false
-        updateTranslationNotice(
-            showConsentNotice = translationPreferenceEnabled,
-            showAppliedNotice = false,
-        )
-        setTranslationInProgress(false)
-        return
-    }
-    val base =
-        baseUrl?.takeIf { it.isNotBlank() }
-            ?: DashboardServerPreferences.getServerBaseUrl(requireContext().applicationContext)
-            ?: return
-    val appLocales = AppCompatDelegate.getApplicationLocales()
-    val targetLanguage =
-        appLocales[0]
-            ?.language
-            ?.takeIf { it.isNotBlank() }
-            ?: Locale.getDefault().language
+    if (!checkTranslationAllowed()) return
+    val base = getTranslationBaseUrl() ?: return
+    val targetLanguage = determineTargetLanguage()
     targetSurveyLanguage = targetLanguage
     val detectedLanguage = translationManager.detectSurveyLanguage(survey)
     detectedSurveyLanguage = detectedLanguage
@@ -137,6 +115,42 @@ internal suspend fun SurveyWizardFragment.attemptSurveyTranslation() {
             detectedLanguage,
         )
     setTranslationInProgress(false)
+    handleTranslationResult(result)
+}
+
+private fun SurveyWizardFragment.checkTranslationAllowed(): Boolean {
+    val translationPreferenceEnabled = DashboardActivity.isSurveyTranslationEnabled(requireContext())
+    val translationConsentAccepted = DashboardActivity.isSurveyTranslationConsentAccepted(requireContext())
+    val translationAllowed = translationPreferenceEnabled && translationConsentAccepted
+    if (!translationAllowed) {
+        translatedTitle = null
+        translatedDescription = null
+        questionTranslations = emptyMap()
+        translationApplied = false
+        updateTranslationNotice(
+            showConsentNotice = translationPreferenceEnabled,
+            showAppliedNotice = false,
+        )
+        setTranslationInProgress(false)
+    }
+    return translationAllowed
+}
+
+private fun SurveyWizardFragment.getTranslationBaseUrl(): String? =
+    baseUrl?.takeIf { it.isNotBlank() }
+        ?: DashboardServerPreferences.getServerBaseUrl(requireContext().applicationContext)
+
+private fun SurveyWizardFragment.determineTargetLanguage(): String {
+    val appLocales = AppCompatDelegate.getApplicationLocales()
+    return appLocales[0]
+        ?.language
+        ?.takeIf { it.isNotBlank() }
+        ?: Locale.getDefault().language
+}
+
+private fun SurveyWizardFragment.handleTranslationResult(
+    result: org.ole.planet.myplanet.lite.surveys.SurveyTranslationManager.SurveyTranslationResult
+) {
     translatedTitle = result.titleTranslation?.takeIf { it.isNotBlank() }
     translatedDescription = result.descriptionTranslation?.takeIf { it.isNotBlank() }
     applySurveyTranslations()


### PR DESCRIPTION
🎯 **What:** Extracted logic from `attemptSurveyTranslation` in `SurveyWizardNavigationExtensions.kt` into smaller helper methods (`checkTranslationAllowed`, `getTranslationBaseUrl`, `determineTargetLanguage`, and `handleTranslationResult`).
💡 **Why:** To fix the "Moderately long method" code health issue, improving readability and maintainability.
✅ **Verification:** Verified through `git diff`, compiled syntax via `./gradlew compileDebugKotlin`, and ran the unit test suite (`./gradlew testDebugUnitTest --tests '*SurveyWizard*'`) and static analysis (`./gradlew lint app:lintDebug`). No regressions were introduced.
✨ **Result:** The original method is now much smaller and delegates responsibilities to focused private helper methods, strictly preserving existing behavior.

---
*PR created automatically by Jules for task [8740036464184344439](https://jules.google.com/task/8740036464184344439) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved survey translation handling for more consistent eligibility checks, language selection, and translated-result application.
  * Updated the app version to 0.4.99.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->