### PR TITLE
🧪 Add DashboardTeamsDependencies unit tests

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsDependenciesTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsDependenciesTest.kt
@@ -1,0 +1,70 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import org.junit.After
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class DashboardTeamsDependenciesTest {
+
+    @Before
+    fun setup() {
+        DashboardTeamsDependencies.resetForTesting()
+    }
+
+    @After
+    fun tearDown() {
+        DashboardTeamsDependencies.resetForTesting()
+    }
+
+    @Test
+    fun provideRepository_returnsSingleton() {
+        val repo1 = DashboardTeamsDependencies.provideRepository()
+        val repo2 = DashboardTeamsDependencies.provideRepository()
+
+        assertSame(repo1, repo2)
+    }
+
+    @Test
+    fun overrideRepository_overridesProvidedRepository() {
+        val originalRepo = DashboardTeamsDependencies.provideRepository()
+        val mockRepo = mock(DashboardTeamsRepository::class.java)
+
+        DashboardTeamsDependencies.overrideRepository(mockRepo)
+
+        val newRepo = DashboardTeamsDependencies.provideRepository()
+
+        assertNotSame(originalRepo, newRepo)
+        assertSame(mockRepo, newRepo)
+    }
+
+    @Test
+    fun overrideRepository_null_clearsOverride() {
+        val originalRepo = DashboardTeamsDependencies.provideRepository()
+        val mockRepo = mock(DashboardTeamsRepository::class.java)
+
+        DashboardTeamsDependencies.overrideRepository(mockRepo)
+        DashboardTeamsDependencies.overrideRepository(null)
+
+        val restoredRepo = DashboardTeamsDependencies.provideRepository()
+
+        assertSame(originalRepo, restoredRepo)
+        assertNotSame(mockRepo, restoredRepo)
+    }
+
+    @Test
+    fun resetForTesting_clearsCachedInstanceAndOverride() {
+        val originalRepo = DashboardTeamsDependencies.provideRepository()
+        val mockRepo = mock(DashboardTeamsRepository::class.java)
+
+        DashboardTeamsDependencies.overrideRepository(mockRepo)
+        DashboardTeamsDependencies.resetForTesting()
+
+        val freshRepo = DashboardTeamsDependencies.provideRepository()
+
+        assertNotSame(originalRepo, freshRepo)
+        assertNotSame(mockRepo, freshRepo)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `DashboardTeamsDependencies` singleton object to verify caching and override mechanisms.
📊 **Coverage:** Covered singleton instance return (`provideRepository`), manual overriding (`overrideRepository`), nulling out the override to fall back (`overrideRepository(null)`), and state cleanup (`resetForTesting`).
✨ **Result:** Enhanced test coverage and reliability of the dependency caching object, allowing safe usage in integration and isolated tests without fear of leaking state.

---
*PR created automatically by Jules for task [4044637390086988763](https://jules.google.com/task/4044637390086988763) started by @dogi*