### PR TITLE
Refactor Survey Submission and Outbox Logic with Outcomes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 487
-        versionName = "0.4.87"
+        versionCode = 504
+        versionName = "0.5.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardGradingExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardGradingExtensions.kt
@@ -1,0 +1,148 @@
+/*
+ * Author: Walfre López Prado
+ * Email: loppra@plataformasinformaticas.com
+ * Creation date: 2026-07-29
+ */
+
+package org.ole.planet.myplanet.lite
+
+import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
+import kotlin.math.roundToInt
+
+internal fun SurveyWizardFragment.isExamPassing(): Boolean {
+    val survey = document ?: return true
+    val questions = survey.questions.orEmpty()
+    if (questions.isEmpty()) return true
+    val passingPercentage = survey.passingPercentage ?: DEFAULT_EXAM_PASSING_PERCENTAGE
+    val totalMarks = questions.sumOf { it.marks ?: 1 }
+    if (totalMarks == 0) return true
+    val earned =
+        questions
+            .mapIndexed { index, question ->
+                if (isAnswerCorrect(question, answers[index])) {
+                    question.marks ?: 1
+                } else {
+                    0
+                }
+            }.sum()
+    val percentage = (earned * 100.0 / totalMarks).roundToInt()
+    return percentage >= passingPercentage
+}
+
+internal fun SurveyWizardFragment.isAnswerCorrect(
+    question: SurveyQuestion,
+    answer: SurveyAnswer?,
+): Boolean {
+    val normalizedCorrect = normalizeCorrectChoice(question.correctChoice)
+    val choiceIds =
+        question.choices
+            .orEmpty()
+            .mapNotNull { it.id?.trim() }
+            .filter { it.isNotBlank() }
+            .toSet()
+    val choiceTextToId =
+        question.choices
+            .orEmpty()
+            .mapNotNull { choice ->
+                val text = choice.text?.trim().orEmpty()
+                val id = choice.id?.trim().orEmpty()
+                if (text.isNotBlank() && id.isNotBlank()) text to id else null
+            }.toMap()
+    val correctIds =
+        normalizedCorrect
+            .map { it.trim() }
+            .filter { it.isNotBlank() && choiceIds.contains(it) }
+    val correctTexts =
+        if (correctIds.isEmpty()) {
+            normalizedCorrect.map { it.trim() }.filter { it.isNotBlank() }
+        } else {
+            emptyList()
+        }
+    return when (question.type) {
+        "input", "textarea" -> isTextInputCorrect(normalizedCorrect, answer)
+        "select" -> isSelectInputCorrect(correctIds, correctTexts, choiceTextToId, answer)
+        "selectMultiple" -> isSelectMultipleInputCorrect(correctIds, answer)
+        "ratingScale" -> isRatingScaleInputCorrect(normalizedCorrect, answer)
+        else -> false
+    }
+}
+
+internal fun SurveyWizardFragment.isTextInputCorrect(
+    normalizedCorrect: List<String>,
+    answer: SurveyAnswer?,
+): Boolean {
+    val correctText = normalizedCorrect.firstOrNull()?.trim().orEmpty()
+    val response = (answer as? SurveyAnswer.Text)?.value?.trim().orEmpty()
+    return if (correctText.isBlank()) {
+        response.isNotBlank()
+    } else {
+        response.equals(correctText, ignoreCase = true)
+    }
+}
+
+internal fun SurveyWizardFragment.isSelectInputCorrect(
+    correctIds: List<String>,
+    correctTexts: List<String>,
+    choiceTextToId: Map<String, String>,
+    answer: SurveyAnswer?,
+): Boolean {
+    val selectedChoice = (answer as? SurveyAnswer.SingleChoice)?.choice
+    return if (correctIds.isNotEmpty()) {
+        val selectedId = normalizeSelectedId(selectedChoice?.id)
+        val resolvedId =
+            selectedId?.takeIf { it.isNotBlank() }
+                ?: selectedChoice?.text?.trim()?.let { choiceTextToId[it] }
+        resolvedId != null && correctIds.contains(resolvedId)
+    } else {
+        val selectedText = selectedChoice?.text?.trim()
+        selectedText != null && correctTexts.any { it.equals(selectedText, ignoreCase = true) }
+    }
+}
+
+internal fun SurveyWizardFragment.isSelectMultipleInputCorrect(
+    correctIds: List<String>,
+    answer: SurveyAnswer?,
+): Boolean {
+    val selectedIds =
+        (answer as? SurveyAnswer.MultipleChoice)
+            ?.choices
+            ?.filter { !it.isOther }
+            ?.mapNotNull { normalizeSelectedId(it.id) }
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
+    return selectedIds.size == correctIds.size && selectedIds.toSet() == correctIds.toSet()
+}
+
+internal fun SurveyWizardFragment.isRatingScaleInputCorrect(
+    normalizedCorrect: List<String>,
+    answer: SurveyAnswer?,
+): Boolean {
+    val correctValue = normalizedCorrect.firstOrNull()?.trim().orEmpty()
+    val selectedScore = (answer as? SurveyAnswer.Rating)?.score?.toString()
+    return correctValue.isNotBlank() && selectedScore == correctValue
+}
+
+internal fun SurveyWizardFragment.normalizeCorrectChoice(correctChoice: Any?): List<String> =
+    when (correctChoice) {
+        is String -> listOf(correctChoice)
+        is List<*> ->
+            correctChoice.mapNotNull { item ->
+                when (item) {
+                    is Map<*, *> ->
+                        item["id"]?.toString()
+                            ?: item["_id"]?.toString()
+                            ?: item["text"]?.toString()
+
+                    else -> item?.toString()
+                }
+            }
+
+        null -> emptyList()
+        else -> listOf(correctChoice.toString())
+    }
+
+internal fun SurveyWizardFragment.normalizeSelectedId(rawId: String?): String? {
+    val trimmed = rawId?.trim().orEmpty()
+    if (trimmed.isBlank()) return null
+    return trimmed.substringBefore("/").trim().takeIf { it.isNotBlank() }
+}

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
@@ -18,11 +18,9 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsReposito
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SubmissionTeam
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
-import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
 import org.ole.planet.myplanet.lite.survey.SubmitOutcome
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
-import kotlin.math.roundToInt
 
 internal fun SurveyWizardFragment.buildSubmissionPayload(): Pair<List<SubmissionAnswer>, Int> {
     val answersPayload =
@@ -383,157 +381,6 @@ internal fun SurveyWizardFragment.resolveExamStatus(survey: SurveyDocument): Str
                 question.type.equals("textarea", ignoreCase = true)
         }
     return if (requiresGrading) "requires grading" else "complete"
