### PR TITLE
🧪 Add unit tests for DashboardTeamsUserOperations

### DIFF
--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperationsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsOperationsTest.kt
@@ -291,4 +291,80 @@ class DashboardTeamsOperationsTest {
         )
         assertNull(result)
     }
+
+    @Test
+    fun fetchTeamMembers_success() {
+        val responseBody = """
+            {
+                "docs": [
+                    {
+                        "_id": "membership1",
+                        "teamId": "team1",
+                        "userId": "user1"
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val result = operations.fetchTeamMembers(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = StoredCredentials("u", "p"),
+            sessionCookie = "cookie",
+            teamId = "team1"
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("membership1", result[0].id)
+        assertEquals("team1", result[0].teamId)
+        assertEquals("user1", result[0].userId)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("POST", request.method)
+        assertTrue(request.path?.startsWith("/db/teams/_find") == true)
+        val body = request.body.readUtf8()
+        assertTrue(body.contains("team1"))
+        assertTrue(body.contains("membership"))
+    }
+
+    @Test
+    fun fetchTeamMembers_missingBaseUrl() {
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchTeamMembers(
+                baseUrl = "",
+                credentials = null,
+                sessionCookie = null,
+                teamId = "team1"
+            )
+        }
+        assertEquals("Missing server base URL", exception.message)
+    }
+
+    @Test
+    fun fetchTeamMembers_missingTeamId() {
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchTeamMembers(
+                baseUrl = mockWebServer.url("/").toString(),
+                credentials = null,
+                sessionCookie = null,
+                teamId = ""
+            )
+        }
+        assertEquals("Missing team id", exception.message)
+    }
+
+    @Test
+    fun fetchTeamMembers_unsuccessfulResponse() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchTeamMembers(
+                baseUrl = mockWebServer.url("/").toString(),
+                credentials = StoredCredentials("u", "p"),
+                sessionCookie = null,
+                teamId = "team1"
+            )
+        }
+        assertTrue(exception.message?.startsWith("Unexpected response") == true)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsRepositoryTest.kt
@@ -188,4 +188,50 @@ class DashboardTeamsRepositoryTest {
         assertTrue(request.path?.startsWith("/db/teams") == true)
         assertEquals("POST", request.method)
     }
+
+
+
+
+    @Test
+    fun fetchTeamMembers_success() = runTest {
+        val responseBody = """
+            {
+                "docs": [
+                    {
+                        "_id": "membership1",
+                        "teamId": "team1",
+                        "userId": "user1"
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val result = repository.fetchTeamMembers(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = StoredCredentials("u", "p"),
+            sessionCookie = "cookie",
+            teamId = "team1"
+        )
+
+        assertTrue(result.isSuccess)
+        val list = result.getOrNull()
+        assertEquals(1, list?.size)
+        assertEquals("membership1", list?.get(0)?.id)
+    }
+
+    @Test
+    fun fetchTeamMembers_failure() = runTest {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val result = repository.fetchTeamMembers(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = StoredCredentials("u", "p"),
+            sessionCookie = "cookie",
+            teamId = "team1"
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is java.io.IOException)
+    }
 }

--- a/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsUserOperationsTest.kt
+++ b/app/src/test/java/org/ole/planet/myplanet/lite/dashboard/DashboardTeamsUserOperationsTest.kt
@@ -1,0 +1,259 @@
+package org.ole.planet.myplanet.lite.dashboard
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.IOException
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.ole.planet.myplanet.lite.profile.StoredCredentials
+import org.ole.planet.myplanet.lite.util.DateStringAdapter
+
+class DashboardTeamsUserOperationsTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var operations: DashboardTeamsUserOperations
+    private val credentials = StoredCredentials("testuser", "testpass")
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        val moshi = Moshi.Builder()
+            .add(DateStringAdapter())
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+        operations = DashboardTeamsUserOperations(OkHttpClient(), moshi)
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun fetchTeamMemberProfileDetails_success() {
+        val responseBody = """
+            {
+                "_id": "org.couchdb.user:testuser",
+                "name": "testuser",
+                "firstName": "Test",
+                "lastName": "User",
+                "email": "test@example.com",
+                "_attachments": {
+                    "img": {
+                        "content_type": "image/png"
+                    }
+                }
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val result = operations.fetchTeamMemberProfileDetails(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            username = "testuser"
+        )
+
+        assertEquals("testuser", result.username)
+        assertEquals("Test", result.firstName)
+        assertEquals("User", result.lastName)
+        assertEquals("test@example.com", result.email)
+        assertTrue(result.hasAvatar)
+        assertEquals("Test User", result.fullName)
+    }
+
+    @Test
+    fun fetchTeamMemberProfileDetails_missingBaseUrl() {
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchTeamMemberProfileDetails(
+                baseUrl = "",
+                credentials = credentials,
+                sessionCookie = null,
+                username = "testuser"
+            )
+        }
+        assertEquals("Missing base url", exception.message)
+    }
+
+    @Test
+    fun fetchTeamMemberProfileDetails_notFound() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchTeamMemberProfileDetails(
+                baseUrl = mockWebServer.url("/").toString(),
+                credentials = credentials,
+                sessionCookie = null,
+                username = "testuser"
+            )
+        }
+        assertEquals("Profile not found", exception.message)
+    }
+
+    @Test
+    fun fetchUserProfiles_success() {
+        val responseBody = """
+            {
+                "docs": [
+                    {
+                        "_id": "user1",
+                        "firstName": "User",
+                        "lastName": "One"
+                    },
+                    {
+                        "_id": "user2",
+                        "firstName": "User",
+                        "lastName": "Two"
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val result = operations.fetchUserProfiles(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            userIds = listOf("user1", "user2")
+        )
+
+        assertEquals(2, result.size)
+        assertEquals("user1", result[0]._id)
+        assertEquals("User", result[0].firstName)
+        assertEquals("user2", result[1]._id)
+    }
+
+    @Test
+    fun fetchUserProfiles_emptyIds() {
+        val result = operations.fetchUserProfiles(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = null,
+            userIds = emptyList()
+        )
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun fetchUserProfiles_missingCredentials() {
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchUserProfiles(
+                baseUrl = mockWebServer.url("/").toString(),
+                credentials = null,
+                sessionCookie = null,
+                userIds = listOf("user1")
+            )
+        }
+        assertEquals("Missing credentials for basic auth", exception.message)
+    }
+
+    @Test
+    fun fetchUserProfiles_unexpectedResponse() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchUserProfiles(
+                baseUrl = mockWebServer.url("/").toString(),
+                credentials = credentials,
+                sessionCookie = null,
+                userIds = listOf("user1")
+            )
+        }
+        assertTrue(exception.message?.startsWith("Unexpected response") == true)
+    }
+
+    @Test
+    fun fetchAllUsers_success() {
+        val responseBody = """
+            {
+                "docs": [
+                    {
+                        "_id": "user1",
+                        "planetCode": "planet1",
+                        "parentCode": "parent1"
+                    }
+                ]
+            }
+        """.trimIndent()
+        mockWebServer.enqueue(MockResponse().setBody(responseBody).setResponseCode(200))
+
+        val request = FetchUsersRequest(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = "cookie",
+            planetCode = "planet1",
+            parentCode = "parent1",
+            pageSize = 10,
+            skip = 0,
+            searchTerm = "test",
+            excludedUserIds = listOf("excluded1")
+        )
+
+        val result = operations.fetchAllUsers(request)
+
+        assertEquals(1, result.size)
+        assertEquals("user1", result[0]._id)
+
+        val takeRequest = mockWebServer.takeRequest()
+        val requestBody = takeRequest.body.readUtf8()
+        assertTrue(requestBody.contains("planet1"))
+        assertTrue(requestBody.contains("parent1"))
+        assertTrue(requestBody.contains("excluded1"))
+        assertTrue(requestBody.contains("(?i)test"))
+    }
+
+    @Test
+    fun fetchAllUsers_zeroPageSize() {
+        val request = FetchUsersRequest(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = null,
+            planetCode = "planet1",
+            parentCode = "parent1",
+            pageSize = 0
+        )
+
+        val result = operations.fetchAllUsers(request)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun fetchAllUsers_missingPlanetCode() {
+        val request = FetchUsersRequest(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = null,
+            planetCode = "",
+            parentCode = "parent1"
+        )
+
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchAllUsers(request)
+        }
+        assertEquals("Missing planet code for user search", exception.message)
+    }
+
+    @Test
+    fun fetchAllUsers_missingParentCode() {
+        val request = FetchUsersRequest(
+            baseUrl = mockWebServer.url("/").toString(),
+            credentials = credentials,
+            sessionCookie = null,
+            planetCode = "planet1",
+            parentCode = ""
+        )
+
+        val exception = assertThrows(IOException::class.java) {
+            operations.fetchAllUsers(request)
+        }
+        assertEquals("Missing parent code for user search", exception.message)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for `DashboardTeamsUserOperations` and improved test coverage for `fetchTeamMembers` in `DashboardTeamsOperations` and `DashboardTeamsRepository`.
📊 **Coverage:** Successfully covered `fetchTeamMemberProfileDetails`, `fetchUserProfiles`, and `fetchAllUsers` as well as the suspend function `fetchTeamMembers`. Handled network mocks successfully with MockWebServer.
✨ **Result:** Improved reliability and test coverage for the Dashboard Teams module.

---
*PR created automatically by Jules for task [15080442515499488689](https://jules.google.com/task/15080442515499488689) started by @dogi*