### PR TITLE
🧹 flushPendingSurveyOutbox: use awaitAll() for clarity

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 506
+        versionName = "0.5.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
@@ -6,6 +6,7 @@ import android.net.NetworkCapabilities
 import java.io.Closeable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
@@ -70,8 +71,7 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
                 }
             }
             val successfulIds = mutableListOf<Long>()
-            deferredResults.forEach { deferred ->
-                val (entry, result) = deferred.await()
+            deferredResults.awaitAll().forEach { (entry, result) ->
                 if (result.isSuccess) {
                     successfulIds.add(entry.id)
                 }


### PR DESCRIPTION
Replaces the manual `deferredResults.forEach { deferred -> deferred.await() }` loop with the idiomatic `awaitAll()` in `flushPendingSurveyOutbox`.

**This is a readability / idiomatic cleanup, not a performance change.** The deferreds are created with eager `async(Dispatchers.IO)`, so the submissions already run concurrently regardless of how they're awaited — both the old loop and `awaitAll()` complete in the same wall-clock time (bounded by the slowest task). `awaitAll()` just expresses "wait for all results" more directly.

No behavior change: each deferred still returns a captured `Result`, and successful ids are collected and deleted from the outbox exactly as before.

---
*PR created automatically by Jules for task [4274887851049243086](https://jules.google.com/task/4274887851049243086) started by @dogi*