-}
-
-internal fun SurveyWizardFragment.isExamPassing(): Boolean {
-    val survey = document ?: return true
-    val questions = survey.questions.orEmpty()
-    if (questions.isEmpty()) return true
-    val passingPercentage = survey.passingPercentage ?: DEFAULT_EXAM_PASSING_PERCENTAGE
-    val totalMarks = questions.sumOf { it.marks ?: 1 }
-    if (totalMarks == 0) return true
-    val earned =
-        questions
-            .mapIndexed { index, question ->
-                if (isAnswerCorrect(question, answers[index])) {
-                    question.marks ?: 1
-                } else {
-                    0
-                }
-            }.sum()
-    val percentage = (earned * 100.0 / totalMarks).roundToInt()
-    return percentage >= passingPercentage
-}
-
-internal fun SurveyWizardFragment.isAnswerCorrect(
-    question: SurveyQuestion,
-    answer: SurveyAnswer?,
-): Boolean {
-    val correctChoice = question.correctChoice
-    val normalizedCorrect = normalizeCorrectChoice(correctChoice)
-    val choiceIds =
-        question.choices
-            .orEmpty()
-            .mapNotNull { it.id?.trim() }
-            .filter { it.isNotBlank() }
-            .toSet()
-    val choiceTextToId =
-        question.choices
-            .orEmpty()
-            .mapNotNull { choice ->
-                val text = choice.text?.trim().orEmpty()
-                val id = choice.id?.trim().orEmpty()
-                if (text.isNotBlank() && id.isNotBlank()) text to id else null
-            }.toMap()
-    val correctIds =
-        normalizedCorrect
-            .map { it.trim() }
-            .filter { it.isNotBlank() && choiceIds.contains(it) }
-    val correctTexts =
-        if (correctIds.isEmpty()) {
-            normalizedCorrect.map { it.trim() }.filter { it.isNotBlank() }
-        } else {
-            emptyList()
-        }
-    return when (question.type) {
-        "input", "textarea" -> isTextInputCorrect(normalizedCorrect, answer)
-        "select" -> isSelectInputCorrect(correctIds, correctTexts, choiceTextToId, answer)
-        "selectMultiple" -> isSelectMultipleInputCorrect(correctIds, answer)
-        "ratingScale" -> isRatingScaleInputCorrect(normalizedCorrect, answer)
-        else -> false
-    }
-}
-
-internal fun SurveyWizardFragment.isTextInputCorrect(
-    normalizedCorrect: List<String>,
-    answer: SurveyAnswer?,
-): Boolean {
-    val correctText = normalizedCorrect.firstOrNull()?.trim().orEmpty()
-    val response = (answer as? SurveyAnswer.Text)?.value?.trim().orEmpty()
-    return if (correctText.isBlank()) {
-        response.isNotBlank()
-    } else {
-        response.equals(correctText, ignoreCase = true)
-    }
-}
-
-internal fun SurveyWizardFragment.isSelectInputCorrect(
-    correctIds: List<String>,
-    correctTexts: List<String>,
-    choiceTextToId: Map<String, String>,
-    answer: SurveyAnswer?,
-): Boolean {
-    val selectedChoice = (answer as? SurveyAnswer.SingleChoice)?.choice
-    return if (correctIds.isNotEmpty()) {
-        val selectedId = normalizeSelectedId(selectedChoice?.id)
-        val resolvedId =
-            selectedId?.takeIf { it.isNotBlank() }
-                ?: selectedChoice?.text?.trim()?.let { choiceTextToId[it] }
-        resolvedId != null && correctIds.contains(resolvedId)
-    } else {
-        val selectedText = selectedChoice?.text?.trim()
-        selectedText != null && correctTexts.any { it.equals(selectedText, ignoreCase = true) }
-    }
-}
-
-internal fun SurveyWizardFragment.isSelectMultipleInputCorrect(
-    correctIds: List<String>,
-    answer: SurveyAnswer?,
-): Boolean {
-    val selectedIds =
-        (answer as? SurveyAnswer.MultipleChoice)
-            ?.choices
-            ?.filter { !it.isOther }
-            ?.mapNotNull { normalizeSelectedId(it.id) }
-            ?.filter { it.isNotBlank() }
-            .orEmpty()
-    return selectedIds.size == correctIds.size && selectedIds.toSet() == correctIds.toSet()
-}
-
-internal fun SurveyWizardFragment.isRatingScaleInputCorrect(
-    normalizedCorrect: List<String>,
-    answer: SurveyAnswer?,
-): Boolean {
-    val correctValue = normalizedCorrect.firstOrNull()?.trim().orEmpty()
-    val selectedScore = (answer as? SurveyAnswer.Rating)?.score?.toString()
-    return correctValue.isNotBlank() && selectedScore == correctValue
-}
-
-internal fun SurveyWizardFragment.normalizeCorrectChoice(correctChoice: Any?): List<String> =
-    when (correctChoice) {
-        is String -> {
-            listOf(correctChoice)
-        }
-
-        is List<*> -> {
-            correctChoice.mapNotNull { item ->
-                when (item) {
-                    is Map<*, *> -> {
-                        item["id"]?.toString()
-                            ?: item["_id"]?.toString()
-                            ?: item["text"]?.toString()
-                    }
-
-                    else -> {
-                        item?.toString()
-                    }
-                }
-            }
-        }
-
-        null -> {
-            emptyList()
-        }
-
-        else -> {
-            listOf(correctChoice.toString())
-        }
-    }
-
-internal fun SurveyWizardFragment.normalizeSelectedId(rawId: String?): String? {
-    val trimmed = rawId?.trim().orEmpty()
-    if (trimmed.isBlank()) return null
-    return trimmed.substringBefore("/").trim().takeIf { it.isNotBlank() }
 }
 
 internal fun SurveyWizardFragment.resolveCustomDeviceName(): String? {

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
@@ -19,6 +19,7 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsReposito
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
+import org.ole.planet.myplanet.lite.survey.SubmitOutcome
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
 import org.ole.planet.myplanet.lite.util.NetworkUtils
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
@@ -313,60 +314,41 @@ internal suspend fun SurveyWizardFragment.processSubmission(
     survey: SurveyDocument,
     username: String?,
 ) {
-    val isOnline = NetworkUtils.isDeviceOnline(requireContext())
-    if (!isOnline) {
-        setSubmitting(false)
-        if (baseUrlOverride != null) {
-            showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
-            return
-        }
-        queueSubmissionForOutbox(submission, survey)
-        return
-    }
+    val outcome = localSurveyRepository.submitOrQueueSubmission(
+        base = base,
+        credentials = credentials,
+        sessionCookie = sessionCookie,
+        submission = submission,
+        surveyId = survey.id ?: "",
+        surveyName = survey.name,
+        teamId = teamId,
+        teamName = teamName,
+        baseUrlOverride = baseUrlOverride
+    )
 
-    val result = submissionRepository.submitSurvey(base, credentials, sessionCookie, submission)
     setSubmitting(false)
-    if (result.isSuccess) {
-        DashboardSurveyStatusStore(
-            requireContext().applicationContext,
-            username,
-        ).markCompleted(survey.id)
-        Toast
-            .makeText(
-                requireContext(),
-                getString(
-                    if (isExam) {
-                        R.string.dashboard_exam_completed
-                    } else {
-                        R.string.dashboard_survey_wizard_completed
-                    },
-                ),
-                Toast.LENGTH_SHORT,
-            ).show()
-        finishWithResult()
-    } else {
-        if (baseUrlOverride != null) {
-            showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
-            return
-        }
-        queueSubmissionForOutbox(submission, survey)
-    }
-}
 
-internal fun SurveyWizardFragment.queueSubmissionForOutbox(
-    submission: SurveySubmission,
-    survey: SurveyDocument,
-) {
-    viewLifecycleOwner.lifecycleScope.launch {
-        val saved =
-            localSurveyRepository.saveSubmission(
-                submission = submission,
-                surveyId = survey.id,
-                surveyName = survey.name,
-                teamId = teamId,
-                teamName = teamName,
-            )
-        if (saved) {
+    when (outcome) {
+        SubmitOutcome.SUBMITTED_ONLINE -> {
+            DashboardSurveyStatusStore(
+                requireContext().applicationContext,
+                username,
+            ).markCompleted(survey.id)
+            Toast
+                .makeText(
+                    requireContext(),
+                    getString(
+                        if (isExam) {
+                            R.string.dashboard_exam_completed
+                        } else {
+                            R.string.dashboard_survey_wizard_completed
+                        },
+                    ),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            finishWithResult()
+        }
+        SubmitOutcome.QUEUED_OFFLINE -> {
             Toast
                 .makeText(
                     requireContext(),
@@ -374,7 +356,8 @@ internal fun SurveyWizardFragment.queueSubmissionForOutbox(
                     Toast.LENGTH_SHORT,
                 ).show()
             finishWithResult()
-        } else {
+        }
+        SubmitOutcome.FAILED -> {
             showValidationMessage(R.string.dashboard_survey_wizard_submission_failed)
         }
     }

--- a/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/SurveyWizardSubmissionExtensions.kt
@@ -21,7 +21,6 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyD
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyQuestion
 import org.ole.planet.myplanet.lite.survey.SubmitOutcome
 import org.ole.planet.myplanet.lite.profile.UserProfileDatabase
-import org.ole.planet.myplanet.lite.util.NetworkUtils
 import org.ole.planet.myplanet.lite.util.SecurePreferencesProvider
 import kotlin.math.roundToInt
 
@@ -319,7 +318,7 @@ internal suspend fun SurveyWizardFragment.processSubmission(
         credentials = credentials,
         sessionCookie = sessionCookie,
         submission = submission,
-        surveyId = survey.id ?: "",
+        surveyId = survey.id,
         surveyName = survey.name,
         teamId = teamId,
         teamName = teamName,

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
@@ -33,6 +33,8 @@ import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
 import org.ole.planet.myplanet.lite.dashboard.DashboardServerPreferences
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
+import org.ole.planet.myplanet.lite.survey.DashboardLocalSurveyRepository
+import org.ole.planet.myplanet.lite.survey.ResendOutcome
 import org.ole.planet.myplanet.lite.util.NetworkUtils
 import java.text.DateFormat
 import java.util.Date
@@ -287,10 +289,6 @@ class DashboardOutboxDetailActivity : BaseActivity() {
     }
 
     private fun attemptSend(entry: DashboardSurveyOutboxStore.OutboxEntry) {
-        if (!NetworkUtils.isDeviceOnline(this@DashboardOutboxDetailActivity)) {
-            Toast.makeText(this, R.string.dashboard_outbox_offline_cannot_send, Toast.LENGTH_SHORT).show()
-            return
-        }
         lifecycleScope.launch {
             val baseUrl = DashboardServerPreferences.getServerBaseUrl(applicationContext)
             val credentials = ProfileCredentialsStore.getStoredCredentials(applicationContext)
@@ -302,80 +300,35 @@ class DashboardOutboxDetailActivity : BaseActivity() {
                             it,
                         ).getStoredToken()
                 }
-            val serverRev =
-                fetchServerRevision(
-                    baseUrl,
-                    entry.submission.parent.id,
-                    entry.teamId,
-                    sessionCookie,
-                    credentials?.username,
-                    credentials?.password,
-                )
-            val localRev = entry.submission.parent.rev
-            if (serverRev == null) {
-                Toast
-                    .makeText(
-                        this@DashboardOutboxDetailActivity,
-                        R.string.dashboard_outbox_unable_to_verify_rev,
-                        Toast.LENGTH_SHORT,
-                    ).show()
-                return@launch
+            val localSurveyRepository = DashboardLocalSurveyRepository(this@DashboardOutboxDetailActivity)
+            val outcome = localSurveyRepository.resendOutboxEntry(
+                entry = entry,
+                baseUrl = baseUrl,
+                username = credentials?.username,
+                password = credentials?.password,
+                sessionCookie = sessionCookie
+            )
+            localSurveyRepository.close()
+
+            when (outcome) {
+                ResendOutcome.SUCCESS -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_send_success, Toast.LENGTH_SHORT).show()
+                    finish()
+                }
+                ResendOutcome.REVISION_MISMATCH -> {
+                    showRevMismatchDialog(entry)
+                }
+                ResendOutcome.OFFLINE -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_offline_cannot_send, Toast.LENGTH_SHORT).show()
+                }
+                ResendOutcome.FAILED -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_send_failed, Toast.LENGTH_SHORT).show()
+                }
             }
-            if (localRev != null && localRev != serverRev) {
-                showRevMismatchDialog(entry)
-                return@launch
-            }
-            submitEntry(entry, baseUrl, credentials?.username, credentials?.password, sessionCookie)
         }
     }
 
-    private suspend fun fetchServerRevision(
-        baseUrl: String?,
-        surveyId: String?,
-        teamId: String?,
-        sessionCookie: String?,
-        username: String?,
-        password: String?,
-    ): String? =
-        withContext(Dispatchers.IO) {
-            val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return@withContext null
-            val id = surveyId?.takeIf { it.isNotBlank() } ?: return@withContext null
-            val selector =
-                JSONObject().apply {
-                    put("_id", id)
-                    put("type", "surveys")
-                    teamId?.takeIf { it.isNotBlank() }?.let { put("teamId", it) }
-                }
-            val payload =
-                JSONObject()
-                    .apply {
-                        put("selector", selector)
-                        put("limit", 1)
-                        put("fields", JSONArray().apply { put("_rev") })
-                    }.toString()
-            val url = "$normalized/db/exams/_find"
-            val requestBuilder =
-                Request
-                    .Builder()
-                    .url(url)
-                    .post(payload.toRequestBody(JSON_MEDIA_TYPE))
-            if (!sessionCookie.isNullOrBlank()) {
-                requestBuilder.addHeader("Cookie", sessionCookie)
-            } else if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
-                val creds = okhttp3.Credentials.basic(username, password)
-                requestBuilder.addHeader("Authorization", creds)
-            }
-            runCatching {
-                httpClient.newCall(requestBuilder.build()).execute().use { response ->
-                    if (!response.isSuccessful) return@use null
-                    val body = response.body.string()
-                    if (body.isBlank()) return@use null
-                    val docs = JSONObject(body).optJSONArray("docs")
-                    val first = docs?.optJSONObject(0)
-                    first?.optString("_rev")?.takeIf { it.isNotBlank() }
-                }
-            }.getOrNull()
-        }
+
 
     private fun confirmDelete(entry: DashboardSurveyOutboxStore.OutboxEntry) {
         MaterialAlertDialogBuilder(this)
@@ -405,43 +358,7 @@ class DashboardOutboxDetailActivity : BaseActivity() {
             }.show()
     }
 
