### PR TITLE
🧹 Refactor `renderNamesStep` in `SurveyWizardRespondentExtensions`

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardRespondentExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardRespondentExtensions.kt
@@ -234,6 +234,26 @@ internal fun SurveyWizardFragment.renderBasicsStep(): Pair<View, () -> Boolean> 
     return container to collector
 }
 
+internal fun SurveyWizardFragment.createTextInputLayout(
+    context: android.content.Context,
+    hintText: String,
+    initialText: String?,
+): Pair<TextInputLayout, TextInputEditText> {
+    val layout =
+        TextInputLayout(context).apply {
+            hint = hintText
+            layoutParams =
+                LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+        }
+    val input = TextInputEditText(context)
+    input.setText(initialText.orEmpty())
+    layout.addView(input)
+    return layout to input
+}
+
 internal fun SurveyWizardFragment.renderNamesStep(): Pair<View, () -> Boolean> {
     val context = requireContext()
     val container =
@@ -246,68 +266,40 @@ internal fun SurveyWizardFragment.renderNamesStep(): Pair<View, () -> Boolean> {
                 )
         }
 
-    val firstLayout =
-        TextInputLayout(context).apply {
-            hint = getString(R.string.dashboard_survey_wizard_first_name_label)
-            layoutParams =
-                LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
-        }
-    val firstInput = TextInputEditText(context)
-    firstInput.setText(respondent.firstName.orEmpty())
-    firstLayout.addView(firstInput)
-
-    val middleLayout =
-        TextInputLayout(context).apply {
-            hint = getString(R.string.dashboard_survey_wizard_middle_name_label)
-            layoutParams =
-                LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
-        }
-    val middleInput = TextInputEditText(context)
-    middleInput.setText(respondent.middleName.orEmpty())
-    middleLayout.addView(middleInput)
-
-    val lastLayout =
-        TextInputLayout(context).apply {
-            hint = getString(R.string.dashboard_survey_wizard_last_name_label)
-            layoutParams =
-                LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
-        }
-    val lastInput = TextInputEditText(context)
-    lastInput.setText(respondent.lastName.orEmpty())
-    lastLayout.addView(lastInput)
+    val (firstLayout, firstInput) =
+        createTextInputLayout(
+            context,
+            getString(R.string.dashboard_survey_wizard_first_name_label),
+            respondent.firstName,
+        )
+    val (middleLayout, middleInput) =
+        createTextInputLayout(
+            context,
+            getString(R.string.dashboard_survey_wizard_middle_name_label),
+            respondent.middleName,
+        )
+    val (lastLayout, lastInput) =
+        createTextInputLayout(
+            context,
+            getString(R.string.dashboard_survey_wizard_last_name_label),
+            respondent.lastName,
+        )
 
     container.addView(firstLayout)
     container.addView(middleLayout)
     container.addView(lastLayout)
 
     val collector = {
-        respondent.firstName =
-            firstInput.text
+        fun TextInputEditText.trimmedValue(): String? =
+            text
                 ?.toString()
                 ?.trim()
                 .orEmpty()
                 .takeIf { it.isNotBlank() }
-        respondent.middleName =
-            middleInput.text
-                ?.toString()
-                ?.trim()
-                .orEmpty()
-                .takeIf { it.isNotBlank() }
-        respondent.lastName =
-            lastInput.text
-                ?.toString()
-                ?.trim()
-                .orEmpty()
-                .takeIf { it.isNotBlank() }
+
+        respondent.firstName = firstInput.trimmedValue()
+        respondent.middleName = middleInput.trimmedValue()
+        respondent.lastName = lastInput.trimmedValue()
         true
     }
     return container to collector


### PR DESCRIPTION
🎯 **What:** Refactored the `SurveyWizardFragment.renderNamesStep()` method to address a code health issue (moderately long method).
💡 **Why:** The original method was lengthy due to identical logic for setting up three different input fields (first name, middle name, last name) and fetching their input values. This refactoring extracts the view creation logic into a reusable `createTextInputLayout` helper and the extraction logic into a local `trimmedValue()` method, improving maintainability and reducing visual noise.
✅ **Verification:** Verified the layout behavior hasn't changed. Compiled the project to check for syntax issues, ran the lint checker, and confirmed no test regressions exist.
✨ **Result:** The method is significantly shorter and more readable.

---
*PR created automatically by Jules for task [7013671341565576250](https://jules.google.com/task/7013671341565576250) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the survey respondent name-entry form for more consistent input handling.
  * Automatically trims entered names and treats blank fields as empty values.
  * Preserves existing name information when editing the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->