### PR TITLE
🧹 [Refactor] Extract intent logic in SplashScreen

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SplashScreen.kt
@@ -128,25 +128,37 @@ class SplashScreen : BaseActivity() {
 
     private suspend fun routeToNextActivity() {
         val launchMode = attemptDirectDashboardLaunch()
-        val nextIntent =
-            when (launchMode) {
-                DashboardLaunchMode.ONLINE -> {
-                    Intent(this@SplashScreen, DashboardActivity::class.java)
-                }
+        val nextIntent = createBaseIntent(launchMode)
+        applyDeepLinkData(nextIntent, launchMode)
 
-                DashboardLaunchMode.OFFLINE -> {
-                    Intent(this@SplashScreen, DashboardActivity::class.java).apply {
-                        putExtra(DashboardActivity.EXTRA_OFFLINE_MODE, true)
-                    }
-                }
+        startActivity(nextIntent)
+        finish()
+    }
 
-                DashboardLaunchMode.NONE -> {
-                    Intent(this@SplashScreen, MyPlanetLite::class.java).apply {
-                        putExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, true)
-                    }
+    private fun createBaseIntent(launchMode: DashboardLaunchMode): Intent {
+        return when (launchMode) {
+            DashboardLaunchMode.ONLINE -> {
+                Intent(this@SplashScreen, DashboardActivity::class.java)
+            }
+
+            DashboardLaunchMode.OFFLINE -> {
+                Intent(this@SplashScreen, DashboardActivity::class.java).apply {
+                    putExtra(DashboardActivity.EXTRA_OFFLINE_MODE, true)
                 }
             }
 
+            DashboardLaunchMode.NONE -> {
+                Intent(this@SplashScreen, MyPlanetLite::class.java).apply {
+                    putExtra(MyPlanetLite.EXTRA_ALLOW_AUTO_LOGIN, true)
+                }
+            }
+        }
+    }
+
+    private fun applyDeepLinkData(
+        nextIntent: Intent,
+        launchMode: DashboardLaunchMode,
+    ) {
         val forwardedPostId =
             intent
                 .getStringExtra(DashboardActivity.EXTRA_DEEP_LINK_POST_ID)
@@ -165,9 +177,6 @@ class SplashScreen : BaseActivity() {
                 }
             }
         }
-
-        startActivity(nextIntent)
-        finish()
     }
 
     private suspend fun attemptDirectDashboardLaunch(): DashboardLaunchMode {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted the lengthy `routeToNextActivity` method in `SplashScreen.kt` into `createBaseIntent` and `applyDeepLinkData`.

💡 **Why:** How this improves maintainability
The original method was handling both the base intent generation (based on launch mode) and the complex evaluation of deep link extras. By breaking these down, the code is much cleaner, more readable, and easier to modify in the future.

✅ **Verification:** How you confirmed the change is safe
- Verified syntax with `./gradlew compileDebugKotlin`.
- Ran the full unit test suite with `./gradlew testDebugUnitTest`. All tests pass.
- Verified style and static analysis using `./gradlew lint app:lintDebug`.

✨ **Result:** The improvement achieved
A moderately long method was broken down safely without modifying functionality.

---
*PR created automatically by Jules for task [270439627645317290](https://jules.google.com/task/270439627645317290) started by @dogi*