-    private suspend fun submitEntry(
-        entry: DashboardSurveyOutboxStore.OutboxEntry,
-        baseUrl: String?,
-        username: String?,
-        password: String?,
-        sessionCookie: String?,
-    ) {
-        val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
-        if (normalized == null) {
-            Toast.makeText(this, R.string.dashboard_surveys_missing_server, Toast.LENGTH_SHORT).show()
-            return
-        }
-        val authService = AuthDependencies.provideAuthService(this, normalized)
-        val token = sessionCookie ?: authService.getStoredToken()
-        val result =
-            withContext(Dispatchers.IO) {
-                DashboardSurveySubmissionsRepository().submitSurvey(
-                    normalized,
-                    credentials =
-                        username?.let { user ->
-                            password?.let { pass ->
-                                org.ole.planet.myplanet.lite.profile
-                                    .StoredCredentials(user, pass)
-                            }
-                        },
-                    sessionCookie = token,
-                    submission = entry.submission,
-                )
-            }
-        if (result.isSuccess) {
-            outboxStore.deleteEntry(entry.id)
-            Toast.makeText(this, R.string.dashboard_outbox_send_success, Toast.LENGTH_SHORT).show()
-            finish()
-        } else {
-            Toast.makeText(this, R.string.dashboard_outbox_send_failed, Toast.LENGTH_SHORT).show()
-        }
-    }
+
 
     private fun showRevMismatchDialog(entry: DashboardSurveyOutboxStore.OutboxEntry) {
         androidx.appcompat.app.AlertDialog

--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardOutboxDetailActivity.kt
@@ -18,16 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import okhttp3.Credentials
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.json.JSONArray
-import org.json.JSONObject
 import org.ole.planet.myplanet.lite.BaseActivity
 import org.ole.planet.myplanet.lite.R
 import org.ole.planet.myplanet.lite.auth.AuthDependencies
@@ -50,8 +41,6 @@ class DashboardOutboxDetailActivity : BaseActivity() {
     private lateinit var deleteButton: MaterialButton
     private lateinit var emptyView: TextView
     private val outboxStore by lazy { DashboardSurveyOutboxStore.getInstance(applicationContext) }
-
-    private val httpClient by lazy { OkHttpClient.Builder().build() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -284,7 +273,6 @@ class DashboardOutboxDetailActivity : BaseActivity() {
     }
 
     companion object {
-        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         const val EXTRA_OUTBOX_ID = "extra_outbox_id"
     }
 
@@ -301,14 +289,17 @@ class DashboardOutboxDetailActivity : BaseActivity() {
                         ).getStoredToken()
                 }
             val localSurveyRepository = DashboardLocalSurveyRepository(this@DashboardOutboxDetailActivity)
-            val outcome = localSurveyRepository.resendOutboxEntry(
-                entry = entry,
-                baseUrl = baseUrl,
-                username = credentials?.username,
-                password = credentials?.password,
-                sessionCookie = sessionCookie
-            )
-            localSurveyRepository.close()
+            val outcome = try {
+                localSurveyRepository.resendOutboxEntry(
+                    entry = entry,
+                    baseUrl = baseUrl,
+                    username = credentials?.username,
+                    password = credentials?.password,
+                    sessionCookie = sessionCookie
+                )
+            } finally {
+                localSurveyRepository.close()
+            }
 
             when (outcome) {
                 ResendOutcome.SUCCESS -> {
@@ -317,6 +308,12 @@ class DashboardOutboxDetailActivity : BaseActivity() {
                 }
                 ResendOutcome.REVISION_MISMATCH -> {
                     showRevMismatchDialog(entry)
+                }
+                ResendOutcome.REVISION_UNVERIFIABLE -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_unable_to_verify_rev, Toast.LENGTH_SHORT).show()
+                }
+                ResendOutcome.MISSING_SERVER -> {
+                    Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_surveys_missing_server, Toast.LENGTH_SHORT).show()
                 }
                 ResendOutcome.OFFLINE -> {
                     Toast.makeText(this@DashboardOutboxDetailActivity, R.string.dashboard_outbox_offline_cannot_send, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
@@ -17,13 +17,39 @@ import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsReposito
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveySubmissionsRepository.SurveySubmission
 import org.ole.planet.myplanet.lite.dashboard.DashboardSurveysRepository.SurveyDocument
 import org.ole.planet.myplanet.lite.profile.ProfileCredentialsStore
+
+import okhttp3.Credentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import org.ole.planet.myplanet.lite.profile.StoredCredentials
 import org.ole.planet.myplanet.lite.util.NetworkUtils
+
+
+enum class SubmitOutcome {
+    SUBMITTED_ONLINE,
+    QUEUED_OFFLINE,
+    FAILED
+}
+
+enum class ResendOutcome {
+    SUCCESS,
+    REVISION_MISMATCH,
+    FAILED,
+    OFFLINE
+}
 
 class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
     private val offlineStore get() = DashboardOfflineSurveyStore.getInstance(context)
     private val outboxStore get() = DashboardSurveyOutboxStore.getInstance(context)
     private val submissionsRepoDelegate = lazy { DashboardSurveySubmissionsRepository() }
     private val submissionsRepo get() = submissionsRepoDelegate.value
+
+    private val httpClient get() = AuthDependencies.client
+
 
     suspend fun getSavedSurveyIds(): Set<String> = offlineStore.getSavedSurveyIds()
 
@@ -36,6 +62,35 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
     suspend fun getPendingForTeam(teamId: String?): List<OutboxEntry> = outboxStore.getPendingForTeam(teamId)
 
     suspend fun getEntry(id: Long): OutboxEntry? = outboxStore.getEntry(id)
+
+
+    suspend fun submitOrQueueSubmission(
+        base: String,
+        credentials: StoredCredentials?,
+        sessionCookie: String?,
+        submission: SurveySubmission,
+        surveyId: String,
+        surveyName: String?,
+        teamId: String?,
+        teamName: String?,
+        baseUrlOverride: String?
+    ): SubmitOutcome {
+        val isOnline = isDeviceOnline()
+        if (!isOnline) {
+            if (baseUrlOverride != null) return SubmitOutcome.FAILED
+            val saved = saveSubmission(submission, surveyId, surveyName, teamId, teamName)
+            return if (saved) SubmitOutcome.QUEUED_OFFLINE else SubmitOutcome.FAILED
+        }
+
+        val result = submissionsRepo.submitSurvey(base, credentials, sessionCookie, submission)
+        if (result.isSuccess) {
+            return SubmitOutcome.SUBMITTED_ONLINE
+        } else {
+            if (baseUrlOverride != null) return SubmitOutcome.FAILED
+            val saved = saveSubmission(submission, surveyId, surveyName, teamId, teamName)
+            return if (saved) SubmitOutcome.QUEUED_OFFLINE else SubmitOutcome.FAILED
+        }
+    }
 
     suspend fun saveSubmission(
         submission: SurveySubmission,
@@ -81,6 +136,96 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
             }
         }
     }
+
+
+    suspend fun resendOutboxEntry(
+        entry: OutboxEntry,
+        baseUrl: String?,
+        username: String?,
+        password: String?,
+        sessionCookie: String?
+    ): ResendOutcome {
+        if (!isDeviceOnline()) {
+            return ResendOutcome.OFFLINE
+        }
+
+        val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return ResendOutcome.FAILED
+        val authService = AuthDependencies.provideAuthService(context, normalized)
+        val token = sessionCookie ?: withContext(Dispatchers.IO) { authService.getStoredToken() }
+
+        val serverRev = fetchServerRevision(
+            normalized,
+            entry.submission.parent.id,
+            entry.teamId,
+            token,
+            username,
+            password
+        ) ?: return ResendOutcome.FAILED
+
+        val localRev = entry.submission.parent.rev
+        if (localRev != null && localRev != serverRev) {
+            return ResendOutcome.REVISION_MISMATCH
+        }
+
+        val creds = if (username != null && password != null) StoredCredentials(username, password) else null
+
+        val result = submissionsRepo.submitSurvey(
+            normalized,
+            credentials = creds,
+            sessionCookie = token,
+            submission = entry.submission
+        )
+
+        return if (result.isSuccess) {
+            deleteEntry(entry.id)
+            ResendOutcome.SUCCESS
+        } else {
+            ResendOutcome.FAILED
+        }
+    }
+
+    private suspend fun fetchServerRevision(
+        baseUrl: String,
+        surveyId: String?,
+        teamId: String?,
+        sessionCookie: String?,
+        username: String?,
+        password: String?,
+    ): String? =
+        withContext(Dispatchers.IO) {
+            val id = surveyId?.takeIf { it.isNotBlank() } ?: return@withContext null
+            val selector = JSONObject().apply {
+                put("_id", id)
+                put("type", "surveys")
+                teamId?.takeIf { it.isNotBlank() }?.let { put("teamId", it) }
+            }
+            val payload = JSONObject().apply {
+                put("selector", selector)
+                put("limit", 1)
+                put("fields", JSONArray().apply { put("_rev") })
+            }.toString()
+            val url = "$baseUrl/db/exams/_find"
+            val jsonMediaType = "application/json; charset=utf-8".toMediaType()
+            val requestBuilder = Request.Builder()
+                .url(url)
+                .post(payload.toRequestBody(jsonMediaType))
+            if (!sessionCookie.isNullOrBlank()) {
+                requestBuilder.addHeader("Cookie", sessionCookie)
+            } else if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
+                val creds = Credentials.basic(username, password)
+                requestBuilder.addHeader("Authorization", creds)
+            }
+            runCatching {
+                httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                    if (!response.isSuccessful) return@use null
+                    val body = response.body.string()
+                    if (body.isBlank()) return@use null
+                    val docs = JSONObject(body).optJSONArray("docs")
+                    val first = docs?.optJSONObject(0)
+                    first?.optString("_rev")?.takeIf { it.isNotBlank() }
+                }
+            }.getOrNull()
+        }
 
     private fun isDeviceOnline(): Boolean {
         val manager = context.getSystemService(ConnectivityManager::class.java) ?: return false

--- a/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/survey/DashboardLocalSurveyRepository.kt
@@ -38,6 +38,8 @@ enum class SubmitOutcome {
 enum class ResendOutcome {
     SUCCESS,
     REVISION_MISMATCH,
+    REVISION_UNVERIFIABLE,
+    MISSING_SERVER,
     FAILED,
     OFFLINE
 }
@@ -69,7 +71,7 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
         credentials: StoredCredentials?,
         sessionCookie: String?,
         submission: SurveySubmission,
-        surveyId: String,
+        surveyId: String?,
         surveyName: String?,
         teamId: String?,
         teamName: String?,
@@ -149,7 +151,7 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
             return ResendOutcome.OFFLINE
         }
 
-        val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return ResendOutcome.FAILED
+        val normalized = baseUrl?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() } ?: return ResendOutcome.MISSING_SERVER
         val authService = AuthDependencies.provideAuthService(context, normalized)
         val token = sessionCookie ?: withContext(Dispatchers.IO) { authService.getStoredToken() }
 
