### PR TITLE
🧹 Extract UI update logic to shorten moderately long methods in DashboardResourcesListLoadingExtensions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 515
+        versionName = "0.5.15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardResourcesListLoadingExtensions.kt
@@ -148,21 +148,33 @@ internal fun DashboardResourcesPageFragment.loadMoreMainResources() {
             val items = fetchResult.page
             isLoadingMainResources = false
             if (isAdded) {
-                mainResourcesItems.addAll(items)
-                ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
-                val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
-                if (currentAdapter == null || mainResourcesSkip == 0) {
-                    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(mainResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
-                } else {
-                    currentAdapter.replaceResources(mainResourcesItems)
-                }
-                mainResourcesSkip += items.size
-                hasMoreMainResources = items.size >= DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE
-                hasLoadedMainResources = true
-                swipeRefreshLayout?.isRefreshing = false
+                processMainResourcesResult(list, items)
             }
         }
     }
+
+private fun DashboardResourcesPageFragment.processMainResourcesResult(
+    list: RecyclerView,
+    items: List<ResourceUi>
+) {
+    mainResourcesItems.addAll(items)
+    ResourceSearchEngine.sortResources(mainResourcesItems, selectedSortBy, isSortDescending)
+    val currentAdapter = list.adapter as? DashboardResourcesPageFragment.ResourceExplorerAdapter
+    if (currentAdapter == null || mainResourcesSkip == 0) {
+        list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(
+            mainResourcesItems.toList(),
+            resourceDownloadProgress,
+            ::openResource,
+            ::onSecondaryAction
+        )
+    } else {
+        currentAdapter.replaceResources(mainResourcesItems)
+    }
+    mainResourcesSkip += items.size
+    hasMoreMainResources = items.size >= DashboardResourcesPageFragment.MAIN_RESOURCES_PAGE_SIZE
+    hasLoadedMainResources = true
+    swipeRefreshLayout?.isRefreshing = false
+}
 
 internal fun DashboardResourcesPageFragment.loadTeamResources() {
         if (isLoadingTeamResources) {
@@ -201,12 +213,24 @@ internal fun DashboardResourcesPageFragment.loadTeamResources() {
             )
             isLoadingTeamResources = false
             if (isAdded) {
-                teamResourcesItems.clear()
-                teamResourcesItems.addAll(mergedResources)
-                ResourceSearchEngine.sortResources(teamResourcesItems, selectedSortBy, isSortDescending)
-                hasLoadedTeamResources = true
-                list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(teamResourcesItems.toList(), resourceDownloadProgress, ::openResource, ::onSecondaryAction)
-                swipeRefreshLayout?.isRefreshing = false
+                processTeamResourcesResult(list, mergedResources)
             }
         }
     }
+
+private fun DashboardResourcesPageFragment.processTeamResourcesResult(
+    list: RecyclerView,
+    mergedResources: List<ResourceUi>
+) {
+    teamResourcesItems.clear()
+    teamResourcesItems.addAll(mergedResources)
+    ResourceSearchEngine.sortResources(teamResourcesItems, selectedSortBy, isSortDescending)
+    hasLoadedTeamResources = true
+    list.adapter = DashboardResourcesPageFragment.ResourceExplorerAdapter(
+        teamResourcesItems.toList(),
+        resourceDownloadProgress,
+        ::openResource,
+        ::onSecondaryAction
+    )
+    swipeRefreshLayout?.isRefreshing = false
+}


### PR DESCRIPTION
🎯 **What:** Extracted the UI update logic from `loadMoreMainResources()` and `loadTeamResources()` into separate private helper methods.
💡 **Why:** To improve code health by breaking down moderately long methods, thereby enhancing readability and maintainability.
✅ **Verification:** Ran `git diff`, `./gradlew compileDebugKotlin`, `./gradlew testDebugUnitTest`, and `./gradlew lint app:lintDebug` to verify no functionality or syntax issues were introduced.
✨ **Result:** The long methods are now significantly shorter and focused strictly on the fetching logic, delegating the UI updates to cleanly separated helpers.

---
*PR created automatically by Jules for task [1310572437092884003](https://jules.google.com/task/1310572437092884003) started by @dogi*