### PR TITLE
🧹 [code health improvement] Deduplicate path generation in ResourceDownloadService

### DIFF
--- a/app/src/main/java/org/ole/planet/myplanet/lite/ResourceDownloadService.kt
+++ b/app/src/main/java/org/ole/planet/myplanet/lite/ResourceDownloadService.kt
@@ -172,26 +172,29 @@ internal class ResourceDownloadService(
         candidates += File(publicDownloads, filename)
 
         context.getExternalFilesDir(null)?.let {
-            if (resourceId.isNotBlank()) {
-                candidates.add(File(it, "resources/$tabFolder/$resourceId/$filename"))
-                candidates.add(File(it, "resources/$resourceId/$filename"))
-            } else {
-                candidates.add(File(it, "resources/$tabFolder/_no_id/$filename"))
-                candidates.add(File(it, "resources/_no_id/$filename"))
-            }
+            candidates.addCandidatesForDir(it, resourceId, tabFolder, filename)
         }
 
         context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)?.let {
-            if (resourceId.isNotBlank()) {
-                candidates.add(File(it, "resources/$tabFolder/$resourceId/$filename"))
-                candidates.add(File(it, "resources/$resourceId/$filename"))
-            } else {
-                candidates.add(File(it, "resources/$tabFolder/_no_id/$filename"))
-                candidates.add(File(it, "resources/_no_id/$filename"))
-            }
+            candidates.addCandidatesForDir(it, resourceId, tabFolder, filename)
         }
 
         return candidates.firstOrNull { it.exists() }
+    }
+
+    private fun MutableList<File>.addCandidatesForDir(
+        baseDir: File,
+        resourceId: String,
+        tabFolder: String,
+        filename: String
+    ) {
+        if (resourceId.isNotBlank()) {
+            add(File(baseDir, "resources/$tabFolder/$resourceId/$filename"))
+            add(File(baseDir, "resources/$resourceId/$filename"))
+        } else {
+            add(File(baseDir, "resources/$tabFolder/_no_id/$filename"))
+            add(File(baseDir, "resources/_no_id/$filename"))
+        }
     }
 
     fun resolveResourceUri(baseUrl: String?, item: ResourceUi): String? {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was code duplication within `ResourceDownloadService.kt`, specifically inside the `findLocalResourceFile` method. The logic for adding file candidates to the `candidates` list was exactly the same inside two `context.getExternalFilesDir` blocks.

💡 **Why:** Duplicated logic makes the codebase harder to maintain and read. Consolidating identical blocks into a single helper method decreases the length of the method, reduces redundancy, minimizes the chance of inconsistencies if the file naming logic changes in the future, and improves overall readability.

✅ **Verification:** Verified that the patch was completely clean by extracting the logic into an idiomatic `MutableList<File>.addCandidatesForDir` extension method and calling it in the target places. Ran standard compilation, lint, and full unit test suite without regressions. 

✨ **Result:** A more robust and clean `findLocalResourceFile` method with the exact same runtime behavior as before.

---
*PR created automatically by Jules for task [5878706703660255577](https://jules.google.com/task/5878706703660255577) started by @dogi*