@@ -160,7 +162,7 @@ class DashboardLocalSurveyRepository(private val context: Context) : Closeable {
             token,
             username,
             password
-        ) ?: return ResendOutcome.FAILED
+        ) ?: return ResendOutcome.REVISION_UNVERIFIABLE
 
         val localRev = entry.submission.parent.rev
         if (localRev != null && localRev != serverRev) {


### PR DESCRIPTION
Refactor survey submission and outbox resending logic to collapse branching paths. Encapsulate online/offline checks, fallback queueing, and network submissions into `DashboardLocalSurveyRepository`. Expose simple outcome enums (`SubmitOutcome`, `ResendOutcome`) to the UI layers. Cleaned up `SurveyWizardSubmissionExtensions` and `DashboardOutboxDetailActivity` to remove heavy business logic and simply evaluate repository outcomes.

---
*PR created automatically by Jules for task [14113351851157147997](https://jules.google.com/task/14113351851157147997) started by @dogi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved survey submission handling with explicit online submission, offline queuing, and resend support for queued items.
  * Enhanced quiz/survey grading to better determine passing status and evaluate answers across multiple question types.

* **Bug Fixes**
  * Improved resend/send behavior with clearer outcomes (success, offline, revision mismatch/unverifiable, missing server, generic failure).
  * More consistent user feedback across online submissions, offline saves, and resend errors.

* **Versioning**
  * Bumped app version to 0.5.4 (versionCode 504).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->