### PR TITLE
🔒 Refactor DashboardAvatarLoader to securely inject credentials via Interceptor

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoader.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/dashboard/DashboardAvatarLoader.kt
@@ -103,6 +103,21 @@ class DashboardAvatarLoader(
         }
     }
 
+    private val authClient: OkHttpClient by lazy {
+        client.newBuilder()
+            .addInterceptor { chain ->
+                val requestBuilder = chain.request().newBuilder()
+                credentials?.let {
+                    requestBuilder.header("Authorization", Credentials.basic(it.username, it.password))
+                }
+                sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
+                    requestBuilder.header("Cookie", cookie)
+                }
+                chain.proceed(requestBuilder.build())
+            }
+            .build()
+    }
+
     fun destroy() {
         AvatarUpdateNotifier.unregister(avatarUpdateListener)
     }
@@ -113,25 +128,15 @@ class DashboardAvatarLoader(
             return null
         }
         val requestUrl = "$normalizedBase/db/_users/org.couchdb.user:$username/img"
-        val requestBuilder =
-            Request
-                .Builder()
-                .url(requestUrl)
-                .get()
-        credentials?.let {
-            requestBuilder.addHeader("Authorization", Credentials.basic(it.username, it.password))
-        }
-        sessionCookie?.takeIf { it.isNotBlank() }?.let { cookie ->
-            requestBuilder.addHeader("Cookie", cookie)
-        }
+        val request = Request.Builder().url(requestUrl).get().build()
+
         return try {
-            client.newCall(requestBuilder.build()).execute().use { response ->
+            authClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     return null
                 }
                 val bytes = response.body.bytes()
-                val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                bitmap
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
             }
         } catch (error: IOException) {
             null


### PR DESCRIPTION
🎯 **What:** Hardcoded basic authentication credentials and session cookies were being injected directly into the `Request.Builder` in `DashboardAvatarLoader`.
⚠️ **Risk:** By placing credentials directly on the builder, any application-level OkHttp loggers (like `HttpLoggingInterceptor`) attached to the base `client` would log the full request object, inadvertently exposing plaintext credentials or session cookies to system logs or traces.
🛡️ **Solution:** The fix refactors the loading logic to utilize an OkHttp `Interceptor`. By creating a localized `authClient` via `client.newBuilder().addInterceptor { ... }.build()`, the sensitive headers are injected downstream of standard application loggers, keeping the request metadata safe from accidental log exposure.

---
*PR created automatically by Jules for task [8237968737675529236](https://jules.google.com/task/8237968737675529236) started by @dogi*