### PR TITLE
⚡ Replace manual file deletion loop with FileUtils.deleteFiles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 518
+        versionName = "0.5.18"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyUiExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyUiExtensions.kt
@@ -23,13 +23,13 @@ import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlin.math.max
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity.Companion.COLLAPSED_REPLY_MIN_LINES
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity.Companion.EXPANDED_REPLY_MIN_LINES
-import kotlin.math.max
+import org.ole.planet.myplanet.lite.util.ApplicationScope
+import org.ole.planet.myplanet.lite.util.FileUtils
 
 internal fun DashboardPostDetailActivity.setupBackNavigation() {
     backCallback =
@@ -273,13 +273,8 @@ internal fun DashboardPostDetailActivity.clearPendingReplyImages() {
     val filesToDelete = pendingReplyImages.values.map { it.file }.toList()
     pendingReplyImages.clear()
 
-    @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-    GlobalScope.launch(Dispatchers.IO) {
-        filesToDelete.forEach { file ->
-            if (file.exists()) {
-                file.delete()
-            }
-        }
+    ApplicationScope.io.launch {
+        FileUtils.deleteFiles(filesToDelete)
     }
     updateReplyPreviewImages()
     updateReplyActionAvailabilityInternal(replyInput.text)

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyUiExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardPostDetailReplyUiExtensions.kt
@@ -23,13 +23,13 @@ import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity.Companion.COLLAPSED_REPLY_MIN_LINES
 import org.ole.planet.myplanet.lite.dashboard.DashboardPostDetailActivity.Companion.EXPANDED_REPLY_MIN_LINES
 import org.ole.planet.myplanet.lite.util.ApplicationScope
 import org.ole.planet.myplanet.lite.util.FileUtils
+import kotlin.math.max
 
 internal fun DashboardPostDetailActivity.setupBackNavigation() {
     backCallback =


### PR DESCRIPTION
💡 **What:** Replaced the manual `forEach` file deletion loop with the existing `FileUtils.deleteFiles` utility method. Removed the usage of `GlobalScope` in favor of the safer, project-level `ApplicationScope.io`.
🎯 **Why:** The manual loop unnecessarily duplicated code that was already properly handled by `FileUtils.deleteFiles`. Furthermore, utilizing `FileUtils` cleanly centralizes background context switching (`withContext(Dispatchers.IO)`) and avoids reliance on delicate coroutine APIs.
📊 **Measured Improvement:** The optimization removes a delicate API dependency and eliminates redundant loop boilerplate, though due to its background I/O nature and lack of existing benchmark infrastructure for this specific UI interaction, an exact millisecond benchmark is impractical to provide here. However, it represents a net improvement in architectural cleanliness and safety.

---
*PR created automatically by Jules for task [6046724680855542608](https://jules.google.com/task/6046724680855542608) started by @dogi*