### PR TITLE
🧹 [Refactor toCourseItem to improve maintainability]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 497
+        versionName = "0.4.97"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseModels.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseModels.kt
@@ -1,6 +1,7 @@
 package org.ole.planet.myplanet.lite
 
 import org.ole.planet.myplanet.lite.dashboard.DashboardCoursesRepository.CourseDocument
+import org.ole.planet.myplanet.lite.dashboard.DashboardCoursesRepository.CourseStep
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import java.security.SecureRandom
 import kotlin.random.asKotlinRandom
@@ -44,53 +45,15 @@ fun CourseDocument.toCourseItem(
     defaultTitle: String,
     stepNum: Int?
 ): CourseItem {
-    val steps = steps.mapNotNull { step ->
-        val title = step.stepTitle?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-        val mediaTypes = buildList {
-            step.resources
-                ?.mapNotNull { resource -> mapCourseMediaType(resource.mediaType) }
-                ?.forEach { add(it) }
-            if (step.survey != null) {
-                add("survey")
-            }
-            if (step.exam != null) {
-                add("exam")
-            }
-        }
-        val resources = step.resources.orEmpty().flatMap { resource ->
-            val resourceId = resource.id?.takeIf { it.isNotBlank() } ?: return@flatMap emptyList()
-            val filenames = when {
-                resource.attachments.isNotEmpty() -> resource.attachments.keys
-                !resource.filename.isNullOrBlank() -> listOf(resource.filename)
-                else -> emptyList()
-            }
-            val mediaType = mapCourseMediaType(resource.mediaType)
-                ?: resource.mediaType?.lowercase()?.trim().orEmpty()
-            filenames.map { name ->
-                CourseItem.LessonResource(
-                    id = resourceId,
-                    filename = name,
-                    mediaType = mediaType
-                )
-            }
-        }
-        CourseItem.LessonStep(
-            title = title,
-            description = step.description.orEmpty(),
-            mediaTypes = mediaTypes,
-            resources = resources,
-            survey = step.survey,
-            exam = step.exam
-        )
-    }
+    val mappedSteps = steps.mapNotNull { it.toLessonStep() }
     val random = SecureRandom(id.orEmpty().toByteArray()).asKotlinRandom()
-    val completedSteps = if (steps.isNotEmpty() && stepNum != null) {
-        stepNum.coerceAtLeast(0).coerceAtMost(steps.size)
+    val completedSteps = if (mappedSteps.isNotEmpty() && stepNum != null) {
+        stepNum.coerceAtLeast(0).coerceAtMost(mappedSteps.size)
     } else {
         null
     }
-    val progressPercent = if (steps.isNotEmpty() && completedSteps != null) {
-        (completedSteps * 100.0 / steps.size)
+    val progressPercent = if (mappedSteps.isNotEmpty() && completedSteps != null) {
+        (completedSteps * 100.0 / mappedSteps.size)
             .toInt()
             .coerceIn(0, 100)
     } else {
@@ -101,10 +64,50 @@ fun CourseDocument.toCourseItem(
         title = courseTitle?.takeIf { it.isNotBlank() } ?: defaultTitle,
         description = description.orEmpty(),
         coverPath = cover?.takeIf { it.isNotBlank() },
-        steps = steps,
+        steps = mappedSteps,
         rating = random.nextDouble(3.5, 5.0),
         progressPercent = progressPercent,
-        currentStep = completedSteps?.minus(1)?.coerceIn(0, steps.lastIndex)
+        currentStep = completedSteps?.minus(1)?.coerceIn(0, mappedSteps.lastIndex)
+    )
+}
+
+private fun CourseStep.toLessonStep(): CourseItem.LessonStep? {
+    val title = stepTitle?.takeIf { it.isNotBlank() } ?: return null
+    val mediaTypes = buildList {
+        resources
+            ?.mapNotNull { resource -> mapCourseMediaType(resource.mediaType) }
+            ?.forEach { add(it) }
+        if (survey != null) {
+            add("survey")
+        }
+        if (exam != null) {
+            add("exam")
+        }
+    }
+    val mappedResources = resources.orEmpty().flatMap { resource ->
+        val resourceId = resource.id?.takeIf { it.isNotBlank() } ?: return@flatMap emptyList()
+        val filenames = when {
+            resource.attachments.isNotEmpty() -> resource.attachments.keys
+            !resource.filename.isNullOrBlank() -> listOf(resource.filename)
+            else -> emptyList()
+        }
+        val mediaType = mapCourseMediaType(resource.mediaType)
+            ?: resource.mediaType?.lowercase()?.trim().orEmpty()
+        filenames.map { name ->
+            CourseItem.LessonResource(
+                id = resourceId,
+                filename = name,
+                mediaType = mediaType
+            )
+        }
+    }
+    return CourseItem.LessonStep(
+        title = title,
+        description = description.orEmpty(),
+        mediaTypes = mediaTypes,
+        resources = mappedResources,
+        survey = survey,
+        exam = exam
     )
 }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a moderately long method: `CourseDocument.toCourseItem` in `app/src/main/java/org/ole/planet/myplanet/lite/DashboardCourseModels.kt`.
💡 **Why:** Breaking down the long `toCourseItem` method into smaller, single-responsibility functions (by extracting `CourseStep.toLessonStep()`) improves maintainability, enhances code readability, and reduces cognitive load by eliminating deep nesting. It also resolves variable shadowing (`steps` and `resources`).
✅ **Verification:**
1. Verified changes with `git diff --staged`.
2. Verified syntax/compilation with `./gradlew compileDebugKotlin`.
3. Ran static analysis successfully with `./gradlew lint app:lintDebug`.
4. Executed all relevant unit tests (filtered using `--tests` to avoid timeouts) ensuring no regressions were introduced.
✨ **Result:** A cleaner, more maintainable `DashboardCourseModels.kt` file with well-segregated logic and improved variable naming.

---
*PR created automatically by Jules for task [4501281510698453925](https://jules.google.com/task/4501281510698453925) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course lesson step mapping and filtering for more accurate course content display.
  * Enhanced progress and completion calculations based on available lesson steps.
  * Improved handling of lesson resources, attachments, media types, surveys, and exams.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->