### PR TITLE
🧹 [code health: Refactor ResourceSyncService to extract duplicated map logic]

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceSyncService.kt
@@ -34,23 +34,7 @@ internal class ResourceSyncService(
         )
         val page = result.getOrDefault(emptyList())
         val mutableKeys = existingKeys.toMutableSet()
-        val items = page.map { resource ->
-            val id = resource.id?.trim().orEmpty()
-            val filename = resource.filename?.trim().orEmpty()
-            ResourceUi(
-                id = id,
-                filename = filename,
-                name = resource.title?.takeIf { it.isNotBlank() }
-                    ?: resource.filename?.takeIf { it.isNotBlank() }
-                    ?: "-",
-                type = resource.mediaType?.uppercase(Locale.ROOT) ?: "PDF",
-                date = DateUtils.toDisplayDate(resource.createdDate),
-                createdDate = resource.createdDate,
-                isDownloaded = downloadService.findLocalResourceFile(id, filename, isTeamResource = false)?.exists() == true,
-                isDownloadable = ResourceSearchEngine.parseIsDownloadable(resource.isDownloadable),
-                isTeamResource = false
-            )
-        }.filter { item ->
+        val items = page.map { mapToResourceUi(it, isTeamResource = false) }.filter { item ->
             val key = item.resourceIdentityKey()
             if (mutableKeys.contains(key)) false else {
                 mutableKeys.add(key)
@@ -87,23 +71,7 @@ internal class ResourceSyncService(
             )
         )
         val page = result.getOrDefault(emptyList())
-        val allRemoteItems = page.map { resource ->
-            val id = resource.id?.trim().orEmpty()
-            val filename = resource.filename?.trim().orEmpty()
-            ResourceUi(
-                id = id,
-                filename = filename,
-                name = resource.title?.takeIf { it.isNotBlank() }
-                    ?: resource.filename?.takeIf { it.isNotBlank() }
-                    ?: "-",
-                type = resource.mediaType?.uppercase(Locale.ROOT) ?: "PDF",
-                date = DateUtils.toDisplayDate(resource.createdDate),
-                createdDate = resource.createdDate,
-                isDownloaded = downloadService.findLocalResourceFile(id, filename, isTeamResource = true)?.exists() == true,
-                isDownloadable = ResourceSearchEngine.parseIsDownloadable(resource.isDownloadable),
-                isTeamResource = true
-            )
-        }
+        val allRemoteItems = page.map { mapToResourceUi(it, isTeamResource = true) }
         val remoteKeys = allRemoteItems.map { it.resourceIdentityKey() }.toSet()
         val downloaded = downloadedResources.filter { remoteKeys.contains(it.resourceIdentityKey()) }
         val existingKeys = downloaded.map { it.resourceIdentityKey() }.toMutableSet()
@@ -115,6 +83,27 @@ internal class ResourceSyncService(
             }
         }
         return downloaded + remoteItems
+    }
+
+    private fun mapToResourceUi(
+        resource: DashboardResourcesRepository.ResourceDocument,
+        isTeamResource: Boolean
+    ): ResourceUi {
+        val id = resource.id?.trim().orEmpty()
+        val filename = resource.filename?.trim().orEmpty()
+        return ResourceUi(
+            id = id,
+            filename = filename,
+            name = resource.title?.takeIf { it.isNotBlank() }
+                ?: resource.filename?.takeIf { it.isNotBlank() }
+                ?: "-",
+            type = resource.mediaType?.uppercase(Locale.ROOT) ?: "PDF",
+            date = DateUtils.toDisplayDate(resource.createdDate),
+            createdDate = resource.createdDate,
+            isDownloaded = downloadService.findLocalResourceFile(id, filename, isTeamResource)?.exists() == true,
+            isDownloadable = ResourceSearchEngine.parseIsDownloadable(resource.isDownloadable),
+            isTeamResource = isTeamResource
+        )
     }
 
     suspend fun downloadResource(


### PR DESCRIPTION
🎯 **What:** Extracted duplicated logic for mapping `DashboardResourcesRepository.ResourceDocument` to `ResourceUi` into a private helper method `mapToResourceUi` in `ResourceSyncService.kt`.
💡 **Why:** To improve code health by reducing method size, reducing duplication, and enhancing readability.
✅ **Verification:**
- Validated via `git diff`.
- Verified compilation and structural changes via `./gradlew compileDebugKotlin`.
- Assessed safety by running corresponding test `./gradlew testDebugUnitTest --tests '*ResourceSyncServiceTest*'`.
- Reviewed by `request_code_review`.
✨ **Result:** Cleaned up the `ResourceSyncService` by centralizing the mapping logic, improving its maintainability without changing any behavior.

---
*PR created automatically by Jules for task [955596823849938753](https://jules.google.com/task/955596823849938753) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in how community and team resources are displayed.
  - Resource names now use clearer fallback values when metadata is incomplete.
  - Media types and dates are formatted more consistently.
  - Download status and availability are reflected more reliably.
  - Resource identifiers and filenames are cleaned up to prevent display inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->