### PR TITLE
🧪 [testing] Add error path test for DateStringAdapter.fromJson

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "org.ole.planet.myplanet.lite"
         minSdk = 28
         targetSdk = 36
-        versionCode = 525
-        versionName = "0.5.25"
+        versionCode = 528
+        versionName = "0.5.28"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "PLANET_BASE_URL", "\"http://10.82.1.30/\"")

--- a/app/src/test/java/org/ole/planet/myplanet/lite/util/DateStringAdapterTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/util/DateStringAdapterTest.kt
@@ -62,6 +62,14 @@ class DateStringAdapterTest {
     }
 
     @Test
+    fun `fromJson returns null when SimpleDateFormat throws ParseException and toLongOrNull fails`() {
+        // This input throws ParseException during parse, hits the catch block, and fails toLongOrNull.
+        val input = "invalid-date-and-not-numeric"
+        val result = adapter.fromJson(input)
+        assertNull(result)
+    }
+
+    @Test
     fun `fromJson returns null when input is null`() {
         val result = adapter.fromJson(null)
         assertNull(result)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error path test for `DateStringAdapter.fromJson` where the input throws a `ParseException` and also fails `toLongOrNull()`.
📊 **Coverage:** The scenario where a completely invalid string (e.g. "invalid-date-and-not-numeric") hits the catch block and falls back to returning null is now explicitly tested.
✨ **Result:** Improved test coverage by formally verifying this specific error handling path in the JSON adapter.

---
*PR created automatically by Jules for task [2774175255214195927](https://jules.google.com/task/2774175255214195927) started by @dogi*